### PR TITLE
Add Router Bench Gateway Tax MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ To pull Harbor-format tasks into OpenBench, see
 [`docs/harbor-import.md`](docs/harbor-import.md) (`obench import harbor`).
 Versioned packs (`org/name@version`, tasks or harness manifests) are covered in
 [`docs/task-packs.md`](docs/task-packs.md) (`obench pack install …`).
+To compare a fixed coding harness and model over direct and gateway serving
+routes, see [`docs/router-bench.md`](docs/router-bench.md) (`obench router
+validate|doctor|run|report|publish|verify`).
 
 **Live results:** https://minghinmatthewlam.github.io/openbench/
 
@@ -27,7 +30,18 @@ Versioned packs (`org/name@version`, tasks or harness manifests) are covered in
 
 Each harness runs headlessly against a set of self-contained coding tasks. A task
 is graded by a checker script (exit 0 = solved, optional `SCORE:` for partial
-credit), never by the harness's own claim of success. Current tiers:
+credit), never by the harness's own claim of success.
+
+OpenBench has two separate benchmark families. **Harness Bench**, described
+throughout this README, varies the coding-agent harness while holding the model
+and task fixed. **Router Bench** holds the Pi harness, model, provider, sampling,
+and task fixed while varying the serving route. Its implemented MVP is the
+direct-vs-gateway **Gateway Tax** track; Provider Router and Model Router tracks
+are deferred, not implemented. See
+[`docs/router-bench.md`](docs/router-bench.md) for its methodology, exploratory
+eligibility limits, example TOML, and separate `obench router` command group.
+
+Current Harness Bench tiers:
 
 - **Core synthetic tasks (`tasks/`).** Small-to-medium tasks built in this repo,
   including partial-credit harder tasks such as `make-ci-green`, `add-feature`,
@@ -156,8 +170,9 @@ pip install "git+https://github.com/minghinmatthewlam/openbench.git"
 Then use the umbrella CLI: `obench init`, `obench run`, `obench report`,
 `obench doctor`, `obench validate`, `obench gate`, `obench compare`,
 `obench publish`, `obench verify`, `obench pack`, `obench export`,
-`obench import`. Legacy `python3 bench/run.py` (and friends) still forward with
-a deprecation note. Versioned packs (`org/name@version`) are documented in
+`obench import`, and `obench router validate|doctor|run|report|publish|verify`. Legacy
+`python3 bench/run.py` (and friends) still forward with a deprecation note.
+Versioned packs (`org/name@version`) are documented in
 [`docs/task-packs.md`](docs/task-packs.md).
 
 ## Quickstart

--- a/docs/router-bench.md
+++ b/docs/router-bench.md
@@ -1,0 +1,200 @@
+# Router Bench
+
+OpenBench has two separate benchmark families:
+
+- **Harness Bench** asks how much the coding-agent harness matters when the
+  underlying model and task are held fixed. Its top-level commands are
+  `obench validate`, `obench doctor`, `obench run`, and `obench report`.
+- **Router Bench** asks how much the serving route matters when the harness,
+  model, provider, sampling, task, and budget are held fixed. Its command group
+  is `obench router validate|doctor|run|report|publish|verify`.
+
+Do not combine their result rows or interpret a Router Bench arm as another
+harness. Router Bench currently supports only the **Gateway Tax** track with Pi
+and the OpenAI Chat Completions streaming protocol.
+
+## Tracks and status
+
+| Track | Question | Status |
+|---|---|---|
+| Gateway Tax | What changes when the same model/provider is called directly versus through a gateway? | Implemented MVP |
+| Provider Router | How well does a router choose among providers for one model? | Deferred; not implemented |
+| Model Router | How well does a router choose among models? | Deferred; not implemented |
+
+Gateway Tax uses one baseline `direct` arm and one or more `gateway` arms. Every
+gateway arm names its `direct_control_arm_id`. The schema requires each pair to
+use the same canonical model revision, requested provider, provider allowlist,
+protocol, and sampling. Each arm has its own endpoint-specific `requested_model`
+wire ID and model allowlist. Fallbacks, gateway retries, and caching must all be
+disabled. This
+design measures the gateway path itself, rather than a gateway's model choice,
+fallback policy, cache hit rate, or retry policy.
+
+## Coding taskset
+
+Router Bench runs the normal OpenBench coding tasks. Each arm receives a fresh
+copy of the same task workspace, and `checker.sh` remains the sole judge of
+correctness and partial credit. A useful starter taskset is:
+
+- `make-ci-green`
+- `add-feature`
+- `misleading-error`
+
+These tasks exercise multi-step code inspection and editing without the runtime
+of the imported Terminal-Bench tier. Use multiple repetitions and time windows
+to reduce sensitivity to transient provider load. The runner deterministically
+counterbalances arm order within complete all-arm blocks. A report includes a
+block only when every expected arm is present, infrastructure-valid, and passes
+route integrity.
+
+`run` executes only blocks whose declared UTC window is currently active. Run
+the command again during each later window; completed blocks resume from the
+same results file without changing the full schedule digest.
+
+## Example: OpenAI direct vs OpenRouter/OpenAI
+
+[`obench/examples/router-bench.toml`](../obench/examples/router-bench.toml)
+compares the exact `gpt-4o-mini-2024-07-18` model:
+
+- directly through OpenAI, using `OPENAI_API_KEY`;
+- through OpenRouter while pinning provider `openai`, using
+  `OPENROUTER_API_KEY`.
+
+Both arms set temperature `0`, top-p `1`, and the same seed. The canonical
+comparison model is `openai/gpt-4o-mini-2024-07-18`; the OpenAI wire ID omits
+the provider prefix while the OpenRouter wire ID includes it. Both pin provider
+`openai`; fallbacks, caching, and retries are disabled.
+
+The TOML stores environment-variable **names only**, never credential values.
+Export the two keys in the shell that runs `doctor` or `run`. For cost
+validation, also provide a frozen price snapshot:
+
+```bash
+export OPENBENCH_ROUTER_FROZEN_PRICES_JSON='{
+  "openai/gpt-4o-mini-2024-07-18": {
+    "input_per_million": "0.15",
+    "output_per_million": "0.60",
+    "effective_at": "2026-07-22"
+  }
+}'
+```
+
+Pricing changes over time; review and deliberately update this snapshot before
+each experiment. The example values are illustrative, not a current price
+claim.
+
+## Commands
+
+Validate the experiment structure, task paths, workspace materialization, and
+deterministic schedule without reading credentials or making model calls:
+
+```bash
+obench router validate obench/examples/router-bench.toml
+```
+
+Preflight credentials, Pi, tasks, and frozen prices without spending tokens:
+
+```bash
+obench router doctor obench/examples/router-bench.toml
+```
+
+Run or resume the scheduled blocks:
+
+```bash
+obench router run obench/examples/router-bench.toml \
+  --results results/router-gpt-4o-mini-openrouter.jsonl
+```
+
+`execution_lane` selects the default lane; `--exec local|docker` overrides it.
+The MVP currently executes only `local` and fails closed if `docker` is chosen.
+An already valid latest block is skipped. `--force` appends a replacement block
+attempt instead of rewriting prior evidence. Invalid paid blocks are never
+retried automatically; an explicit later `run` is required.
+
+Report matched, eligible blocks:
+
+```bash
+obench router report results/router-gpt-4o-mini-openrouter.jsonl
+obench router report results/router-gpt-4o-mini-openrouter.jsonl --json
+```
+
+Create a sanitized evidence bundle, then verify every artifact digest and
+public ledger chain:
+
+```bash
+obench router publish results/router-gpt-4o-mini-openrouter.jsonl \
+  obench/examples/router-bench.toml results/router-gpt-4o-mini-bundle
+obench router verify results/router-gpt-4o-mini-bundle
+```
+
+The runner durably persists the frozen price snapshot beside the results file,
+so publishing does not depend on retaining the original shell environment.
+Published rows retain their `exploratory` route-isolation classification.
+
+Only `run` sends paid model requests. Invoking it is the explicit cost
+authorization step. `budget.usd_cap`, `max_calls`, and `max_output_tokens` are
+checked from the sealed cell ledger and can invalidate a cell, but they are not
+a provider-side prepaid limit or a guarantee against overspend. In particular,
+the USD check uses the frozen price estimate after observed calls. Start with a
+small taskset, one repetition, and a low cap.
+
+For tasks outside `tasks/`, pass the same `--tasks-dir PATH` to `validate`,
+`doctor`, and `run`.
+
+## Metrics and route evidence
+
+Reports keep the direct and gateway arms separate and calculate:
+
+- solve rate, mean checker score, availability, and task latency;
+- time to first byte, semantic time to first token, and generation throughput;
+- attempted cost and cost per solve for each available cost basis;
+- served provider/model route distribution;
+- paired gateway-minus-direct contrasts with task-cluster bootstrap intervals.
+
+Metrics retain explicit task, cell, call, and cost-basis coverage. Missing timing
+or pricing evidence does not silently become zero. Cost per solve is withheld
+unless the selected cost basis covers every included call.
+
+The managed proxy fixes the requested model, provider, and sampling on every
+request. For gateway calls it requests OpenRouter route metadata and checks the
+requested model, served model, selected provider, complete stream, and parse
+integrity. When attempt metadata is present, it also rejects unsuccessful or
+fallback attempts. Route failures are recorded as reasons, and the entire
+all-arm block is excluded from matched reporting. Ledgers contain
+privacy-safe timing, usage, route identifiers, status, and hashes; they do not
+retain prompts, generated text, or credential values.
+
+## Secrets, proxy, and ledgers
+
+At admission, declared key values are loaded into a memory-only secret plan.
+The Pi subprocess receives a sanitized route plan, a synthetic proxy key, and a
+cell-scoped proxy URL, not the OpenAI or OpenRouter key. The proxy authorizes the
+committed arm digest, strips client credential headers and uncontrolled cache
+or routing fields, injects the admitted upstream credential, rejects redirects,
+and forwards the fixed request.
+
+Each cell has an append-only JSONL proxy ledger. Calls are sequence-bound and
+hash-chained; the ledger is drained and terminally sealed before the checker
+runs and before the result row is appended. Results bind the arm, task,
+experiment, policy, pricing, schedule, sampling, harness version, execution
+lane, and ledger seal by digest.
+
+## Exploratory and verified-route eligibility
+
+Route integrity and route isolation are different claims:
+
+- **Route integrity** means the observed response evidence matches the committed
+  arm. It is required for a block to enter the report.
+- **Verified-route eligibility** would additionally require enforced outbound
+  network isolation, so the harness cannot bypass the managed proxy.
+
+The current local lane records `classification = "exploratory"` and
+`egress_enforced = false`. Therefore current Router Bench results are
+eligible only for **exploratory** analysis, not verified-route publication or
+ranking.
+
+The local lane runs the adapter on the host, has no image
+digest, and inherits host CLI/runtime and network conditions. Use it for schema,
+credential, and low-cost smoke work. Docker execution remains deferred until
+its route and secret isolation contract can be enforced; do not mix execution
+lanes in one comparison stratum.

--- a/obench/adapters/pi.py
+++ b/obench/adapters/pi.py
@@ -28,17 +28,29 @@ Notes / quirks:
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
+from pathlib import Path
 from urllib.parse import urlsplit
 
 try:
     from obench.auth_persist import try_persist_auth_file
+    from obench import router_spec as _router_spec
 except ImportError:  # file-path / Docker mount layout
     from auth_persist import try_persist_auth_file
+    import router_spec as _router_spec
 
 NAME = "pi"
+ADAPTER_API_VERSION = 2
+ROUTED_CAPABILITIES = {
+    "protocols": ["openai_chat"],
+    "execution_lanes": ["local", "docker"],
+    "streaming": True,
+    "dynamic_model_ids": True,
+    "route_plan_transport": "sanitized_file",
+}
 
 
 def _doctor_auth(probes):
@@ -72,6 +84,26 @@ MODELS = {
 }
 _REAL_AUTH = os.path.expanduser("~/.pi/agent/auth.json")
 _EXE = "pi"
+_ROUTED_PROVIDER = "openbench-routed"
+_SYNTHETIC_API_KEY = "openbench-routed-synthetic"
+_ROUTE_PLAN_FIELDS = {
+    "schema_version", "experiment_digest", "arm_digest", "arm_id",
+    "route_kind", "endpoint", "protocol", "requested_model",
+    "requested_provider", "allowed_models", "allowed_providers",
+    "fallback_enabled", "retry_count", "cache_enabled", "auth_env",
+    "sampling", "private_router", "private_host_allowlist",
+    "private_cidr_allowlist",
+}
+_SAMPLING_FIELDS = {"temperature", "top_p", "seed"}
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_ENV_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_CELL_TOKEN_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_ROUTED_ENV_ALLOWLIST = {
+    "PATH", "LANG", "LC_ALL", "LC_CTYPE", "TMPDIR", "TMP", "TEMP",
+    "TERM", "SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS",
+    "NO_PROXY", "no_proxy",
+}
 
 
 def _empty_token_usage():
@@ -293,6 +325,205 @@ def _pi_provider_ext(spec):
     )
 
 
+def _route_error(message):
+    raise _router_spec.RouterSpecError(f"invalid sanitized RoutePlan: {message}")
+
+
+def _strict_keys(value, expected, path):
+    if not isinstance(value, dict):
+        _route_error(f"{path} must be an object")
+    unknown = sorted(set(value) - expected)
+    missing = sorted(expected - set(value))
+    if unknown:
+        _route_error(f"{path} has unknown fields: {', '.join(unknown)}")
+    if missing:
+        _route_error(f"{path} missing fields: {', '.join(missing)}")
+    return value
+
+
+def _route_string(value, path, pattern=None):
+    if not isinstance(value, str) or not value.strip():
+        _route_error(f"{path} must be a non-empty string")
+    result = value.strip()
+    if pattern is not None and not pattern.fullmatch(result):
+        _route_error(f"{path} has invalid format")
+    return result
+
+
+def _route_string_tuple(value, path, pattern=None):
+    if not isinstance(value, list) or not value:
+        _route_error(f"{path} must be a non-empty array")
+    result = tuple(
+        _route_string(item, f"{path}[{index}]", pattern)
+        for index, item in enumerate(value)
+    )
+    if len(set(result)) != len(result):
+        _route_error(f"{path} must not contain duplicates")
+    return result
+
+
+def _route_bool(value, path):
+    if not isinstance(value, bool):
+        _route_error(f"{path} must be a boolean")
+    return value
+
+
+def _route_int(value, path, minimum=0):
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        _route_error(f"{path} must be an integer of at least {minimum}")
+    return value
+
+
+def _route_number(value, path, minimum, maximum):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        _route_error(f"{path} must be a number")
+    result = float(value)
+    if not minimum <= result <= maximum:
+        _route_error(f"{path} must be between {minimum} and {maximum}")
+    return result
+
+
+def _load_route_plan(route_plan_path):
+    path = Path(route_plan_path)
+    try:
+        if path.stat().st_size > 1024 * 1024:
+            _route_error("file exceeds 1 MiB")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except _router_spec.RouterSpecError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        _route_error(f"cannot load {path}: {exc}")
+
+    data = _strict_keys(raw, _ROUTE_PLAN_FIELDS, "route plan")
+    schema_version = _route_int(data["schema_version"], "schema_version", 1)
+    if schema_version != _router_spec.SCHEMA_VERSION:
+        _route_error(f"schema_version must be {_router_spec.SCHEMA_VERSION}")
+    protocol = _route_string(data["protocol"], "protocol")
+    if protocol != "openai_chat":
+        _route_error("protocol must be 'openai_chat'")
+    route_kind = _route_string(data["route_kind"], "route_kind")
+    if route_kind not in {"direct", "gateway"}:
+        _route_error("route_kind must be 'direct' or 'gateway'")
+
+    allowed_models = _route_string_tuple(data["allowed_models"], "allowed_models")
+    allowed_providers = _route_string_tuple(
+        data["allowed_providers"], "allowed_providers", _ID_RE)
+    requested_model = _route_string(data["requested_model"], "requested_model")
+    requested_provider = _route_string(
+        data["requested_provider"], "requested_provider", _ID_RE)
+    if requested_model not in allowed_models:
+        _route_error("allowed_models must contain requested_model")
+    if requested_provider not in allowed_providers:
+        _route_error("allowed_providers must contain requested_provider")
+
+    fallback_enabled = _route_bool(data["fallback_enabled"], "fallback_enabled")
+    retry_count = _route_int(data["retry_count"], "retry_count")
+    cache_enabled = _route_bool(data["cache_enabled"], "cache_enabled")
+    if fallback_enabled or retry_count != 0 or cache_enabled:
+        _route_error("fallback, retries, and cache must be disabled")
+
+    sampling_data = _strict_keys(data["sampling"], _SAMPLING_FIELDS, "sampling")
+    sampling = _router_spec.Sampling(
+        temperature=_route_number(
+            sampling_data["temperature"], "sampling.temperature", 0.0, 2.0),
+        top_p=_route_number(sampling_data["top_p"], "sampling.top_p", 0.0, 1.0),
+        seed=_route_int(sampling_data["seed"], "sampling.seed"),
+    )
+
+    private_router = _route_bool(data["private_router"], "private_router")
+    hosts_raw = data["private_host_allowlist"]
+    cidrs_raw = data["private_cidr_allowlist"]
+    try:
+        hosts, cidrs = _router_spec._parse_allowlists(  # noqa: SLF001
+            {
+                "private_host_allowlist": hosts_raw,
+                "private_cidr_allowlist": cidrs_raw,
+            },
+            private_router,
+        )
+        endpoint = _router_spec._validate_endpoint(  # noqa: SLF001
+            data["endpoint"], "endpoint", private_router, hosts, cidrs)
+    except _router_spec.RouterSpecError as exc:
+        _route_error(str(exc))
+    if not urlsplit(endpoint).path.rstrip("/").endswith("/chat/completions"):
+        _route_error("endpoint path must end with /chat/completions")
+
+    return _router_spec.RoutePlan(
+        schema_version=schema_version,
+        experiment_digest=_route_string(
+            data["experiment_digest"], "experiment_digest", _DIGEST_RE),
+        arm_digest=_route_string(data["arm_digest"], "arm_digest", _DIGEST_RE),
+        arm_id=_route_string(data["arm_id"], "arm_id", _ID_RE),
+        route_kind=route_kind,
+        endpoint=endpoint,
+        protocol=protocol,
+        requested_model=requested_model,
+        requested_provider=requested_provider,
+        allowed_models=allowed_models,
+        allowed_providers=allowed_providers,
+        fallback_enabled=fallback_enabled,
+        retry_count=retry_count,
+        cache_enabled=cache_enabled,
+        auth_env=_route_string(data["auth_env"], "auth_env", _ENV_RE),
+        sampling=sampling,
+        private_router=private_router,
+        private_host_allowlist=hosts,
+        private_cidr_allowlist=cidrs,
+    )
+
+
+def _routed_proxy_url(plan):
+    if os.environ.get("OPENBENCH_PROXY") != "1":
+        _route_error("OPENBENCH_PROXY=1 is required")
+    base = os.environ.get("OPENBENCH_PROXY_BASE_URL", "")
+    token = os.environ.get("OPENBENCH_PROXY_CELL_TOKEN", "")
+    parsed = urlsplit(base)
+    if (parsed.scheme not in {"http", "https"} or not parsed.netloc
+            or parsed.username or parsed.password or parsed.query or parsed.fragment):
+        _route_error("OPENBENCH_PROXY_BASE_URL must be an absolute HTTP(S) URL")
+    if not _CELL_TOKEN_RE.fullmatch(token):
+        _route_error("OPENBENCH_PROXY_CELL_TOKEN has invalid format")
+
+    return (
+        f"{base.rstrip('/')}/cell/{token}/route/{plan.arm_digest}"
+    )
+
+
+def _routed_provider_ext(plan, proxy_url):
+    return (
+        "export default function (pi) {\n"
+        f"  pi.registerProvider({json.dumps(_ROUTED_PROVIDER)}, {{\n"
+        '    name: "OpenBench routed proxy",\n'
+        f"    baseUrl: {json.dumps(proxy_url)},\n"
+        f"    apiKey: {json.dumps(_SYNTHETIC_API_KEY)},\n"
+        '    api: "openai-completions",\n'
+        "    models: [{\n"
+        f"      id: {json.dumps(plan.requested_model)},\n"
+        f"      name: {json.dumps(plan.requested_model)},\n"
+        '      reasoning: false, input: ["text"],\n'
+        "      compat: {\n"
+        "        supportsStore: false, supportsDeveloperRole: true,\n"
+        "        supportsUsageInStreaming: true\n"
+        "      },\n"
+        "      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },\n"
+        "      contextWindow: 1000000, maxTokens: 32768\n"
+        "    }]\n"
+        "  });\n"
+        "}\n"
+    )
+
+
+def _routed_child_env(iso_home):
+    env = {
+        key: value for key, value in os.environ.items()
+        if key in _ROUTED_ENV_ALLOWLIST
+    }
+    env["HOME"] = iso_home
+    env["PI_CODING_AGENT_DIR"] = os.path.join(iso_home, ".pi", "agent")
+    env["PI_TELEMETRY"] = "0"
+    return env
+
+
 def _parse_json_with_usage(stdout):
     """Parse pi's JSONL event stream into (tokens, turns, tail, token_usage).
 
@@ -398,6 +629,56 @@ def _parse_json(stdout):
     """Backward-compatible parser returning legacy fields only."""
     tokens, turns, tail, token_usage = _parse_json_with_usage(stdout)
     return tokens, turns, tail
+
+
+def run_routed(
+    instruction: str,
+    workdir: str,
+    route_plan_path: str,
+    timeout_s: int,
+) -> dict:
+    plan = _load_route_plan(route_plan_path)
+    proxy_url = _routed_proxy_url(plan)
+    iso_home = tempfile.mkdtemp(prefix="pi_routed_home_")
+    try:
+        ext_path = os.path.join(iso_home, "routed-provider.mjs")
+        with open(ext_path, "w", encoding="utf-8") as fh:
+            fh.write(_routed_provider_ext(plan, proxy_url))
+        cmd = [
+            _EXE, "-p", "--no-approve", "--no-extensions",
+            "-e", ext_path,
+            "--provider", _ROUTED_PROVIDER,
+            "--model", plan.requested_model,
+            "--mode", "json",
+            instruction,
+        ]
+        stdout_text, stderr_text, returncode, timed_out = _run_streaming(
+            cmd, workdir, timeout_s, _routed_child_env(iso_home))
+        combined = stdout_text + stderr_text
+        if timed_out:
+            return {
+                "completed": False, "error": f"timeout after {timeout_s}s",
+                "output_tail": combined[-2000:], "full_output": combined,
+                "tokens": None, "turns": None, "cmd": cmd,
+                **_empty_token_usage(),
+            }
+        try:
+            tokens, turns, tail, token_usage = _parse_json_with_usage(stdout_text)
+        except Exception:  # noqa: BLE001
+            tokens, turns, tail, token_usage = None, None, "", _empty_token_usage()
+        return {
+            "completed": returncode == 0,
+            "error": None if returncode == 0 else f"exit {returncode}",
+            "output_tail": tail or combined[-2000:],
+            "full_output": combined,
+            "tokens": tokens,
+            "turns": turns,
+            "cmd": cmd,
+            **token_usage,
+        }
+    finally:
+        shutil.rmtree(iso_home, ignore_errors=True)
+
 
 def run(instruction: str, workdir: str, model: str, timeout_s: int) -> dict:
     if model in MODELS:

--- a/obench/adapters/pi.py
+++ b/obench/adapters/pi.py
@@ -88,7 +88,7 @@ _ROUTED_PROVIDER = "openbench-routed"
 _SYNTHETIC_API_KEY = "openbench-routed-synthetic"
 _ROUTE_PLAN_FIELDS = {
     "schema_version", "experiment_digest", "arm_digest", "arm_id",
-    "route_kind", "endpoint", "protocol", "requested_model",
+    "route_kind", "endpoint", "protocol", "canonical_model", "requested_model",
     "requested_provider", "allowed_models", "allowed_providers",
     "fallback_enabled", "retry_count", "cache_enabled", "auth_env",
     "sampling", "private_router", "private_host_allowlist",
@@ -409,6 +409,7 @@ def _load_route_plan(route_plan_path):
     allowed_providers = _route_string_tuple(
         data["allowed_providers"], "allowed_providers", _ID_RE)
     requested_model = _route_string(data["requested_model"], "requested_model")
+    canonical_model = _route_string(data["canonical_model"], "canonical_model")
     requested_provider = _route_string(
         data["requested_provider"], "requested_provider", _ID_RE)
     if requested_model not in allowed_models:
@@ -457,6 +458,7 @@ def _load_route_plan(route_plan_path):
         route_kind=route_kind,
         endpoint=endpoint,
         protocol=protocol,
+        canonical_model=canonical_model,
         requested_model=requested_model,
         requested_provider=requested_provider,
         allowed_models=allowed_models,
@@ -502,11 +504,11 @@ def _routed_provider_ext(plan, proxy_url):
         f"      name: {json.dumps(plan.requested_model)},\n"
         '      reasoning: false, input: ["text"],\n'
         "      compat: {\n"
-        "        supportsStore: false, supportsDeveloperRole: true,\n"
-        "        supportsUsageInStreaming: true\n"
+        "        supportsStore: false, supportsDeveloperRole: false,\n"
+        "        supportsUsageInStreaming: true, maxTokensField: \"max_tokens\"\n"
         "      },\n"
         "      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },\n"
-        "      contextWindow: 1000000, maxTokens: 32768\n"
+        "      contextWindow: 128000, maxTokens: 16384\n"
         "    }]\n"
         "  });\n"
         "}\n"

--- a/obench/cli.py
+++ b/obench/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Umbrella CLI for the OpenBench harness benchmarking framework.
 
-    obench run | report | doctor | validate | gate | compare | init |
+    obench run | report | doctor | validate | router | gate | compare | init |
          publish | verify | community | leaderboard | pack | export | import [args...]
 """
 
@@ -27,6 +27,7 @@ def main(argv=None):
     sub.add_parser("report", help="aggregate results.jsonl", add_help=False)
     sub.add_parser("doctor", help="preflight CLI/auth/model checks", add_help=False)
     sub.add_parser("validate", help="check task checker polarity", add_help=False)
+    sub.add_parser("router", help="run Gateway Tax experiments", add_help=False)
     sub.add_parser("gate", help="BYO candidate admission gate", add_help=False)
     sub.add_parser("compare", help="matched-denominator scorecard", add_help=False)
     sub.add_parser("init", help="scaffold .openbench/ for private evals", add_help=False)
@@ -65,14 +66,14 @@ def main(argv=None):
         return 0
 
     known = {
-        "run", "report", "doctor", "validate", "gate", "compare", "init",
+        "run", "report", "doctor", "validate", "router", "gate", "compare", "init",
         "publish", "verify", "community", "leaderboard", "pack", "export",
         "import",
     }
     if command not in known:
         parser.error(
             f"unknown command {command!r}; choose from run, report, doctor, "
-            "validate, gate, compare, init, publish, verify, community, "
+            "validate, router, gate, compare, init, publish, verify, community, "
             "leaderboard, pack, export, import"
         )
 
@@ -88,6 +89,9 @@ def main(argv=None):
     if command == "validate":
         from .validate_tasks import main as validate_main
         return validate_main(rest)
+    if command == "router":
+        from .router_cli import main as router_main
+        return router_main(rest)
     if command == "gate":
         from .candidate_gate import main as gate_main
         return gate_main(rest)

--- a/obench/entry.py
+++ b/obench/entry.py
@@ -45,6 +45,11 @@ WORKDIR = os.environ.get("BENCH_WORKDIR", "/work")
 # must write into their config home work, while the host config stays read-only.
 AUTH_STAGING = os.environ.get("BENCH_AUTH_STAGING", "/bench/auth")
 AUTH_RETURN = os.environ.get("BENCH_AUTH_RETURN", "/bench/auth-return")
+ROUTE_PLAN_PATH = os.environ.get("OPENBENCH_ROUTE_PLAN_PATH")
+_ROUTED_CAPABILITY_FIELDS = {
+    "protocols", "execution_lanes", "streaming", "dynamic_model_ids",
+    "route_plan_transport",
+}
 
 
 def _stage_auth():
@@ -122,6 +127,44 @@ def _load_adapter(name):
     return module
 
 
+def _route_plan_protocol(path):
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict) or not isinstance(data.get("protocol"), str):
+        raise ValueError("routed RoutePlan must be a JSON object with a protocol")
+    return data["protocol"]
+
+
+def _validate_routed_adapter(adapter, route_plan_path):
+    version = getattr(adapter, "ADAPTER_API_VERSION", None)
+    if type(version) is not int or version != 2:
+        raise ValueError("routed dispatch requires ADAPTER_API_VERSION=2")
+    capabilities = getattr(adapter, "ROUTED_CAPABILITIES", None)
+    if not isinstance(capabilities, dict) or set(capabilities) != _ROUTED_CAPABILITY_FIELDS:
+        raise ValueError("invalid ROUTED_CAPABILITIES descriptor")
+    protocols = capabilities["protocols"]
+    lanes = capabilities["execution_lanes"]
+    if (not isinstance(protocols, list) or not protocols
+            or any(not isinstance(item, str) for item in protocols)
+            or len(protocols) != len(set(protocols))):
+        raise ValueError("ROUTED_CAPABILITIES.protocols must be unique strings")
+    if (not isinstance(lanes, list) or not lanes
+            or any(item not in {"local", "docker"} for item in lanes)
+            or len(lanes) != len(set(lanes))):
+        raise ValueError("ROUTED_CAPABILITIES.execution_lanes is invalid")
+    if (capabilities["streaming"] is not True
+            or capabilities["dynamic_model_ids"] is not True
+            or capabilities["route_plan_transport"] != "sanitized_file"):
+        raise ValueError("adapter does not meet routed execution requirements")
+    if "docker" not in lanes:
+        raise ValueError("adapter does not support routed docker execution")
+    protocol = _route_plan_protocol(route_plan_path)
+    if protocol not in protocols:
+        raise ValueError(f"adapter does not support routed protocol {protocol!r}")
+    if not callable(getattr(adapter, "run_routed", None)):
+        raise ValueError("routed adapter has no run_routed() function")
+
+
 def _emit(result):
     sys.stdout.flush()
     print(RESULT_SENTINEL + " " + json.dumps(result))
@@ -158,8 +201,18 @@ def main(argv):
 
     candidate_obj = None
     try:
-        _stage_auth()
-        if len(argv) == 5:
+        routed = ROUTE_PLAN_PATH is not None
+        if routed:
+            if len(argv) == 5:
+                raise ValueError("routed dispatch does not support candidate adapters")
+            if harness == "null":
+                raise ValueError("null adapter does not support routed dispatch")
+            adapter = _load_adapter(harness)
+            _validate_routed_adapter(adapter, ROUTE_PLAN_PATH)
+            result = adapter.run_routed(
+                instruction, WORKDIR, ROUTE_PLAN_PATH, timeout_s)
+        elif len(argv) == 5:
+            _stage_auth()
             candidates_path = os.path.dirname(argv[4])
             if candidates_path not in sys.path:
                 sys.path.insert(0, "/bench")
@@ -181,6 +234,7 @@ def main(argv):
         elif harness == "null":
             result = _null_run(instruction, WORKDIR, model, timeout_s)
         else:
+            _stage_auth()
             adapter = _load_adapter(harness)
             result = adapter.run(instruction, WORKDIR, model, timeout_s)
     except Exception:  # noqa: BLE001 - surface as a failed result, never crash
@@ -201,7 +255,8 @@ def main(argv):
             cand_rels = [auth.get("destination", "") for auth in candidate_obj.auth_files
                          if auth.get("destination")]
             relatives = (relatives or []) + cand_rels
-        _return_auth(persist_harness, relatives=relatives)
+        if ROUTE_PLAN_PATH is None:
+            _return_auth(persist_harness, relatives=relatives)
     except OSError as exc:
         result = {
             "completed": False,

--- a/obench/examples/router-bench.toml
+++ b/obench/examples/router-bench.toml
@@ -1,0 +1,68 @@
+schema_version = 1
+experiment_id = "gpt-4o-mini-openrouter-gateway-tax"
+track = "gateway_tax"
+harness = "pi"
+tasks = ["make-ci-green", "add-feature", "misleading-error"]
+repetitions_per_window = 1
+schedule_seed = 20260722
+execution_lane = "local"
+private_router = false
+
+[[windows]]
+window_id = "morning-utc"
+start = "2026-07-23T15:00:00Z"
+end = "2026-07-23T17:00:00Z"
+
+[[windows]]
+window_id = "evening-utc"
+start = "2026-07-24T00:00:00Z"
+end = "2026-07-24T02:00:00Z"
+
+[budget]
+timeout_s = 900
+max_calls = 12
+max_output_tokens = 24000
+usd_cap = 1.00
+
+[[arms]]
+arm_id = "direct-openai"
+route_kind = "direct"
+endpoint = "https://api.openai.com/v1/chat/completions"
+protocol = "openai_chat"
+baseline = true
+canonical_model = "openai/gpt-4o-mini-2024-07-18"
+requested_model = "gpt-4o-mini-2024-07-18"
+requested_provider = "openai"
+allowed_models = ["gpt-4o-mini-2024-07-18"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENAI_API_KEY"
+
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260722
+
+[[arms]]
+arm_id = "openrouter-openai"
+route_kind = "gateway"
+endpoint = "https://openrouter.ai/api/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "openai/gpt-4o-mini-2024-07-18"
+requested_model = "openai/gpt-4o-mini-2024-07-18"
+requested_provider = "openai"
+allowed_models = ["openai/gpt-4o-mini-2024-07-18"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENROUTER_API_KEY"
+direct_control_arm_id = "direct-openai"
+
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260722

--- a/obench/proxy.py
+++ b/obench/proxy.py
@@ -21,6 +21,7 @@ import sys
 import threading
 import time
 import zlib
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -62,6 +63,34 @@ DEFAULT_ANTHROPIC_UPSTREAMS = {
     # Local CLIProxyAPI Anthropic-compatible ingress (claude x gpt-5.6-sol).
     "cliproxyapi": "http://127.0.0.1:8317",
 }
+EMPTY_LEDGER_HASH = hashlib.sha256(b"").hexdigest()
+
+
+@dataclass(frozen=True)
+class LedgerSeal:
+    """Durable terminal state for one explicitly registered cell ledger."""
+
+    token: str
+    path: Path
+    record_count: int
+    last_sequence: int
+    root_hash: str
+
+    @property
+    def ledger_path(self) -> Path:
+        return self.path
+
+
+@dataclass
+class _CellLedger:
+    state: str = "ACTIVE"
+    in_flight: int = 0
+    record_count: int = 0
+    last_sequence: int = 0
+    root_hash: str = EMPTY_LEDGER_HASH
+    seal: LedgerSeal | None = None
+    write_error: str | None = None
+    terminal_written: bool = False
 
 
 def new_cell_token() -> str:
@@ -321,8 +350,12 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
         capture_truncated = False
         headers_sent = False
         error = None
+        token = self._token_from_header_or_path()
+        managed_ledger: bool | None = None
         try:
             route = self._route_request()
+            token = route.token
+            managed_ledger = self.server.admit_cell_request(token)  # type: ignore[attr-defined]
             body = self._read_body()
             request_body = decode_for_parsing(body, self.headers.get("content-encoding", ""))
             sampling = observed_sampling(
@@ -387,7 +420,7 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             else:
                 self.close_connection = True
         finally:
-            token = route.token if route is not None else self._token_from_header_or_path()
+            token = route.token if route is not None else token
             meta = self._read_metadata(token)
             configured_sampling = meta.get("sampling") if isinstance(meta.get("sampling"), dict) else {}
             recorded_sampling = sampling or configured_sampling
@@ -416,7 +449,12 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
                 rec["capture_truncated"] = True
             if error:
                 rec["error"] = error
-            self._write_record(token, scrub(rec))
+            if managed_ledger:
+                self.server.complete_cell_request(token, rec)  # type: ignore[attr-defined]
+            elif managed_ledger is False:
+                self.server.complete_legacy_request(token, rec)  # type: ignore[attr-defined]
+            else:
+                self.server.write_legacy_record_if_unregistered(token, rec)  # type: ignore[attr-defined]
 
     def _route_request(self) -> Route:
         path_query = self.path if self.path.startswith("/") else "/" + self.path
@@ -584,6 +622,220 @@ class CountingProxyServer(ThreadingHTTPServer):
     daemon_threads = True
     allow_reuse_address = True
 
+    def register_cell(self, token: str) -> None:
+        """Opt a router cell into lifecycle-managed, sealed ledger writes."""
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+", token):
+            raise ValueError("cell token must contain only letters, digits, '.', '_', or '-'")
+        with self._ledger_condition:
+            if token in self._cell_ledgers:
+                raise RuntimeError(f"cell already registered: {token}")
+            if self._legacy_in_flight.get(token, 0):
+                raise RuntimeError(f"cell has active legacy requests: {token}")
+            path = self._ledger_path(token)
+            if path.exists():
+                raise FileExistsError(f"cell ledger already exists: {path}")
+            self._cell_ledgers[token] = _CellLedger()
+
+    def cell_is_registered(self, token: str) -> bool:
+        with self._ledger_condition:
+            return token in self._cell_ledgers
+
+    def admit_cell_request(self, token: str) -> bool:
+        """Atomically admit a request, returning False for a legacy cell."""
+        with self._ledger_condition:
+            ledger = self._cell_ledgers.get(token)
+            if ledger is None:
+                self._legacy_in_flight[token] = self._legacy_in_flight.get(token, 0) + 1
+                return False
+            if ledger.state != "ACTIVE":
+                raise RuntimeError(f"cell ledger is {ledger.state.lower()}: {token}")
+            ledger.in_flight += 1
+            return True
+
+    def complete_cell_request(self, token: str, record: dict[str, Any]) -> None:
+        """Durably append one admitted request and release its in-flight slot."""
+        with self._ledger_condition:
+            ledger = self._cell_ledgers.get(token)
+            if ledger is None:
+                raise RuntimeError(f"cell is not registered: {token}")
+            if ledger.state == "SEALED":
+                raise RuntimeError(f"cell ledger is sealed: {token}")
+            if ledger.in_flight <= 0:
+                raise RuntimeError(f"cell has no admitted request: {token}")
+            try:
+                sequence = ledger.last_sequence + 1
+                chained = scrub(record)
+                for key in ("record_type", "sequence", "previous_hash", "record_hash"):
+                    chained.pop(key, None)
+                chained.update({
+                    "record_type": "request",
+                    "sequence": sequence,
+                    "previous_hash": ledger.root_hash,
+                })
+                canonical = json.dumps(chained, sort_keys=True, separators=(",", ":"))
+                record_hash = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+                chained["record_hash"] = record_hash
+                self._append_durable(self._ledger_path(token), chained)
+                ledger.record_count += 1
+                ledger.last_sequence = sequence
+                ledger.root_hash = record_hash
+            except Exception as exc:
+                ledger.state = "DRAINING"
+                ledger.write_error = f"{type(exc).__name__}: {exc}"
+                raise
+            finally:
+                ledger.in_flight -= 1
+                self._ledger_condition.notify_all()
+
+    def complete_legacy_request(self, token: str, record: dict[str, Any]) -> None:
+        """Append a request admitted before explicit lifecycle registration."""
+        with self._ledger_condition:
+            in_flight = self._legacy_in_flight.get(token, 0)
+            if in_flight <= 0:
+                raise RuntimeError(f"cell has no admitted legacy request: {token}")
+            try:
+                self._append_legacy(self._legacy_ledger_path(token), scrub(record))
+            finally:
+                if in_flight == 1:
+                    self._legacy_in_flight.pop(token, None)
+                else:
+                    self._legacy_in_flight[token] = in_flight - 1
+                self._ledger_condition.notify_all()
+
+    def write_legacy_record_if_unregistered(
+            self, token: str, record: dict[str, Any]) -> bool:
+        """Atomically retain a pre-admission error unless the cell is managed."""
+        with self._ledger_condition:
+            if token in self._cell_ledgers:
+                return False
+            self._append_legacy(self._legacy_ledger_path(token), scrub(record))
+            return True
+
+    def revoke_cell(self, token: str) -> None:
+        """Stop new admissions while allowing admitted requests to drain."""
+        with self._ledger_condition:
+            ledger = self._require_cell(token)
+            if ledger.state == "SEALED":
+                raise RuntimeError(f"cell ledger is sealed: {token}")
+            ledger.state = "DRAINING"
+
+    def seal_cell(self, token: str, timeout_s: float = 30.0) -> LedgerSeal:
+        """Drain a cell for at most ``timeout_s`` and durably seal its ledger."""
+        if timeout_s < 0:
+            raise ValueError("timeout_s must be nonnegative")
+        deadline = time.monotonic() + timeout_s
+        with self._ledger_condition:
+            ledger = self._require_cell(token)
+            if ledger.seal is not None:
+                return ledger.seal
+            ledger.state = "DRAINING"
+            while ledger.in_flight:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"timed out draining cell {token}: {ledger.in_flight} request(s) remain")
+                self._ledger_condition.wait(remaining)
+            if ledger.write_error is not None:
+                raise RuntimeError(
+                    f"cannot seal cell {token} after ledger write failure: {ledger.write_error}")
+
+            path = self._ledger_path(token)
+            terminal = {
+                "record_type": "ledger_seal",
+                "state": "SEALED",
+                "record_count": ledger.record_count,
+                "last_sequence": ledger.last_sequence,
+                "root_hash": ledger.root_hash,
+            }
+            if not ledger.terminal_written:
+                try:
+                    self._append_durable(path, terminal)
+                except Exception:
+                    if self._last_record_equals(path, terminal):
+                        ledger.terminal_written = True
+                    else:
+                        self._truncate_partial_record(path)
+                    raise
+                ledger.terminal_written = True
+            else:
+                self._fsync_file(path)
+            self._fsync_directory(path.parent)
+            ledger.state = "SEALED"
+            ledger.seal = LedgerSeal(
+                token=token,
+                path=path,
+                record_count=ledger.record_count,
+                last_sequence=ledger.last_sequence,
+                root_hash=ledger.root_hash,
+            )
+            return ledger.seal
+
+    def _require_cell(self, token: str) -> _CellLedger:
+        ledger = self._cell_ledgers.get(token)
+        if ledger is None:
+            raise RuntimeError(f"cell is not registered: {token}")
+        return ledger
+
+    def _ledger_path(self, token: str) -> Path:
+        return self.ledger_dir / f"{token}.jsonl"  # type: ignore[attr-defined]
+
+    def _legacy_ledger_path(self, token: str) -> Path:
+        safe = re.sub(r"[^A-Za-z0-9_.-]", "_", token or "unknown")
+        return self.ledger_dir / f"{safe}.jsonl"  # type: ignore[attr-defined]
+
+    def _append_durable(self, path: Path, record: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
+        if getattr(self, "verbose", False):
+            print(line, end="", flush=True)
+
+    def _append_legacy(self, path: Path, record: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+        if getattr(self, "verbose", False):
+            print(line, end="", flush=True)
+
+    @staticmethod
+    def _last_record_equals(path: Path, expected: dict[str, Any]) -> bool:
+        try:
+            lines = path.read_bytes().splitlines()
+            return bool(lines) and json.loads(lines[-1]) == expected
+        except (OSError, json.JSONDecodeError):
+            return False
+
+    @staticmethod
+    def _truncate_partial_record(path: Path) -> None:
+        try:
+            with path.open("r+b") as fh:
+                data = fh.read()
+                if not data or data.endswith(b"\n"):
+                    return
+                last_newline = data.rfind(b"\n")
+                fh.truncate(last_newline + 1)
+                fh.flush()
+                os.fsync(fh.fileno())
+        except FileNotFoundError:
+            return
+
+    @staticmethod
+    def _fsync_file(path: Path) -> None:
+        with path.open("rb") as fh:
+            os.fsync(fh.fileno())
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
 
 def make_server(listen_host: str, port: int, ledger_dir: str | os.PathLike[str],
                 chat_upstreams: dict[str, str] | None = None,
@@ -615,6 +867,9 @@ def make_server(listen_host: str, port: int, ledger_dir: str | os.PathLike[str],
     httpd.timeout_s = timeout_s
     httpd.capture_limit = max(capture_limit, 4096)
     httpd.max_request_bytes = max(max_request_bytes, 0)
+    httpd._ledger_condition = threading.Condition()
+    httpd._cell_ledgers = {}
+    httpd._legacy_in_flight = {}
     # Docker requires a non-loopback bind. In that mode the runner enables this
     # gate so arbitrary LAN clients cannot spend through a subscription route.
     httpd.require_registered_tokens = require_registered_tokens

--- a/obench/proxy.py
+++ b/obench/proxy.py
@@ -27,6 +27,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote, urlsplit
 
+from obench.router_metrics import OpenAIChatSSEParser
+from obench.router_spec import RoutePlan, SecretPlan
+
 HOP_BY_HOP = {
     "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
     "te", "trailer", "transfer-encoding", "upgrade", "host",
@@ -93,6 +96,13 @@ class _CellLedger:
     terminal_written: bool = False
 
 
+@dataclass(frozen=True, repr=False)
+class _RouterRoute:
+    plan: RoutePlan
+    upstream: Any
+    secret: str
+
+
 def new_cell_token() -> str:
     return secrets.token_urlsafe(18)
 
@@ -119,6 +129,17 @@ def _sensitive_name(name: str) -> bool:
     # Redact credential-like fields without catching accounting fields such as
     # input_tokens / completion_tokens / totalTokens.
     return any(part in low for part in ("secret", "password")) or low.endswith("_token") or low.endswith("token")
+
+
+def _credential_header(name: str) -> bool:
+    low = name.lower().replace("-", "_")
+    return (
+        name.lower() in SENSITIVE_HEADERS
+        or low in {"authorization", "proxy_authorization", "cookie", "set_cookie"}
+        or low.endswith(("_token", "_secret", "_password"))
+        or ("api" in low and low.endswith("_key"))
+        or "credential" in low
+    )
 
 
 def scrub(obj: Any) -> Any:
@@ -317,11 +338,13 @@ def _urlsplit_map(values: dict[str, str]) -> dict[str, Any]:
 
 
 class Route:
-    def __init__(self, token: str, route: str, upstream: Any, upstream_path: str):
+    def __init__(self, token: str, route: str, upstream: Any, upstream_path: str,
+                 router: _RouterRoute | None = None):
         self.token = token
         self.route = route
         self.upstream = upstream
         self.upstream_path = upstream_path
+        self.router = router
 
 
 class CountingProxyHandler(BaseHTTPRequestHandler):
@@ -341,6 +364,7 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
 
     def _proxy(self) -> None:
         started = time.time()
+        started_monotonic = time.monotonic()
         status = 502
         usage = None
         body = b""
@@ -352,19 +376,23 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
         error = None
         token = self._token_from_header_or_path()
         managed_ledger: bool | None = None
+        router_parser = None
+        router_metrics = None
         try:
             route = self._route_request()
             token = route.token
             managed_ledger = self.server.admit_cell_request(token)  # type: ignore[attr-defined]
             body = self._read_body()
+            if route.router is not None:
+                body = self._router_request_body(body, route.router.plan)
             request_body = decode_for_parsing(body, self.headers.get("content-encoding", ""))
             sampling = observed_sampling(
                 body,
                 self.headers.get("content-type", ""),
-                self.headers.get("content-encoding", ""),
+                "" if route.router is not None else self.headers.get("content-encoding", ""),
             )
             links.update(protocol_links(request_body))
-            headers = self._forward_headers()
+            headers = self._forward_headers(route, len(body))
             conn_cls = http.client.HTTPSConnection if route.upstream.scheme == "https" else http.client.HTTPConnection
             if not route.upstream.hostname:
                 raise RuntimeError("upstream URL missing host")
@@ -373,6 +401,17 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             resp = conn.getresponse()
             status = resp.status
             resp_headers = resp.getheaders()
+            if route.router is not None and 300 <= resp.status < 400:
+                status = 502
+                conn.close()
+                raise RuntimeError(f"router upstream redirect rejected: HTTP {resp.status}")
+            header_map = {k.lower(): v for k, v in resp_headers}
+            if (route.router is not None
+                    and "text/event-stream" in header_map.get("content-type", "").lower()):
+                router_parser = OpenAIChatSSEParser(
+                    requested_model=route.router.plan.requested_model,
+                    started_at=started_monotonic,
+                )
             self.send_response(resp.status, resp.reason)
             for key, value in resp_headers:
                 if key.lower() in HOP_BY_HOP:
@@ -385,9 +424,11 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             capture = bytearray()
             limit = self.server.capture_limit  # type: ignore[attr-defined]
             while True:
-                chunk = resp.read(65536)
+                chunk = resp.read1(65536)
                 if not chunk:
                     break
+                if router_parser is not None:
+                    router_parser.feed(chunk, time.monotonic())
                 if len(capture) + len(chunk) <= limit:
                     capture.extend(chunk)
                 else:
@@ -398,11 +439,14 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
                     capture.extend(chunk[-limit:])
                 self.wfile.write(chunk)
                 self.wfile.flush()
-            header_map = {k.lower(): v for k, v in resp_headers}
+            if router_parser is not None:
+                router_metrics = router_parser.finalize(time.monotonic())
             parse_body = decode_for_parsing(bytes(capture), header_map.get("content-encoding", ""))
             usage = parse_json_usage(parse_body)
             if usage is None:
                 usage = parse_sse_usage(parse_body)
+            if router_metrics is not None and router_metrics.get("usage") is not None:
+                usage = router_metrics["usage"]
             links.update(protocol_links(parse_body, response=True))
             conn.close()
         except Exception as exc:  # noqa: BLE001
@@ -420,6 +464,11 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             else:
                 self.close_connection = True
         finally:
+            if router_parser is not None and router_metrics is None:
+                try:
+                    router_metrics = router_parser.finalize(time.monotonic())
+                except Exception:
+                    router_metrics = None
             token = route.token if route is not None else token
             meta = self._read_metadata(token)
             configured_sampling = meta.get("sampling") if isinstance(meta.get("sampling"), dict) else {}
@@ -438,6 +487,14 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             if route is not None:
                 rec["route"] = route.route
                 rec["upstream"] = f"{route.upstream.scheme}://{route.upstream.netloc}{route.upstream.path.rstrip('/')}"
+                if route.router is not None:
+                    rec["router_arm"] = {
+                        "arm_id": route.router.plan.arm_id,
+                        "arm_digest": route.router.plan.arm_digest,
+                        "route_kind": route.router.plan.route_kind,
+                    }
+            if router_metrics is not None:
+                rec["router_metrics"] = router_metrics
             if "session" in links:
                 rec["session_hash"] = _identifier_hash(links["session"], self.server.identifier_salt)
             if "previous_response" in links:
@@ -488,6 +545,16 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             if (registration_meta.get("harness") != "grokbuild"
                     or registration_meta.get("model") not in {"gpt-5.6", "gpt-5.6-sol"}):
                 raise RuntimeError("cell token is not authorized for subscription bridge")
+        router = None
+        if prefix == "route":
+            if not tail:
+                raise RuntimeError("/route requires an arm digest")
+            router = self.server.resolve_route(token, tail[0])  # type: ignore[attr-defined]
+            upstream = router.upstream
+            upstream_path = upstream.path or "/"
+            if upstream.query:
+                upstream_path += "?" + upstream.query
+            return Route(token, f"route/{router.plan.arm_digest}", upstream, upstream_path, router)
         if prefix == "codex":
             upstream = self.server.upstreams["codex"]  # type: ignore[attr-defined]
             route_name = "codex"
@@ -553,14 +620,68 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
     def _scrub_cell_path(path: str) -> str:
         return TOKEN_RE.sub("/cell/<redacted>", path)
 
-    def _forward_headers(self) -> dict[str, str]:
+    def _forward_headers(self, route: Route, body_length: int) -> dict[str, str]:
         connection_tokens = set()
         if self.headers.get("Connection"):
             connection_tokens = {x.strip().lower() for x in self.headers.get("Connection", "").split(",")}
         # Host identifies this proxy on ingress; let http.client generate the
         # selected upstream's Host header instead of forwarding the proxy host.
         blocked = HOP_BY_HOP | connection_tokens | {"host", "x-openbench-cell-token"}
-        return {k: v for k, v in self.headers.items() if k.lower() not in blocked}
+        if route.router is None:
+            return {k: v for k, v in self.headers.items() if k.lower() not in blocked}
+        headers = {
+            k: v for k, v in self.headers.items()
+            if k.lower() not in blocked
+            and not _credential_header(k)
+            and k.lower() not in {
+                "content-length", "content-encoding", "x-openrouter-metadata",
+            }
+        }
+        headers["Authorization"] = f"Bearer {route.router.secret}"
+        headers["Content-Length"] = str(body_length)
+        if route.router.plan.route_kind == "gateway":
+            headers["X-OpenRouter-Metadata"] = "enabled"
+        return headers
+
+    def _router_request_body(self, body: bytes, plan: RoutePlan) -> bytes:
+        if self.headers.get("content-encoding"):
+            raise RuntimeError("router requests do not permit content encoding")
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("router request body must be a JSON object") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError("router request body must be a JSON object")
+        payload["model"] = plan.requested_model
+        for key in ("top_k", "reasoning_effort", "reasoning", "thinking"):
+            payload.pop(key, None)
+        payload.update({
+            "temperature": plan.sampling.temperature,
+            "top_p": plan.sampling.top_p,
+            "seed": plan.sampling.seed,
+        })
+        if plan.route_kind == "gateway":
+            self._strip_cache_controls(payload)
+            payload["provider"] = {
+                "only": [plan.requested_provider],
+                "allow_fallbacks": False,
+            }
+        else:
+            payload.pop("provider", None)
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    @classmethod
+    def _strip_cache_controls(cls, value: Any) -> None:
+        if isinstance(value, dict):
+            for key in list(value):
+                normalized = str(key).lower().replace("-", "_")
+                if normalized in {"cache", "cache_control", "cache_key", "prompt_cache_key"}:
+                    value.pop(key)
+                else:
+                    cls._strip_cache_controls(value[key])
+        elif isinstance(value, list):
+            for item in value:
+                cls._strip_cache_controls(item)
 
     def _read_body(self) -> bytes:
         max_bytes = self.server.max_request_bytes  # type: ignore[attr-defined]
@@ -635,6 +756,49 @@ class CountingProxyServer(ThreadingHTTPServer):
             if path.exists():
                 raise FileExistsError(f"cell ledger already exists: {path}")
             self._cell_ledgers[token] = _CellLedger()
+
+    def register_route(
+            self, token: str, plan: RoutePlan, secrets_plan: SecretPlan) -> None:
+        """Bind one committed arm and its admitted credential to a managed cell."""
+        if not isinstance(plan, RoutePlan):
+            raise TypeError("plan must be a RoutePlan")
+        if not isinstance(secrets_plan, SecretPlan):
+            raise TypeError("secrets_plan must be a SecretPlan")
+        if plan.protocol != "openai_chat":
+            raise ValueError("router route protocol must be openai_chat")
+        if plan.route_kind not in {"direct", "gateway"}:
+            raise ValueError("router route kind must be direct or gateway")
+        if plan.requested_model not in plan.allowed_models:
+            raise ValueError("requested model is not allowed by the route plan")
+        if plan.allowed_providers != (plan.requested_provider,):
+            raise ValueError("router route must allow exactly the requested provider")
+        if plan.fallback_enabled or plan.retry_count or plan.cache_enabled:
+            raise ValueError("router route controls do not match gateway_tax")
+        upstream = urlsplit(plan.endpoint)
+        if upstream.scheme not in {"http", "https"} or not upstream.hostname:
+            raise ValueError("router route endpoint must be an absolute HTTP(S) URL")
+        secret = secrets_plan.value_for(plan.arm_id)
+        if secrets_plan.env_name_for(plan.arm_id) != plan.auth_env:
+            raise ValueError("secret plan does not match route auth environment")
+        if not secret:
+            raise ValueError("router route secret must not be empty")
+        with self._ledger_condition:
+            ledger = self._require_cell(token)
+            if ledger.state != "ACTIVE" or ledger.in_flight:
+                raise RuntimeError(f"cell cannot register a route while {ledger.state.lower()}")
+            if token in self._router_routes:
+                raise RuntimeError(f"cell already has a registered route: {token}")
+            self._router_routes[token] = _RouterRoute(plan, upstream, secret)
+
+    register_router_route = register_route
+
+    def resolve_route(self, token: str, arm_digest: str) -> _RouterRoute:
+        """Authorize one route digest without exposing its in-memory secret."""
+        with self._ledger_condition:
+            route = self._router_routes.get(token)
+            if route is None or route.plan.arm_digest != arm_digest:
+                raise RuntimeError("router arm is not authorized for this cell")
+            return route
 
     def cell_is_registered(self, token: str) -> bool:
         with self._ledger_condition:
@@ -870,6 +1034,7 @@ def make_server(listen_host: str, port: int, ledger_dir: str | os.PathLike[str],
     httpd._ledger_condition = threading.Condition()
     httpd._cell_ledgers = {}
     httpd._legacy_in_flight = {}
+    httpd._router_routes = {}
     # Docker requires a non-loopback bind. In that mode the runner enables this
     # gate so arbitrary LAN clients cannot spend through a subscription route.
     httpd.require_registered_tokens = require_registered_tokens

--- a/obench/proxy.py
+++ b/obench/proxy.py
@@ -639,7 +639,8 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             if k.lower() not in blocked
             and not _credential_header(k)
             and k.lower() not in {
-                "content-length", "content-encoding", "x-openrouter-metadata",
+                "content-length", "content-encoding", "accept-encoding",
+                "x-openrouter-metadata",
             }
             and not k.lower().startswith("x-openrouter-cache")
         }

--- a/obench/proxy.py
+++ b/obench/proxy.py
@@ -411,6 +411,11 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
                 router_parser = OpenAIChatSSEParser(
                     requested_model=route.router.plan.requested_model,
                     started_at=started_monotonic,
+                    route_kind=route.router.plan.route_kind,
+                    requested_provider=route.router.plan.requested_provider,
+                    allowed_models=route.router.plan.allowed_models,
+                    allowed_providers=route.router.plan.allowed_providers,
+                    fallback_enabled=route.router.plan.fallback_enabled,
                 )
             self.send_response(resp.status, resp.reason)
             for key, value in resp_headers:
@@ -636,11 +641,13 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             and k.lower() not in {
                 "content-length", "content-encoding", "x-openrouter-metadata",
             }
+            and not k.lower().startswith("x-openrouter-cache")
         }
         headers["Authorization"] = f"Bearer {route.router.secret}"
         headers["Content-Length"] = str(body_length)
         if route.router.plan.route_kind == "gateway":
             headers["X-OpenRouter-Metadata"] = "enabled"
+            headers["X-OpenRouter-Cache"] = "false"
         return headers
 
     def _router_request_body(self, body: bytes, plan: RoutePlan) -> bytes:

--- a/obench/results.py
+++ b/obench/results.py
@@ -1,0 +1,538 @@
+"""Versioned result identity and fail-closed resume helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any, TypeVar
+
+
+LEGACY_SCHEMA_VERSION = 0
+CURRENT_SCHEMA_VERSION = 2
+HARNESS_BENCHMARK = "harness"
+ROUTER_BENCHMARK = "router"
+_SHA256_HEX_LENGTH = 64
+
+_IDENTITY_FIELDS = frozenset({
+    "schema_version", "benchmark", "experiment", "arm", "comparison",
+    "task", "harness", "execution", "schedule",
+})
+_BENCHMARK_FIELDS = frozenset({"name", "track"})
+_EXPERIMENT_FIELDS = frozenset({"id", "digest"})
+_ARM_FIELDS = frozenset({"id", "digest"})
+_COMPARISON_FIELDS = frozenset({
+    "policy_digest", "catalog_digest", "price_digest", "sampling_digest",
+    "schedule_digest",
+})
+_TASK_FIELDS = frozenset({
+    "name", "digest", "checker_digest", "workspace_source_sha",
+})
+_HARNESS_FIELDS = frozenset({"name", "candidate", "version"})
+_EXECUTION_FIELDS = frozenset({
+    "lane", "image_digest", "budget", "adapter_timeout_s",
+    "checker_timeout_s",
+})
+_BUDGET_FIELDS = frozenset({
+    "timeout_s", "max_calls", "max_output_tokens", "usd_cap",
+})
+_SCHEDULE_FIELDS = frozenset({
+    "window_id", "repetition", "block_id", "block_attempt",
+})
+
+
+class ResultError(ValueError):
+    """Base class for invalid result data."""
+
+
+class ResultIdentityError(ResultError):
+    """Raised when a result identity is incomplete or inconsistent."""
+
+
+class UnsupportedResultError(ResultError):
+    """Raised when no consumer is registered for a result kind."""
+
+
+class ResultsLogError(RuntimeError):
+    """Raised when a JSONL log cannot be resumed without ambiguity."""
+
+
+class DuplicateResultError(ResultsLogError):
+    """Raised when a JSONL log contains the same cell more than once."""
+
+
+class _DuplicateJsonKey(ValueError):
+    pass
+
+
+def canonical_json(value: Any) -> str:
+    """Serialize ``value`` to deterministic, whitespace-free JSON."""
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Return the UTF-8 bytes used for canonical result digests."""
+    return canonical_json(value).encode("utf-8")
+
+
+def canonical_digest(value: Any) -> str:
+    """Return the lowercase SHA-256 hex digest of canonical JSON."""
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise _DuplicateJsonKey(f"duplicate object key {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant {value!r}")
+
+
+def _require_non_empty_string(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        raise ResultIdentityError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_optional_string(name: str, value: Any) -> str | None:
+    if value is not None:
+        _require_non_empty_string(name, value)
+    return value
+
+
+def _require_digest(name: str, value: Any) -> str:
+    value = _require_non_empty_string(name, value)
+    if len(value) != _SHA256_HEX_LENGTH or any(c not in "0123456789abcdef" for c in value):
+        raise ResultIdentityError(f"{name} must be a lowercase SHA-256 hex digest")
+    return value
+
+
+def _require_optional_digest(name: str, value: Any) -> str | None:
+    if value is not None:
+        _require_digest(name, value)
+    return value
+
+
+def _require_source_sha(name: str, value: Any) -> str:
+    value = _require_non_empty_string(name, value)
+    if len(value) not in (40, 64) or any(c not in "0123456789abcdef" for c in value):
+        raise ResultIdentityError(f"{name} must be a lowercase 40- or 64-character SHA")
+    return value
+
+
+def _require_positive_int(name: str, value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ResultIdentityError(f"{name} must be a positive integer")
+    return value
+
+
+def _require_non_negative_int(name: str, value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ResultIdentityError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _require_positive_number(name: str, value: Any) -> int | float:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or value <= 0
+        or not math.isfinite(value)
+    ):
+        raise ResultIdentityError(f"{name} must be a positive finite number")
+    return value
+
+
+def _require_object(name: str, value: Any, fields: frozenset[str]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ResultIdentityError(f"{name} must be an object")
+    keys = frozenset(value)
+    if not all(isinstance(key, str) for key in keys):
+        raise ResultIdentityError(f"{name} field names must be strings")
+    missing = sorted(fields - keys)
+    extra = sorted(keys - fields)
+    if missing or extra:
+        details = []
+        if missing:
+            details.append(f"missing fields: {', '.join(missing)}")
+        if extra:
+            details.append(f"unexpected fields: {', '.join(extra)}")
+        raise ResultIdentityError(f"{name} has " + "; ".join(details))
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class CellIdentity:
+    """Immutable normative identity for one router benchmark cell."""
+
+    schema_version: int
+    benchmark: str
+    track: str
+    experiment_id: str
+    experiment_digest: str
+    arm_id: str
+    arm_digest: str
+    policy_digest: str
+    catalog_digest: str
+    price_digest: str
+    sampling_digest: str
+    schedule_digest: str
+    task: str
+    task_digest: str
+    checker_digest: str
+    workspace_source_sha: str
+    harness: str
+    candidate: str | None
+    harness_version: str
+    execution_lane: str
+    image_digest: str | None
+    budget_timeout_s: int | float
+    budget_max_calls: int
+    budget_max_output_tokens: int
+    budget_usd_cap: str
+    adapter_timeout_s: int | float
+    checker_timeout_s: int | float
+    window_id: str
+    repetition: int
+    block_id: str
+    block_attempt: int
+
+    def __post_init__(self) -> None:
+        if self.schema_version != CURRENT_SCHEMA_VERSION:
+            raise ResultIdentityError(
+                f"schema_version must be {CURRENT_SCHEMA_VERSION} for router identities"
+            )
+        if self.benchmark != ROUTER_BENCHMARK:
+            raise ResultIdentityError(f"benchmark must be {ROUTER_BENCHMARK!r}")
+        for name in (
+            "track", "experiment_id", "arm_id", "task", "harness",
+            "harness_version", "execution_lane", "budget_usd_cap", "window_id",
+            "block_id",
+        ):
+            _require_non_empty_string(name, getattr(self, name))
+        _require_optional_string("candidate", self.candidate)
+        for name in (
+            "experiment_digest", "arm_digest", "policy_digest", "catalog_digest",
+            "price_digest", "sampling_digest", "schedule_digest", "task_digest",
+            "checker_digest",
+        ):
+            _require_digest(name, getattr(self, name))
+        _require_source_sha("workspace_source_sha", self.workspace_source_sha)
+        _require_optional_digest("image_digest", self.image_digest)
+        _require_positive_number("budget_timeout_s", self.budget_timeout_s)
+        _require_positive_int("budget_max_calls", self.budget_max_calls)
+        _require_positive_int("budget_max_output_tokens", self.budget_max_output_tokens)
+        _require_positive_number("adapter_timeout_s", self.adapter_timeout_s)
+        _require_positive_number("checker_timeout_s", self.checker_timeout_s)
+        _require_positive_int("repetition", self.repetition)
+        _require_non_negative_int("block_attempt", self.block_attempt)
+
+    @classmethod
+    def for_router(cls, **values: Any) -> "CellIdentity":
+        """Build a schema-v2 router identity without repeating fixed fields."""
+        return cls(
+            schema_version=CURRENT_SCHEMA_VERSION,
+            benchmark=ROUTER_BENCHMARK,
+            **values,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the canonical nested identity representation."""
+        return {
+            "schema_version": self.schema_version,
+            "benchmark": {"name": self.benchmark, "track": self.track},
+            "experiment": {
+                "id": self.experiment_id,
+                "digest": self.experiment_digest,
+            },
+            "arm": {"id": self.arm_id, "digest": self.arm_digest},
+            "comparison": {
+                "policy_digest": self.policy_digest,
+                "catalog_digest": self.catalog_digest,
+                "price_digest": self.price_digest,
+                "sampling_digest": self.sampling_digest,
+                "schedule_digest": self.schedule_digest,
+            },
+            "task": {
+                "name": self.task,
+                "digest": self.task_digest,
+                "checker_digest": self.checker_digest,
+                "workspace_source_sha": self.workspace_source_sha,
+            },
+            "harness": {
+                "name": self.harness,
+                "candidate": self.candidate,
+                "version": self.harness_version,
+            },
+            "execution": {
+                "lane": self.execution_lane,
+                "image_digest": self.image_digest,
+                "budget": {
+                    "timeout_s": self.budget_timeout_s,
+                    "max_calls": self.budget_max_calls,
+                    "max_output_tokens": self.budget_max_output_tokens,
+                    "usd_cap": self.budget_usd_cap,
+                },
+                "adapter_timeout_s": self.adapter_timeout_s,
+                "checker_timeout_s": self.checker_timeout_s,
+            },
+            "schedule": {
+                "window_id": self.window_id,
+                "repetition": self.repetition,
+                "block_id": self.block_id,
+                "block_attempt": self.block_attempt,
+            },
+        }
+
+    def run_dict(self) -> dict[str, Any]:
+        """Return comparison-shared dimensions that define one router run."""
+        identity = self.as_dict()
+        return {
+            key: identity[key]
+            for key in (
+                "schema_version", "benchmark", "experiment", "comparison",
+                "harness", "execution",
+            )
+        }
+
+
+def validate_router_identity(value: CellIdentity | Mapping[str, Any]) -> CellIdentity:
+    """Return a validated schema-v2 router identity."""
+    if isinstance(value, CellIdentity):
+        return value
+    root = _require_object("router identity", value, _IDENTITY_FIELDS)
+    benchmark = _require_object("identity.benchmark", root["benchmark"], _BENCHMARK_FIELDS)
+    experiment = _require_object(
+        "identity.experiment", root["experiment"], _EXPERIMENT_FIELDS
+    )
+    arm = _require_object("identity.arm", root["arm"], _ARM_FIELDS)
+    comparison = _require_object(
+        "identity.comparison", root["comparison"], _COMPARISON_FIELDS
+    )
+    task = _require_object("identity.task", root["task"], _TASK_FIELDS)
+    harness = _require_object("identity.harness", root["harness"], _HARNESS_FIELDS)
+    execution = _require_object(
+        "identity.execution", root["execution"], _EXECUTION_FIELDS
+    )
+    budget = _require_object(
+        "identity.execution.budget", execution["budget"], _BUDGET_FIELDS
+    )
+    schedule = _require_object("identity.schedule", root["schedule"], _SCHEDULE_FIELDS)
+    return CellIdentity(
+        schema_version=root["schema_version"],
+        benchmark=benchmark["name"],
+        track=benchmark["track"],
+        experiment_id=experiment["id"],
+        experiment_digest=experiment["digest"],
+        arm_id=arm["id"],
+        arm_digest=arm["digest"],
+        policy_digest=comparison["policy_digest"],
+        catalog_digest=comparison["catalog_digest"],
+        price_digest=comparison["price_digest"],
+        sampling_digest=comparison["sampling_digest"],
+        schedule_digest=comparison["schedule_digest"],
+        task=task["name"],
+        task_digest=task["digest"],
+        checker_digest=task["checker_digest"],
+        workspace_source_sha=task["workspace_source_sha"],
+        harness=harness["name"],
+        candidate=harness["candidate"],
+        harness_version=harness["version"],
+        execution_lane=execution["lane"],
+        image_digest=execution["image_digest"],
+        budget_timeout_s=budget["timeout_s"],
+        budget_max_calls=budget["max_calls"],
+        budget_max_output_tokens=budget["max_output_tokens"],
+        budget_usd_cap=budget["usd_cap"],
+        adapter_timeout_s=execution["adapter_timeout_s"],
+        checker_timeout_s=execution["checker_timeout_s"],
+        window_id=schedule["window_id"],
+        repetition=schedule["repetition"],
+        block_id=schedule["block_id"],
+        block_attempt=schedule["block_attempt"],
+    )
+
+
+def router_identity_from_row(row: Mapping[str, Any]) -> CellIdentity:
+    """Read the canonical nested identity and verify dispatch metadata."""
+    if "identity" not in row:
+        raise ResultIdentityError("router row identity is required")
+    identity = validate_router_identity(row["identity"])
+    if row.get("schema_version") != identity.schema_version:
+        raise ResultIdentityError("router row schema_version conflicts with its identity")
+    if row.get("benchmark") != identity.benchmark:
+        raise ResultIdentityError("router row benchmark conflicts with its identity")
+    return identity
+
+
+def make_router_run_id(identity: CellIdentity | Mapping[str, Any]) -> str:
+    """Return the deterministic ID shared by comparable cells in one run."""
+    identity = validate_router_identity(identity)
+    return f"router-run-v{CURRENT_SCHEMA_VERSION}-{canonical_digest(identity.run_dict())}"
+
+
+def make_router_cell_id(identity: CellIdentity | Mapping[str, Any]) -> str:
+    """Return the deterministic ID for one router benchmark cell."""
+    identity = validate_router_identity(identity)
+    return f"router-cell-v{CURRENT_SCHEMA_VERSION}-{canonical_digest(identity.as_dict())}"
+
+
+def schema_version(row: Mapping[str, Any]) -> int:
+    """Return a row's schema version; missing means the legacy schema."""
+    version = row.get("schema_version", LEGACY_SCHEMA_VERSION)
+    if not isinstance(version, int) or isinstance(version, bool) or version < 0:
+        raise ResultError("schema_version must be a non-negative integer")
+    return version
+
+
+def benchmark_name(row: Mapping[str, Any]) -> str:
+    """Return a row's benchmark, preserving metadata-free legacy dispatch."""
+    version = schema_version(row)
+    benchmark = row.get("benchmark")
+    if version == LEGACY_SCHEMA_VERSION and benchmark is None:
+        return HARNESS_BENCHMARK
+    return _require_non_empty_string("benchmark", benchmark)
+
+
+def result_kind(row: Mapping[str, Any]) -> tuple[int, str]:
+    """Return the stable ``(schema_version, benchmark)`` dispatch key."""
+    return schema_version(row), benchmark_name(row)
+
+
+T = TypeVar("T")
+
+
+def dispatch_result(
+    row: Mapping[str, Any],
+    handlers: Mapping[tuple[int, str], Callable[[Mapping[str, Any]], T]],
+) -> T:
+    """Dispatch a result row by schema version and benchmark."""
+    kind = result_kind(row)
+    try:
+        handler = handlers[kind]
+    except KeyError as exc:
+        raise UnsupportedResultError(
+            f"unsupported result schema_version={kind[0]} benchmark={kind[1]!r}"
+        ) from exc
+    return handler(row)
+
+
+def result_cell_id(row: Mapping[str, Any]) -> str:
+    """Return the resumable cell ID for a legacy or versioned result row."""
+    if "identity" in row:
+        identity = validate_router_identity(row["identity"])
+        if row.get("schema_version") != identity.schema_version:
+            raise ResultIdentityError(
+                "router row schema_version conflicts with its identity"
+            )
+        if row.get("benchmark") != identity.benchmark:
+            raise ResultIdentityError(
+                "router row benchmark conflicts with its identity"
+            )
+    kind = result_kind(row)
+    if kind == (LEGACY_SCHEMA_VERSION, HARNESS_BENCHMARK):
+        value = row.get("run_id")
+        if not isinstance(value, str) or not value:
+            raise ResultIdentityError("legacy row run_id must be a non-empty string")
+        return value
+    if kind == (CURRENT_SCHEMA_VERSION, ROUTER_BENCHMARK):
+        identity = router_identity_from_row(row)
+        if row.get("run_id") != make_router_run_id(identity):
+            raise ResultIdentityError("router row run_id does not match its identity")
+        if row.get("cell_id") != make_router_cell_id(identity):
+            raise ResultIdentityError("router row cell_id does not match its identity")
+        return row["cell_id"]
+    raise UnsupportedResultError(
+        f"unsupported result schema_version={kind[0]} benchmark={kind[1]!r}"
+    )
+
+
+def find_duplicate_cells(rows: Iterable[Mapping[str, Any]]) -> dict[str, tuple[int, ...]]:
+    """Return duplicate cell IDs mapped to their one-based row numbers."""
+    locations: dict[str, list[int]] = {}
+    for line_no, row in enumerate(rows, 1):
+        locations.setdefault(result_cell_id(row), []).append(line_no)
+    return {
+        cell_id: tuple(line_numbers)
+        for cell_id, line_numbers in locations.items()
+        if len(line_numbers) > 1
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ResumeState:
+    """Validated rows and cell IDs recovered from a results log."""
+
+    rows: tuple[dict[str, Any], ...]
+    cell_ids: frozenset[str]
+
+
+def read_jsonl_for_resume(path: str | Path) -> ResumeState:
+    """Read a results log, failing closed on corruption or duplicate cells."""
+    path = Path(path)
+    if not path.exists() and not path.is_symlink():
+        return ResumeState((), frozenset())
+    if not path.is_file():
+        raise ResultsLogError(f"{path} exists but is not a regular file")
+    raw = path.read_bytes()
+    if raw and not raw.endswith(b"\n"):
+        raise ResultsLogError(f"{path} has a truncated final JSONL line (missing newline)")
+
+    rows: list[dict[str, Any]] = []
+    for line_no, raw_line in enumerate(raw.splitlines(), 1):
+        if not raw_line.strip():
+            continue
+        try:
+            line = raw_line.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ResultsLogError(f"{path} has invalid UTF-8 at line {line_no}") from exc
+        try:
+            row = json.loads(
+                line,
+                object_pairs_hook=_unique_object,
+                parse_constant=_reject_json_constant,
+            )
+        except ValueError as exc:
+            message = exc.msg if isinstance(exc, json.JSONDecodeError) else str(exc)
+            raise ResultsLogError(
+                f"{path} has corrupt JSON at line {line_no}: {message}"
+            ) from exc
+        if not isinstance(row, dict):
+            raise ResultsLogError(f"{path} has a non-object JSON value at line {line_no}")
+        try:
+            result_cell_id(row)
+        except ResultError as exc:
+            raise ResultsLogError(
+                f"{path} has invalid result identity at line {line_no}: {exc}"
+            ) from exc
+        rows.append(row)
+
+    duplicates = find_duplicate_cells(rows)
+    if duplicates:
+        details = ", ".join(
+            f"{cell_id} on lines {','.join(map(str, line_numbers))}"
+            for cell_id, line_numbers in sorted(duplicates.items())
+        )
+        raise DuplicateResultError(f"{path} has duplicate result cells: {details}")
+    return ResumeState(tuple(rows), frozenset(map(result_cell_id, rows)))
+
+
+get_schema_version = schema_version
+get_benchmark = benchmark_name
+router_run_id = make_router_run_id
+router_cell_id = make_router_cell_id
+load_resume_state = read_jsonl_for_resume

--- a/obench/router_cli.py
+++ b/obench/router_cli.py
@@ -1,0 +1,180 @@
+"""CLI for Gateway Tax experiments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from . import results, router_publish, router_report, router_run, router_spec
+
+
+def _tasks_dir(value: str | None) -> str:
+    return value or "tasks"
+
+
+def _print_error(exc: Exception) -> int:
+    print(f"obench router: {exc}", file=sys.stderr)
+    return 2
+
+
+def _validate(args: argparse.Namespace) -> int:
+    experiment, tasks = router_run.validate_experiment(
+        args.experiment, tasks_dir=_tasks_dir(args.tasks_dir)
+    )
+    print(
+        f"valid experiment={experiment.experiment_id} "
+        f"digest={experiment.digest} tasks={len(tasks)} arms={len(experiment.arms)}"
+    )
+    return 0
+
+
+def _doctor(args: argparse.Namespace) -> int:
+    report = router_run.doctor_experiment(
+        args.experiment, tasks_dir=_tasks_dir(args.tasks_dir)
+    )
+    print(json.dumps(report, sort_keys=True))
+    if not report["usd_cap_enforceable"]:
+        print(
+            f"obench router: {router_run.FROZEN_PRICES_ENV} is required to run",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+def _run(args: argparse.Namespace) -> int:
+    experiment = router_spec.load_experiment(args.experiment)
+    results_path = args.results or f"results/router-{experiment.experiment_id}.jsonl"
+    summary = router_run.run_experiment(
+        args.experiment,
+        results_path=results_path,
+        tasks_dir=_tasks_dir(args.tasks_dir),
+        exec_mode=args.exec_mode,
+        force=args.force,
+    )
+    print(
+        f"results={summary.results_path} rows_appended={summary.rows_appended} "
+        f"blocks_completed={summary.blocks_completed} "
+        f"blocks_replaced={summary.blocks_replaced} "
+        f"blocks_skipped={summary.blocks_skipped}"
+    )
+    return 0
+
+
+def _report(args: argparse.Namespace) -> int:
+    state = results.read_jsonl_for_resume(Path(args.results))
+    if not state.rows:
+        raise router_run.RouterRunError("results file contains no rows")
+    expected = set()
+    for row in state.rows:
+        raw = row.get("expected_arm_ids")
+        if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+            expected.update(raw)
+    report = router_report.aggregate(
+        state.rows,
+        expected_arm_ids=expected or None,
+    )
+    if args.json:
+        print(json.dumps(report, allow_nan=False, sort_keys=True))
+    else:
+        print(router_report.render_text(report))
+    return 0
+
+
+def _publish(args: argparse.Namespace) -> int:
+    results_path = Path(args.results).resolve()
+    experiment = router_spec.load_experiment(args.experiment)
+    state = results.read_jsonl_for_resume(results_path)
+    if not state.rows:
+        raise router_run.RouterRunError("results file contains no rows")
+    price_snapshot = router_run.load_persisted_price_snapshot(results_path)
+    ledger_dir = (
+        Path(args.ledgers_dir).resolve()
+        if args.ledgers_dir
+        else results_path.parent / f".{results_path.stem}.router-ledgers"
+    )
+    ledgers = {}
+    for row in state.rows:
+        seal = row.get("ledger_seal")
+        if not isinstance(seal, dict) or not isinstance(seal.get("ledger_file"), str):
+            raise router_run.RouterRunError("result row is missing its sealed ledger binding")
+        ledgers[results.result_cell_id(row)] = ledger_dir / seal["ledger_file"]
+    provenance = router_publish.publish_bundle(
+        results_path,
+        args.bundle,
+        experiment=experiment,
+        policy=router_run.policy_snapshot(),
+        catalog=router_run.catalog_snapshot(experiment),
+        prices=price_snapshot,
+        ledgers=ledgers,
+    )
+    print(json.dumps(provenance, sort_keys=True))
+    return 0
+
+
+def _verify(args: argparse.Namespace) -> int:
+    print(json.dumps(router_publish.verify_bundle(args.bundle), sort_keys=True))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="obench router",
+        description="Run and report Gateway Tax experiments.",
+    )
+    sub = parser.add_subparsers(dest="router_command", required=True)
+
+    validate = sub.add_parser("validate", help="validate experiment and task inputs")
+    validate.add_argument("experiment")
+    validate.add_argument("--tasks-dir")
+    validate.set_defaults(handler=_validate)
+
+    doctor = sub.add_parser("doctor", help="check credentials, Pi, tasks, and prices")
+    doctor.add_argument("experiment")
+    doctor.add_argument("--tasks-dir")
+    doctor.set_defaults(handler=_doctor)
+
+    run = sub.add_parser("run", help="run or resume an experiment")
+    run.add_argument("experiment")
+    run.add_argument("--results")
+    run.add_argument("--tasks-dir")
+    run.add_argument("--exec", dest="exec_mode", choices=("local", "docker"))
+    run.add_argument("--force", action="store_true")
+    run.set_defaults(handler=_run)
+
+    report = sub.add_parser("report", help="report schema-v2 router results")
+    report.add_argument("results")
+    report.add_argument("--json", action="store_true")
+    report.set_defaults(handler=_report)
+
+    publish = sub.add_parser("publish", help="create a sanitized evidence bundle")
+    publish.add_argument("results")
+    publish.add_argument("experiment")
+    publish.add_argument("bundle")
+    publish.add_argument("--ledgers-dir")
+    publish.set_defaults(handler=_publish)
+
+    verify = sub.add_parser("verify", help="verify a Router Bench evidence bundle")
+    verify.add_argument("bundle")
+    verify.set_defaults(handler=_verify)
+
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except (
+        OSError,
+        results.ResultError,
+        results.ResultsLogError,
+        router_report.RouterReportError,
+        router_publish.RouterPublishError,
+        router_run.RouterRunError,
+        router_spec.RouterSpecError,
+    ) as exc:
+        return _print_error(exc)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/obench/router_metrics.py
+++ b/obench/router_metrics.py
@@ -150,6 +150,7 @@ class OpenAIChatSSEParser:
         self._metadata_provider: str | None = None
         self._attempts: list[dict[str, Any]] = []
         self._attempts_present = False
+        self._attempts_malformed = False
         self._usage: dict[str, int] | None = None
         self._events = 0
         self._ignored_events = 0
@@ -350,10 +351,19 @@ class OpenAIChatSSEParser:
             requested = _identifier(metadata.get("requested"))
             if requested is not None:
                 self._metadata_requested = requested
-            raw_attempts = metadata.get("attempts")
-            if isinstance(raw_attempts, list) and raw_attempts:
-                self._attempts_present = True
-                self._attempts = _clean_attempts(raw_attempts)
+            if "attempts" in metadata:
+                raw_attempts = metadata.get("attempts")
+                if not isinstance(raw_attempts, list):
+                    self._attempts_present = True
+                    self._attempts_malformed = True
+                    self._attempts = []
+                elif not raw_attempts:
+                    self._attempts = []
+                else:
+                    self._attempts_present = True
+                    self._attempts = _clean_attempts(raw_attempts)
+                    if len(self._attempts) != len(raw_attempts):
+                        self._attempts_malformed = True
             endpoints = metadata.get("endpoints")
             available = endpoints.get("available") if isinstance(endpoints, dict) else None
             if isinstance(available, list):
@@ -434,7 +444,7 @@ class OpenAIChatSSEParser:
                 reasons.append("provider_conflict")
 
             if self._attempts_present:
-                if not self._attempts:
+                if self._attempts_malformed or not self._attempts:
                     reasons.append("malformed_attempts")
                 success = _successful_attempt(self._attempts)
                 if success is None:
@@ -442,6 +452,7 @@ class OpenAIChatSSEParser:
                 for attempt in self._attempts:
                     attempt_provider = _identifier(attempt.get("provider"))
                     attempt_model = _identifier(attempt.get("model"))
+                    status = attempt.get("status")
                     if not attempt_provider:
                         reasons.append("missing_attempt_provider")
                     elif provider_folded and attempt_provider.casefold() != provider_folded:
@@ -450,6 +461,10 @@ class OpenAIChatSSEParser:
                         reasons.append("missing_attempt_model")
                     elif self._served_model and attempt_model != self._served_model:
                         reasons.append("fallback_attempt")
+                    if not isinstance(status, int) or isinstance(status, bool):
+                        reasons.append("missing_attempt_status")
+                    elif not 200 <= status < 300:
+                        reasons.append("unsuccessful_attempt")
                 if self._fallback_enabled:
                     reasons.append("fallback_enabled")
         return {

--- a/obench/router_metrics.py
+++ b/obench/router_metrics.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Privacy-preserving metrics and route evidence for OpenAI Chat SSE streams.
+
+The parser accepts response chunks with caller-supplied monotonic timestamps.
+It deliberately exposes no event payloads or generated text: snapshots contain
+only timing, token accounting, model/provider identifiers, and coverage state.
+"""
+
+from __future__ import annotations
+
+import codecs
+import json
+import math
+from typing import Any, Iterable
+
+
+_SEMANTIC_DELTA_KEYS = ("content", "reasoning_content", "reasoning", "refusal")
+
+
+def _timestamp(value: Any, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a finite number")
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite number")
+    return value
+
+
+def _identifier(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _token_count(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _has_text(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value)
+    if isinstance(value, list):
+        return any(_has_text(item) for item in value)
+    if isinstance(value, dict):
+        return any(
+            _has_text(value.get(key))
+            for key in ("text", "content", "arguments", "name", "function")
+        )
+    return False
+
+
+def _has_semantic_delta(obj: dict[str, Any]) -> bool:
+    choices = obj.get("choices")
+    if not isinstance(choices, list):
+        return False
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        delta = choice.get("delta")
+        if not isinstance(delta, dict):
+            continue
+        if any(_has_text(delta.get(key)) for key in _SEMANTIC_DELTA_KEYS):
+            return True
+        if _has_text(delta.get("tool_calls")) or _has_text(delta.get("function_call")):
+            return True
+    return False
+
+
+def _clean_attempts(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    attempts = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        attempt = {}
+        provider = _identifier(item.get("provider"))
+        model = _identifier(item.get("model"))
+        status = item.get("status")
+        if provider is not None:
+            attempt["provider"] = provider
+        if model is not None:
+            attempt["model"] = model
+        if isinstance(status, int) and not isinstance(status, bool):
+            attempt["status"] = status
+        if attempt:
+            attempts.append(attempt)
+    return attempts
+
+
+def _successful_attempt(attempts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for attempt in reversed(attempts):
+        status = attempt.get("status")
+        try:
+            status_code = int(status)
+        except (TypeError, ValueError):
+            continue
+        if 200 <= status_code < 300:
+            return attempt
+    return None
+
+
+class OpenAIChatSSEParser:
+    """Incrementally derive metrics from an OpenAI Chat Completions SSE body."""
+
+    def __init__(self, *, requested_model: str | None, started_at: float):
+        self._started_at = _timestamp(started_at, "started_at")
+        self._requested_model = _identifier(requested_model)
+        self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        self._chunk_type: type | None = None
+        self._line = ""
+        self._line_observed_at: float | None = None
+        self._pending_cr = False
+        self._data_lines: list[str] = []
+        self._event_data_at: float | None = None
+        self._first_byte_at: float | None = None
+        self._first_semantic_at: float | None = None
+        self._last_received_at: float | None = None
+        self._completed_at: float | None = None
+        self._served_model: str | None = None
+        self._top_level_provider: str | None = None
+        self._metadata_requested: str | None = None
+        self._metadata_seen = False
+        self._metadata_provider: str | None = None
+        self._attempts: list[dict[str, Any]] = []
+        self._usage: dict[str, int] | None = None
+        self._events = 0
+        self._ignored_events = 0
+        self._malformed_events = 0
+        self._done_seen = False
+        self._finalized = False
+
+    def feed(self, chunk: bytes | str, received_at: float) -> None:
+        """Consume one arbitrary response fragment observed at ``received_at``."""
+        if self._finalized:
+            raise RuntimeError("cannot feed a finalized parser")
+        received_at = _timestamp(received_at, "received_at")
+        if received_at < self._started_at:
+            raise ValueError("received_at precedes started_at")
+        if self._last_received_at is not None and received_at < self._last_received_at:
+            raise ValueError("received_at must be monotonic")
+        if not isinstance(chunk, (bytes, str)):
+            raise TypeError("chunk must be bytes or str")
+        chunk_type = type(chunk)
+        if self._chunk_type is not None and chunk_type is not self._chunk_type:
+            raise TypeError("cannot mix bytes and str chunks")
+        self._chunk_type = chunk_type
+        if chunk:
+            if self._first_byte_at is None:
+                self._first_byte_at = received_at
+        self._last_received_at = received_at
+        text = self._decoder.decode(chunk, final=False) if isinstance(chunk, bytes) else chunk
+        self._consume_text(text, received_at)
+
+    def finalize(self, completed_at: float | None = None) -> dict[str, Any]:
+        """Close the stream and return a privacy-safe metrics snapshot."""
+        if not self._finalized:
+            if completed_at is None:
+                completed_at = self._last_received_at
+            if completed_at is not None:
+                completed_at = _timestamp(completed_at, "completed_at")
+                if completed_at < self._started_at:
+                    raise ValueError("completed_at precedes started_at")
+                if self._last_received_at is not None and completed_at < self._last_received_at:
+                    raise ValueError("completed_at precedes the last chunk")
+            tail = self._decoder.decode(b"", final=True)
+            terminal_at = completed_at
+            if terminal_at is None:
+                terminal_at = self._last_received_at
+            if terminal_at is None:
+                terminal_at = self._started_at
+            if tail:
+                self._consume_text(tail, terminal_at)
+            if self._pending_cr:
+                self._emit_line(terminal_at)
+                self._pending_cr = False
+            if self._line or self._data_lines:
+                self._malformed_events += 1
+            self._line = ""
+            self._line_observed_at = None
+            self._data_lines.clear()
+            self._event_data_at = None
+            self._decoder = None
+            self._completed_at = completed_at
+            self._finalized = True
+        return self.snapshot()
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return current derived state without retaining or exposing SSE content."""
+        ttfb = self._elapsed(self._first_byte_at, self._started_at)
+        ttft = self._elapsed(self._first_semantic_at, self._started_at)
+        generation_duration = self._elapsed(self._completed_at, self._first_semantic_at)
+        output_tokens = (self._usage or {}).get("output_tokens")
+        generation = None
+        if output_tokens is not None and generation_duration is not None:
+            generation = {
+                "output_tokens": output_tokens,
+                "duration_s": generation_duration,
+                "tokens_per_second": (
+                    output_tokens / generation_duration if generation_duration > 0 else None
+                ),
+            }
+
+        provider = self._resolved_provider()
+        coverage = {
+            "ttfb": ttfb is not None,
+            "semantic_ttft": ttft is not None,
+            "usage": self._usage is not None,
+            "generation": generation is not None,
+            "requested_model": self._requested_model is not None,
+            "served_model": self._served_model is not None,
+            "openrouter_metadata": self._metadata_seen,
+            "provider": provider is not None,
+            "attempts": bool(self._attempts),
+            "stream_done": self._done_seen,
+        }
+        covered = sum(coverage.values())
+        return {
+            "timing": {
+                "ttfb_s": ttfb,
+                "semantic_ttft_s": ttft,
+                "total_s": self._elapsed(self._completed_at, self._started_at),
+            },
+            "usage": dict(self._usage) if self._usage is not None else None,
+            "generation": generation,
+            "route": {
+                "requested_model": self._requested_model,
+                "metadata_requested_model": self._metadata_requested,
+                "served_model": self._served_model,
+                "provider": provider,
+                "attempts": [dict(attempt) for attempt in self._attempts],
+            },
+            "coverage": {
+                **coverage,
+                "covered": covered,
+                "total": len(coverage),
+                "ratio": covered / len(coverage),
+            },
+            "route_evidence": self._route_evidence(provider),
+            "stream": {
+                "events": self._events,
+                "ignored_events": self._ignored_events,
+                "malformed_events": self._malformed_events,
+                "done": self._done_seen,
+                "finalized": self._finalized,
+            },
+        }
+
+    @staticmethod
+    def _elapsed(end: float | None, start: float | None) -> float | None:
+        if end is None or start is None:
+            return None
+        return max(0.0, end - start)
+
+    def _consume_text(self, text: str, timestamp: float) -> None:
+        for char in text:
+            if self._pending_cr:
+                self._emit_line(timestamp)
+                self._pending_cr = False
+                if char == "\n":
+                    continue
+            if char == "\r":
+                self._pending_cr = True
+            elif char == "\n":
+                self._emit_line(timestamp)
+            else:
+                self._line += char
+                self._line_observed_at = timestamp
+
+    def _emit_line(self, timestamp: float) -> None:
+        line, self._line = self._line, ""
+        line_observed_at, self._line_observed_at = self._line_observed_at, None
+        if not line:
+            self._dispatch(timestamp)
+            return
+        if line.startswith(":"):
+            return
+        field, separator, value = line.partition(":")
+        if separator and value.startswith(" "):
+            value = value[1:]
+        if field == "data":
+            self._data_lines.append(value)
+            self._event_data_at = line_observed_at if line_observed_at is not None else timestamp
+
+    def _dispatch(self, timestamp: float) -> None:
+        if not self._data_lines:
+            return
+        data = "\n".join(self._data_lines)
+        event_data_at = self._event_data_at if self._event_data_at is not None else timestamp
+        self._data_lines.clear()
+        self._event_data_at = None
+        if not data.strip():
+            self._ignored_events += 1
+            return
+        if data.strip() == "[DONE]":
+            self._done_seen = True
+            self._events += 1
+            return
+        try:
+            obj = json.loads(data)
+        except (json.JSONDecodeError, UnicodeError):
+            self._malformed_events += 1
+            return
+        if not isinstance(obj, dict):
+            self._ignored_events += 1
+            return
+        if self._observe(obj, event_data_at):
+            self._events += 1
+        else:
+            self._ignored_events += 1
+
+    def _observe(self, obj: dict[str, Any], timestamp: float) -> bool:
+        model = _identifier(obj.get("model"))
+        if model is not None:
+            self._served_model = model
+        provider = _identifier(obj.get("provider"))
+        if provider is not None:
+            self._top_level_provider = provider
+
+        metadata = obj.get("openrouter_metadata")
+        if isinstance(metadata, dict):
+            self._metadata_seen = True
+            requested = _identifier(metadata.get("requested"))
+            if requested is not None:
+                self._metadata_requested = requested
+            attempts = _clean_attempts(metadata.get("attempts"))
+            if attempts:
+                self._attempts = attempts
+            endpoints = metadata.get("endpoints")
+            available = endpoints.get("available") if isinstance(endpoints, dict) else None
+            if isinstance(available, list):
+                for endpoint in available:
+                    if isinstance(endpoint, dict) and endpoint.get("selected") is True:
+                        self._metadata_provider = _identifier(endpoint.get("provider"))
+                        break
+
+        usage = obj.get("usage")
+        if isinstance(usage, dict):
+            prompt = _token_count(usage.get("prompt_tokens"))
+            completion = _token_count(usage.get("completion_tokens"))
+            if prompt is None:
+                prompt = _token_count(usage.get("input_tokens"))
+            if completion is None:
+                completion = _token_count(usage.get("output_tokens"))
+            total = _token_count(usage.get("total_tokens"))
+            clean = {}
+            if prompt is not None:
+                clean["input_tokens"] = prompt
+            if completion is not None:
+                clean["output_tokens"] = completion
+            if total is not None:
+                clean["total_tokens"] = total
+            if clean:
+                self._usage = clean
+
+        semantic = _has_semantic_delta(obj)
+        if self._first_semantic_at is None and semantic:
+            self._first_semantic_at = timestamp
+        return (
+            semantic
+            or isinstance(metadata, dict)
+            or (self._usage is not None and isinstance(usage, dict))
+        )
+
+    def _resolved_provider(self) -> str | None:
+        success = _successful_attempt(self._attempts)
+        attempt_provider = _identifier(success.get("provider")) if success else None
+        return self._top_level_provider or self._metadata_provider or attempt_provider
+
+    def _route_evidence(self, provider: str | None) -> dict[str, Any]:
+        reasons = []
+        success = _successful_attempt(self._attempts)
+        required = (
+            (self._requested_model, "missing_requested_model"),
+            (self._metadata_requested, "missing_metadata_requested_model"),
+            (self._served_model, "missing_served_model"),
+            (self._metadata_seen, "missing_openrouter_metadata"),
+            (provider, "missing_provider"),
+            (self._attempts, "missing_attempts"),
+            (success, "missing_successful_attempt"),
+            (self._done_seen, "stream_not_done"),
+            (self._malformed_events == 0, "malformed_events"),
+        )
+        reasons.extend(reason for value, reason in required if not value)
+        if self._metadata_requested and self._requested_model != self._metadata_requested:
+            reasons.append("requested_model_conflict")
+        if success:
+            attempt_provider = _identifier(success.get("provider"))
+            attempt_model = _identifier(success.get("model"))
+            if not attempt_provider:
+                reasons.append("missing_successful_attempt_provider")
+            if not attempt_model:
+                reasons.append("missing_successful_attempt_model")
+            if provider and attempt_provider and provider.casefold() != attempt_provider.casefold():
+                reasons.append("provider_conflict")
+            if self._served_model and attempt_model and self._served_model != attempt_model:
+                reasons.append("served_model_conflict")
+        return {
+            "pass": not reasons,
+            "verdict": "pass" if not reasons else "fail",
+            "reasons": reasons,
+        }
+
+
+# Short alias for callers that already know the protocol context.
+ChatSSEMetricsParser = OpenAIChatSSEParser
+
+
+def parse_chat_sse(
+    chunks: Iterable[tuple[float, bytes | str]],
+    *,
+    requested_model: str | None,
+    started_at: float,
+    completed_at: float | None = None,
+) -> dict[str, Any]:
+    """Replay timestamped chunks through :class:`OpenAIChatSSEParser`."""
+    parser = OpenAIChatSSEParser(requested_model=requested_model, started_at=started_at)
+    for received_at, chunk in chunks:
+        parser.feed(chunk, received_at)
+    return parser.finalize(completed_at)

--- a/obench/router_metrics.py
+++ b/obench/router_metrics.py
@@ -106,9 +106,32 @@ def _successful_attempt(attempts: list[dict[str, Any]]) -> dict[str, Any] | None
 class OpenAIChatSSEParser:
     """Incrementally derive metrics from an OpenAI Chat Completions SSE body."""
 
-    def __init__(self, *, requested_model: str | None, started_at: float):
+    def __init__(
+        self,
+        *,
+        requested_model: str | None,
+        started_at: float,
+        route_kind: str = "gateway",
+        requested_provider: str | None = None,
+        allowed_models: Iterable[str] = (),
+        allowed_providers: Iterable[str] = (),
+        fallback_enabled: bool = False,
+    ):
         self._started_at = _timestamp(started_at, "started_at")
         self._requested_model = _identifier(requested_model)
+        if route_kind not in {"direct", "gateway"}:
+            raise ValueError("route_kind must be direct or gateway")
+        self._route_kind = route_kind
+        self._requested_provider = _identifier(requested_provider)
+        self._allowed_models = tuple(
+            model for value in allowed_models if (model := _identifier(value)) is not None
+        )
+        self._allowed_providers = tuple(
+            provider
+            for value in allowed_providers
+            if (provider := _identifier(value)) is not None
+        )
+        self._fallback_enabled = bool(fallback_enabled)
         self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
         self._chunk_type: type | None = None
         self._line = ""
@@ -126,6 +149,7 @@ class OpenAIChatSSEParser:
         self._metadata_seen = False
         self._metadata_provider: str | None = None
         self._attempts: list[dict[str, Any]] = []
+        self._attempts_present = False
         self._usage: dict[str, int] | None = None
         self._events = 0
         self._ignored_events = 0
@@ -326,9 +350,10 @@ class OpenAIChatSSEParser:
             requested = _identifier(metadata.get("requested"))
             if requested is not None:
                 self._metadata_requested = requested
-            attempts = _clean_attempts(metadata.get("attempts"))
-            if attempts:
-                self._attempts = attempts
+            raw_attempts = metadata.get("attempts")
+            if isinstance(raw_attempts, list) and raw_attempts:
+                self._attempts_present = True
+                self._attempts = _clean_attempts(raw_attempts)
             endpoints = metadata.get("endpoints")
             available = endpoints.get("available") if isinstance(endpoints, dict) else None
             if isinstance(available, list):
@@ -366,42 +391,71 @@ class OpenAIChatSSEParser:
         )
 
     def _resolved_provider(self) -> str | None:
-        success = _successful_attempt(self._attempts)
-        attempt_provider = _identifier(success.get("provider")) if success else None
-        return self._top_level_provider or self._metadata_provider or attempt_provider
+        return self._top_level_provider or self._metadata_provider
 
     def _route_evidence(self, provider: str | None) -> dict[str, Any]:
         reasons = []
-        success = _successful_attempt(self._attempts)
         required = (
             (self._requested_model, "missing_requested_model"),
-            (self._metadata_requested, "missing_metadata_requested_model"),
             (self._served_model, "missing_served_model"),
-            (self._metadata_seen, "missing_openrouter_metadata"),
-            (provider, "missing_provider"),
-            (self._attempts, "missing_attempts"),
-            (success, "missing_successful_attempt"),
             (self._done_seen, "stream_not_done"),
             (self._malformed_events == 0, "malformed_events"),
         )
         reasons.extend(reason for value, reason in required if not value)
-        if self._metadata_requested and self._requested_model != self._metadata_requested:
-            reasons.append("requested_model_conflict")
-        if success:
-            attempt_provider = _identifier(success.get("provider"))
-            attempt_model = _identifier(success.get("model"))
-            if not attempt_provider:
-                reasons.append("missing_successful_attempt_provider")
-            if not attempt_model:
-                reasons.append("missing_successful_attempt_model")
-            if provider and attempt_provider and provider.casefold() != attempt_provider.casefold():
+        if self._requested_model and self._served_model != self._requested_model:
+            reasons.append("served_model_conflict")
+
+        if self._route_kind == "gateway":
+            gateway_required = (
+                (self._metadata_seen, "missing_openrouter_metadata"),
+                (self._metadata_requested, "missing_metadata_requested_model"),
+                (provider, "missing_provider"),
+            )
+            reasons.extend(reason for value, reason in gateway_required if not value)
+            if self._metadata_requested and self._metadata_requested != self._requested_model:
+                reasons.append("requested_model_conflict")
+            if self._allowed_models and self._served_model not in self._allowed_models:
+                reasons.append("served_model_not_allowed")
+
+            expected_provider = self._requested_provider
+            provider_folded = provider.casefold() if provider else None
+            if expected_provider and provider_folded != expected_provider.casefold():
                 reasons.append("provider_conflict")
-            if self._served_model and attempt_model and self._served_model != attempt_model:
-                reasons.append("served_model_conflict")
+            allowed_provider_folds = {
+                allowed.casefold() for allowed in self._allowed_providers
+            }
+            if provider and allowed_provider_folds and provider_folded not in allowed_provider_folds:
+                reasons.append("provider_not_allowed")
+            if (
+                self._top_level_provider
+                and self._metadata_provider
+                and self._top_level_provider.casefold() != self._metadata_provider.casefold()
+            ):
+                reasons.append("provider_conflict")
+
+            if self._attempts_present:
+                if not self._attempts:
+                    reasons.append("malformed_attempts")
+                success = _successful_attempt(self._attempts)
+                if success is None:
+                    reasons.append("missing_successful_attempt")
+                for attempt in self._attempts:
+                    attempt_provider = _identifier(attempt.get("provider"))
+                    attempt_model = _identifier(attempt.get("model"))
+                    if not attempt_provider:
+                        reasons.append("missing_attempt_provider")
+                    elif provider_folded and attempt_provider.casefold() != provider_folded:
+                        reasons.append("fallback_attempt")
+                    if not attempt_model:
+                        reasons.append("missing_attempt_model")
+                    elif self._served_model and attempt_model != self._served_model:
+                        reasons.append("fallback_attempt")
+                if self._fallback_enabled:
+                    reasons.append("fallback_enabled")
         return {
             "pass": not reasons,
             "verdict": "pass" if not reasons else "fail",
-            "reasons": reasons,
+            "reasons": list(dict.fromkeys(reasons)),
         }
 
 
@@ -415,9 +469,22 @@ def parse_chat_sse(
     requested_model: str | None,
     started_at: float,
     completed_at: float | None = None,
+    route_kind: str = "gateway",
+    requested_provider: str | None = None,
+    allowed_models: Iterable[str] = (),
+    allowed_providers: Iterable[str] = (),
+    fallback_enabled: bool = False,
 ) -> dict[str, Any]:
     """Replay timestamped chunks through :class:`OpenAIChatSSEParser`."""
-    parser = OpenAIChatSSEParser(requested_model=requested_model, started_at=started_at)
+    parser = OpenAIChatSSEParser(
+        requested_model=requested_model,
+        started_at=started_at,
+        route_kind=route_kind,
+        requested_provider=requested_provider,
+        allowed_models=allowed_models,
+        allowed_providers=allowed_providers,
+        fallback_enabled=fallback_enabled,
+    )
     for received_at, chunk in chunks:
         parser.feed(chunk, received_at)
     return parser.finalize(completed_at)

--- a/obench/router_publish.py
+++ b/obench/router_publish.py
@@ -743,8 +743,36 @@ def publish_bundle(
         artifacts: dict[str, str] = {}
         ledger_provenance: dict[str, Any] = {}
         bindings: dict[str, dict[str, Any]] = {}
+        rows_by_cell = {
+            results.result_cell_id(row): row for row in resume.rows
+        }
         for cell_id in sorted(cell_ids):
-            requests, _source_seal = _validate_source_ledger(ledger_sources[cell_id])
+            source_path = ledger_sources[cell_id]
+            requests, source_seal = _validate_source_ledger(source_path)
+            source_row = rows_by_cell[cell_id]
+            identity = results.router_identity_from_row(source_row)
+            expected_seal = source_row.get("ledger_seal")
+            if not isinstance(expected_seal, Mapping):
+                raise RouterPublishError(f"result {cell_id} is missing ledger_seal")
+            for field in ("record_count", "last_sequence", "root_hash"):
+                if expected_seal.get(field) != source_seal.get(field):
+                    raise RouterPublishError(
+                        f"result {cell_id} ledger_seal.{field} does not match source ledger"
+                    )
+            if expected_seal.get("ledger_file") != source_path.name:
+                raise RouterPublishError(
+                    f"result {cell_id} ledger file does not match source ledger"
+                )
+            for request in requests:
+                arm = request.get("router_arm")
+                if (
+                    not isinstance(arm, Mapping)
+                    or arm.get("arm_id") != identity.arm_id
+                    or arm.get("arm_digest") != identity.arm_digest
+                ):
+                    raise RouterPublishError(
+                        f"result {cell_id} arm identity does not match source ledger"
+                    )
             raw, seal = _public_ledger(cell_id, requests)
             relative = f"ledgers/{cell_id}.jsonl"
             artifacts[relative] = _write_file(temporary, relative, raw)

--- a/obench/router_publish.py
+++ b/obench/router_publish.py
@@ -1,0 +1,919 @@
+"""Create and verify sanitized, tamper-evident Router Bench bundles.
+
+This module is deliberately a pure library.  Source artifacts are validated,
+projected through explicit public DTO allowlists, and written to a new bundle.
+The public ledger is re-chained after sanitization so verification never needs
+the private source ledger.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import shutil
+import tempfile
+from typing import Any
+
+from . import results
+from . import router_spec
+
+
+BUNDLE_SCHEMA_VERSION = 1
+PROVENANCE_FILE = "provenance.json"
+RESULTS_FILE = "results.jsonl"
+SNAPSHOT_FILES = {
+    "experiment": "experiment.json",
+    "policy": "policy.json",
+    "catalog": "catalog.json",
+    "price": "prices.json",
+}
+
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
+_HOME_PATH_RE = re.compile(r"(?:^|[\s\"'])/(?:Users|home)/[^/\s\"']+(?:/[^ \t\r\n\"']*)?")
+_ABSOLUTE_PATH_RE = re.compile(r"(?:^|[\s\"'=])/(?!/)[^ \t\r\n\"']+")
+_WINDOWS_PATH_RE = re.compile(r"(?i)\b[A-Z]:\\(?:[^\\\r\n]+\\)*[^\\\r\n]*")
+_SECRET_PATTERNS = (
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bgh[opusr]_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b", re.IGNORECASE),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    re.compile(r"\b\d{12}\b"),
+    re.compile(r"\b(?:\d[ -]*?){13,19}\b"),
+    re.compile(
+        r"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|password|secret)"
+        r"\s*[:=]\s*[\"']?[^,;\"'\s]{8,}"
+    ),
+)
+_FORBIDDEN_KEY_PARTS = (
+    "header", "query", "request_body", "response_body", "transcript",
+    "endpoint", "account_id", "credential", "environment_value",
+)
+_FORBIDDEN_EXACT_KEYS = {
+    "path", "absolute_path", "env", "environment", "authorization",
+    "api_key", "apikey", "password", "secret",
+}
+
+_SCALAR = object()
+
+_USAGE_SCHEMA = {
+    "input_tokens": _SCALAR,
+    "output_tokens": _SCALAR,
+    "total_tokens": _SCALAR,
+    "prompt_tokens": _SCALAR,
+    "completion_tokens": _SCALAR,
+    "cached_input_tokens": _SCALAR,
+    "cache_read_input_tokens": _SCALAR,
+    "cache_creation_input_tokens": _SCALAR,
+    "reasoning_output_tokens": _SCALAR,
+    "cost_usd": _SCALAR,
+}
+_TIMING_SCHEMA = {
+    "ttfb_s": _SCALAR,
+    "semantic_ttft_s": _SCALAR,
+    "total_s": _SCALAR,
+    "wall_time_s": _SCALAR,
+}
+_GENERATION_SCHEMA = {
+    "output_tokens": _SCALAR,
+    "duration_s": _SCALAR,
+    "tokens_per_second": _SCALAR,
+}
+_ATTEMPT_SCHEMA = {
+    "provider": _SCALAR,
+    "model": _SCALAR,
+    "status": _SCALAR,
+}
+_ROUTE_SCHEMA = {
+    "requested_model": _SCALAR,
+    "metadata_requested_model": _SCALAR,
+    "served_model": _SCALAR,
+    "provider": _SCALAR,
+    "attempts": [_ATTEMPT_SCHEMA],
+}
+_ROUTE_EVIDENCE_SCHEMA = {
+    "pass": _SCALAR,
+    "verdict": _SCALAR,
+    "reasons": [_SCALAR],
+}
+_COVERAGE_SCHEMA = {
+    "covered": _SCALAR,
+    "total": _SCALAR,
+    "usage": _SCALAR,
+    "semantic_ttft": _SCALAR,
+    "route": _SCALAR,
+    "attempts": _SCALAR,
+}
+_STREAM_SCHEMA = {
+    "done": _SCALAR,
+    "malformed_events": _SCALAR,
+    "ignored_events": _SCALAR,
+}
+_METRICS_SCHEMA = {
+    "timing": _TIMING_SCHEMA,
+    "usage": _USAGE_SCHEMA,
+    "generation": _GENERATION_SCHEMA,
+    "route": _ROUTE_SCHEMA,
+    "route_evidence": _ROUTE_EVIDENCE_SCHEMA,
+    "coverage": _COVERAGE_SCHEMA,
+    "stream": _STREAM_SCHEMA,
+}
+_RESULT_SCHEMA = {
+    "completed": _SCALAR,
+    "success": _SCALAR,
+    "score": _SCALAR,
+    "failure_class": _SCALAR,
+    "wall_time_s": _SCALAR,
+    "checker_exit_code": _SCALAR,
+    "checker_timed_out": _SCALAR,
+    "cost_usd": _SCALAR,
+    "timing": _TIMING_SCHEMA,
+    "usage": _USAGE_SCHEMA,
+    "generation": _GENERATION_SCHEMA,
+    "route": _ROUTE_SCHEMA,
+    "route_evidence": _ROUTE_EVIDENCE_SCHEMA,
+    "coverage": _COVERAGE_SCHEMA,
+    "stream": _STREAM_SCHEMA,
+    "router_metrics": _METRICS_SCHEMA,
+}
+_SAMPLING_SCHEMA = {
+    "model": _SCALAR,
+    "temperature": _SCALAR,
+    "top_p": _SCALAR,
+    "top_k": _SCALAR,
+    "max_tokens": _SCALAR,
+    "max_completion_tokens": _SCALAR,
+    "max_output_tokens": _SCALAR,
+    "reasoning_effort": _SCALAR,
+    "stream": _SCALAR,
+    "seed": _SCALAR,
+}
+_ROUTER_ARM_SCHEMA = {
+    "arm_id": _SCALAR,
+    "arm_digest": _SCALAR,
+    "route_kind": _SCALAR,
+}
+_LEDGER_REQUEST_SCHEMA = {
+    "ts": _SCALAR,
+    "status": _SCALAR,
+    "usage": _USAGE_SCHEMA,
+    "model": _SCALAR,
+    "sampling_observed": _SAMPLING_SCHEMA,
+    "sampling_source": _SCALAR,
+    "duration_ms": _SCALAR,
+    "router_arm": _ROUTER_ARM_SCHEMA,
+    "router_metrics": _METRICS_SCHEMA,
+    "session_hash": _SCALAR,
+    "previous_response_hash": _SCALAR,
+    "response_hash": _SCALAR,
+    "capture_truncated": _SCALAR,
+}
+_POLICY_SCHEMA = {
+    "schema_version": _SCALAR,
+    "id": _SCALAR,
+    "policy_id": _SCALAR,
+    "name": _SCALAR,
+    "version": _SCALAR,
+    "track": _SCALAR,
+    "route_kind": _SCALAR,
+    "allowed_models": [_SCALAR],
+    "allowed_providers": [_SCALAR],
+    "fallback_enabled": _SCALAR,
+    "retry_count": _SCALAR,
+    "cache_enabled": _SCALAR,
+    "require_parameters": _SCALAR,
+    "data_collection": _SCALAR,
+}
+_CATALOG_ENTRY_SCHEMA = {
+    "model": _SCALAR,
+    "model_id": _SCALAR,
+    "provider": _SCALAR,
+    "context_window": _SCALAR,
+    "max_output_tokens": _SCALAR,
+    "capabilities": [_SCALAR],
+    "available": _SCALAR,
+    "region": _SCALAR,
+}
+_CATALOG_SCHEMA = {
+    "schema_version": _SCALAR,
+    "id": _SCALAR,
+    "catalog_id": _SCALAR,
+    "name": _SCALAR,
+    "version": _SCALAR,
+    "generated_at": _SCALAR,
+    "models": [_CATALOG_ENTRY_SCHEMA],
+    "entries": [_CATALOG_ENTRY_SCHEMA],
+}
+_PRICE_ENTRY_SCHEMA = {
+    "model": _SCALAR,
+    "model_id": _SCALAR,
+    "provider": _SCALAR,
+    "input_per_million": _SCALAR,
+    "output_per_million": _SCALAR,
+    "cache_read_per_million": _SCALAR,
+    "cache_write_per_million": _SCALAR,
+    "input_cost_per_million": _SCALAR,
+    "output_cost_per_million": _SCALAR,
+    "currency": _SCALAR,
+    "unit": _SCALAR,
+    "effective_at": _SCALAR,
+}
+_PRICE_SCHEMA = {
+    "schema_version": _SCALAR,
+    "id": _SCALAR,
+    "price_id": _SCALAR,
+    "name": _SCALAR,
+    "version": _SCALAR,
+    "currency": _SCALAR,
+    "effective_at": _SCALAR,
+    "prices": [_PRICE_ENTRY_SCHEMA],
+    "entries": [_PRICE_ENTRY_SCHEMA],
+}
+_WINDOW_SCHEMA = {
+    "window_id": _SCALAR,
+    "start": _SCALAR,
+    "end": _SCALAR,
+}
+_BUDGET_SCHEMA = {
+    "timeout_s": _SCALAR,
+    "max_calls": _SCALAR,
+    "max_output_tokens": _SCALAR,
+    "usd_cap": _SCALAR,
+}
+_SAMPLING_PUBLIC_SCHEMA = {
+    "temperature": _SCALAR,
+    "top_p": _SCALAR,
+    "seed": _SCALAR,
+}
+_EXPERIMENT_ARM_SCHEMA = {
+    "arm_id": _SCALAR,
+    "arm_digest": _SCALAR,
+    "route_kind": _SCALAR,
+    "protocol": _SCALAR,
+    "baseline": _SCALAR,
+    "requested_model": _SCALAR,
+    "requested_provider": _SCALAR,
+    "allowed_models": [_SCALAR],
+    "allowed_providers": [_SCALAR],
+    "fallback_enabled": _SCALAR,
+    "retry_count": _SCALAR,
+    "cache_enabled": _SCALAR,
+    "sampling": _SAMPLING_PUBLIC_SCHEMA,
+    "direct_control_arm_id": _SCALAR,
+}
+_EXPERIMENT_PUBLIC_SCHEMA = {
+    "kind": _SCALAR,
+    "source_digest": _SCALAR,
+    "schema_version": _SCALAR,
+    "experiment_id": _SCALAR,
+    "track": _SCALAR,
+    "harness": _SCALAR,
+    "tasks": [_SCALAR],
+    "repetitions_per_window": _SCALAR,
+    "schedule_seed": _SCALAR,
+    "execution_lane": _SCALAR,
+    "private_router": _SCALAR,
+    "windows": [_WINDOW_SCHEMA],
+    "budget": _BUDGET_SCHEMA,
+    "arms": [_EXPERIMENT_ARM_SCHEMA],
+}
+
+
+class RouterPublishError(ValueError):
+    """A Router Bench bundle is unsafe, incomplete, or inconsistent."""
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    try:
+        return results.canonical_json_bytes(value)
+    except (TypeError, ValueError) as exc:
+        raise RouterPublishError(f"value is not canonical JSON: {exc}") from exc
+
+
+def _artifact_bytes(value: Any) -> bytes:
+    return _canonical_bytes(value) + b"\n"
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise RouterPublishError(f"duplicate JSON key {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_constant(value: str) -> None:
+    raise RouterPublishError(f"non-standard JSON constant {value!r}")
+
+
+def _decode_json(raw: bytes, source: str) -> Any:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise RouterPublishError(f"{source} is not valid UTF-8") from exc
+    try:
+        return json.loads(
+            text,
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_constant,
+        )
+    except (json.JSONDecodeError, RouterPublishError) as exc:
+        raise RouterPublishError(f"{source} is corrupt JSON: {exc}") from exc
+
+
+def _read_json(path: str | os.PathLike[str]) -> Any:
+    source = Path(path)
+    if source.is_symlink() or not source.is_file():
+        raise RouterPublishError(f"{source} must be a regular, non-symlink file")
+    return _decode_json(source.read_bytes(), str(source))
+
+
+def _json_scalar(value: Any, path: str) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and math.isfinite(value):
+        return value
+    raise RouterPublishError(f"{path} must be a finite JSON scalar")
+
+
+def _project(value: Any, schema: Any, path: str) -> Any:
+    if schema is _SCALAR:
+        return _json_scalar(value, path)
+    if isinstance(schema, list):
+        if not isinstance(value, list):
+            raise RouterPublishError(f"{path} must be an array")
+        return [_project(item, schema[0], f"{path}[{index}]")
+                for index, item in enumerate(value)]
+    if not isinstance(value, Mapping):
+        raise RouterPublishError(f"{path} must be an object")
+    return {
+        key: _project(value[key], child_schema, f"{path}.{key}")
+        for key, child_schema in schema.items()
+        if key in value
+    }
+
+
+def _require_projected(value: Any, schema: Any, path: str) -> None:
+    if _project(value, schema, path) != value:
+        raise RouterPublishError(f"{path} contains missing or extra public DTO fields")
+
+
+def _assert_safe(value: Any, artifact: str) -> None:
+    def walk(item: Any, path: str) -> None:
+        if isinstance(item, Mapping):
+            for key, child in item.items():
+                low = str(key).lower()
+                if low in _FORBIDDEN_EXACT_KEYS or any(part in low for part in _FORBIDDEN_KEY_PARTS):
+                    raise RouterPublishError(f"{artifact} contains forbidden field {path}.{key}")
+                walk(child, f"{path}.{key}")
+        elif isinstance(item, list):
+            for index, child in enumerate(item):
+                walk(child, f"{path}[{index}]")
+        elif isinstance(item, str):
+            if _EMAIL_RE.search(item):
+                raise RouterPublishError(f"{artifact} contains an email address at {path}")
+            if (
+                _HOME_PATH_RE.search(item)
+                or _ABSOLUTE_PATH_RE.search(item)
+                or _WINDOWS_PATH_RE.search(item)
+            ):
+                raise RouterPublishError(f"{artifact} contains a local absolute path at {path}")
+            if re.search(r"(?i)\bhttps?://", item):
+                raise RouterPublishError(f"{artifact} contains an endpoint URL at {path}")
+            if any(pattern.search(item) for pattern in _SECRET_PATTERNS):
+                raise RouterPublishError(f"{artifact} contains a credential pattern at {path}")
+
+    walk(value, "$")
+
+
+def _snapshot_source(value: Any, kind: str) -> tuple[Any, str]:
+    if kind == "experiment" and isinstance(value, router_spec.RouterExperiment):
+        experiment = value
+        return experiment.to_dict(), experiment.digest
+    if isinstance(value, (str, os.PathLike)):
+        path = Path(value)
+        if kind == "experiment" and path.suffix.lower() == ".toml":
+            try:
+                experiment = router_spec.load_experiment(path)
+            except (OSError, router_spec.RouterSpecError) as exc:
+                raise RouterPublishError(f"invalid experiment {path}: {exc}") from exc
+            return experiment.to_dict(), experiment.digest
+        decoded = _read_json(path)
+    else:
+        decoded = value
+    if not isinstance(decoded, Mapping):
+        raise RouterPublishError(f"{kind} snapshot must be a JSON object")
+    if kind == "experiment":
+        try:
+            experiment = router_spec.parse_experiment(decoded)
+        except router_spec.RouterSpecError as exc:
+            raise RouterPublishError(f"invalid experiment snapshot: {exc}") from exc
+        return experiment.to_dict(), experiment.digest
+    return dict(decoded), results.canonical_digest(decoded)
+
+
+def _experiment_dto(source: Mapping[str, Any], source_digest: str) -> dict[str, Any]:
+    arms = []
+    for arm in source["arms"]:
+        arms.append({
+            "arm_id": arm["arm_id"],
+            "arm_digest": router_spec.canonical_digest(arm),
+            "route_kind": arm["route_kind"],
+            "protocol": arm["protocol"],
+            "baseline": arm["baseline"],
+            "requested_model": arm["requested_model"],
+            "requested_provider": arm["requested_provider"],
+            "allowed_models": list(arm["allowed_models"]),
+            "allowed_providers": list(arm["allowed_providers"]),
+            "fallback_enabled": arm["fallback_enabled"],
+            "retry_count": arm["retry_count"],
+            "cache_enabled": arm["cache_enabled"],
+            "sampling": dict(arm["sampling"]),
+            "direct_control_arm_id": arm["direct_control_arm_id"],
+        })
+    return {
+        "kind": "experiment",
+        "source_digest": source_digest,
+        "schema_version": source["schema_version"],
+        "experiment_id": source["experiment_id"],
+        "track": source["track"],
+        "harness": source["harness"],
+        "tasks": list(source["tasks"]),
+        "repetitions_per_window": source["repetitions_per_window"],
+        "schedule_seed": source["schedule_seed"],
+        "execution_lane": source["execution_lane"],
+        "private_router": source["private_router"],
+        "windows": [dict(window) for window in source["windows"]],
+        "budget": dict(source["budget"]),
+        "arms": arms,
+    }
+
+
+def _snapshot_dto(kind: str, source: Mapping[str, Any], digest: str) -> dict[str, Any]:
+    schemas = {
+        "policy": _POLICY_SCHEMA,
+        "catalog": _CATALOG_SCHEMA,
+        "price": _PRICE_SCHEMA,
+    }
+    return {
+        "kind": kind,
+        "source_digest": digest,
+        "data": _project(source, schemas[kind], kind),
+    }
+
+
+def _load_jsonl(path: Path, label: str) -> list[dict[str, Any]]:
+    if path.is_symlink() or not path.is_file():
+        raise RouterPublishError(f"{label} must be a regular, non-symlink file")
+    raw = path.read_bytes()
+    if not raw or not raw.endswith(b"\n"):
+        raise RouterPublishError(f"{label} must be non-empty JSONL ending in a newline")
+    rows = []
+    for line_no, line in enumerate(raw.splitlines(), 1):
+        if not line.strip():
+            raise RouterPublishError(f"{label} has a blank line at {line_no}")
+        row = _decode_json(line, f"{label} line {line_no}")
+        if not isinstance(row, dict):
+            raise RouterPublishError(f"{label} line {line_no} is not an object")
+        rows.append(row)
+    return rows
+
+
+def _validate_source_ledger(path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    rows = _load_jsonl(path, f"ledger {path}")
+    seals = [index for index, row in enumerate(rows)
+             if row.get("record_type") == "ledger_seal"]
+    if seals != [len(rows) - 1]:
+        raise RouterPublishError(f"ledger {path} must have exactly one terminal seal")
+    requests = rows[:-1]
+    seal = rows[-1]
+    previous = hashlib.sha256(b"").hexdigest()
+    for sequence, row in enumerate(requests, 1):
+        if row.get("record_type") != "request" or row.get("sequence") != sequence:
+            raise RouterPublishError(f"ledger {path} has invalid request sequence {sequence}")
+        if row.get("previous_hash") != previous:
+            raise RouterPublishError(f"ledger {path} has a broken hash chain")
+        unhashed = {key: value for key, value in row.items() if key != "record_hash"}
+        expected = _sha256(_canonical_bytes(unhashed))
+        if row.get("record_hash") != expected:
+            raise RouterPublishError(f"ledger {path} has a tampered request record")
+        previous = expected
+    expected_seal = {
+        "record_type": "ledger_seal",
+        "state": "SEALED",
+        "record_count": len(requests),
+        "last_sequence": len(requests),
+        "root_hash": previous,
+    }
+    if seal != expected_seal:
+        raise RouterPublishError(f"ledger {path} has an invalid terminal seal")
+    return requests, seal
+
+
+def _public_ledger(
+    cell_id: str,
+    requests: list[dict[str, Any]],
+) -> tuple[bytes, dict[str, Any]]:
+    public_rows = []
+    previous = hashlib.sha256(b"").hexdigest()
+    for sequence, source in enumerate(requests, 1):
+        projected = _project(source, _LEDGER_REQUEST_SCHEMA, f"ledger[{sequence}]")
+        row = {
+            "record_type": "request",
+            "sequence": sequence,
+            "previous_hash": previous,
+            **projected,
+        }
+        row["record_hash"] = _sha256(_canonical_bytes(row))
+        previous = row["record_hash"]
+        public_rows.append(row)
+    seal_body = {
+        "record_type": "ledger_seal",
+        "state": "SEALED",
+        "cell_id": cell_id,
+        "record_count": len(requests),
+        "last_sequence": len(requests),
+        "root_hash": previous,
+    }
+    seal = dict(seal_body, seal_sha256=_sha256(_canonical_bytes(seal_body)))
+    public_rows.append(seal)
+    _assert_safe(public_rows, f"ledger for {cell_id}")
+    raw = b"".join(_artifact_bytes(row) for row in public_rows)
+    return raw, seal
+
+
+def _ledger_mapping(
+    ledgers: Mapping[str, str | os.PathLike[str]] | str | os.PathLike[str],
+) -> dict[str, Path]:
+    if isinstance(ledgers, Mapping):
+        mapping = {str(cell_id): Path(path) for cell_id, path in ledgers.items()}
+    else:
+        directory = Path(ledgers)
+        if directory.is_symlink() or not directory.is_dir():
+            raise RouterPublishError("ledgers must be a mapping or a non-symlink directory")
+        mapping = {path.stem: path for path in directory.iterdir()
+                   if path.is_file() and path.suffix == ".jsonl"}
+    if len(mapping) != len(set(mapping)):
+        raise RouterPublishError("duplicate ledger cell binding")
+    return mapping
+
+
+def _result_dto(
+    row: Mapping[str, Any],
+    ledger_binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    identity = results.router_identity_from_row(row)
+    dto = {
+        "schema_version": results.CURRENT_SCHEMA_VERSION,
+        "benchmark": results.ROUTER_BENCHMARK,
+        "identity": identity.as_dict(),
+        "run_id": results.make_router_run_id(identity),
+        "cell_id": results.make_router_cell_id(identity),
+        **_project(row, _RESULT_SCHEMA, "result"),
+        "ledger": dict(ledger_binding),
+    }
+    if row.get("run_id") != dto["run_id"] or row.get("cell_id") != dto["cell_id"]:
+        raise RouterPublishError(f"result {dto['cell_id']} has inconsistent IDs")
+    _assert_safe(dto, f"result {dto['cell_id']}")
+    return dto
+
+
+def _write_file(root: Path, relative: str, raw: bytes) -> str:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(raw)
+    return _sha256(raw)
+
+
+def publish_bundle(
+    results_path: str | os.PathLike[str],
+    bundle_dir: str | os.PathLike[str],
+    *,
+    experiment: Any,
+    policy: Any,
+    catalog: Any,
+    prices: Any,
+    ledgers: Mapping[str, str | os.PathLike[str]] | str | os.PathLike[str],
+) -> dict[str, Any]:
+    """Create a new sanitized bundle and return its provenance object.
+
+    ``ledgers`` is either ``{cell_id: sealed_ledger_path}`` or a directory
+    containing ``<cell_id>.jsonl`` files.  Existing destinations are refused.
+    """
+    destination = Path(bundle_dir)
+    if destination.exists() or destination.is_symlink():
+        raise RouterPublishError(f"bundle destination already exists: {destination}")
+
+    try:
+        resume = results.read_jsonl_for_resume(results_path)
+    except results.ResultsLogError as exc:
+        raise RouterPublishError(str(exc)) from exc
+    if not resume.rows:
+        raise RouterPublishError("results JSONL is empty")
+    for row in resume.rows:
+        if results.result_kind(row) != (
+            results.CURRENT_SCHEMA_VERSION,
+            results.ROUTER_BENCHMARK,
+        ):
+            raise RouterPublishError("bundle accepts only schema-v2 router results")
+
+    ledger_sources = _ledger_mapping(ledgers)
+    cell_ids = set(resume.cell_ids)
+    if set(ledger_sources) != cell_ids:
+        missing = sorted(cell_ids - set(ledger_sources))
+        extra = sorted(set(ledger_sources) - cell_ids)
+        raise RouterPublishError(
+            f"cell/ledger bindings mismatch; missing={missing!r} extra={extra!r}"
+        )
+
+    experiment_source, experiment_digest = _snapshot_source(experiment, "experiment")
+    policy_source, policy_digest = _snapshot_source(policy, "policy")
+    catalog_source, catalog_digest = _snapshot_source(catalog, "catalog")
+    price_source, price_digest = _snapshot_source(prices, "price")
+    snapshot_digests = {
+        "experiment": experiment_digest,
+        "policy": policy_digest,
+        "catalog": catalog_digest,
+        "price": price_digest,
+    }
+
+    identities = [results.router_identity_from_row(row) for row in resume.rows]
+    for identity in identities:
+        expected = {
+            "experiment": identity.experiment_digest,
+            "policy": identity.policy_digest,
+            "catalog": identity.catalog_digest,
+            "price": identity.price_digest,
+        }
+        if expected != snapshot_digests:
+            raise RouterPublishError(
+                f"result {results.make_router_cell_id(identity)} snapshot digests do not match"
+            )
+
+    parent = destination.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{destination.name}.", dir=parent))
+    try:
+        artifacts: dict[str, str] = {}
+        ledger_provenance: dict[str, Any] = {}
+        bindings: dict[str, dict[str, Any]] = {}
+        for cell_id in sorted(cell_ids):
+            requests, _source_seal = _validate_source_ledger(ledger_sources[cell_id])
+            raw, seal = _public_ledger(cell_id, requests)
+            relative = f"ledgers/{cell_id}.jsonl"
+            artifacts[relative] = _write_file(temporary, relative, raw)
+            binding = {
+                "artifact": relative,
+                "root_hash": seal["root_hash"],
+                "seal_sha256": seal["seal_sha256"],
+                "record_count": seal["record_count"],
+            }
+            bindings[cell_id] = binding
+            ledger_provenance[cell_id] = dict(binding)
+
+        public_rows = [
+            _result_dto(row, bindings[results.result_cell_id(row)])
+            for row in resume.rows
+        ]
+        results_raw = b"".join(_artifact_bytes(row) for row in public_rows)
+        artifacts[RESULTS_FILE] = _write_file(temporary, RESULTS_FILE, results_raw)
+
+        snapshot_values = {
+            "experiment": _experiment_dto(experiment_source, experiment_digest),
+            "policy": _snapshot_dto("policy", policy_source, policy_digest),
+            "catalog": _snapshot_dto("catalog", catalog_source, catalog_digest),
+            "price": _snapshot_dto("price", price_source, price_digest),
+        }
+        for kind, dto in snapshot_values.items():
+            _assert_safe(dto, f"{kind} snapshot")
+            relative = SNAPSHOT_FILES[kind]
+            artifacts[relative] = _write_file(temporary, relative, _artifact_bytes(dto))
+
+        provenance = {
+            "schema_version": BUNDLE_SCHEMA_VERSION,
+            "bundle_kind": "router_bench",
+            "result_schema_version": results.CURRENT_SCHEMA_VERSION,
+            "result_count": len(public_rows),
+            "snapshot_digests": snapshot_digests,
+            "artifacts": dict(sorted(artifacts.items())),
+            "ledgers": dict(sorted(ledger_provenance.items())),
+        }
+        _assert_safe(provenance, "provenance")
+        _write_file(temporary, PROVENANCE_FILE, _artifact_bytes(provenance))
+        temporary.rename(destination)
+        return provenance
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+
+
+def _require_digest(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not _DIGEST_RE.fullmatch(value):
+        raise RouterPublishError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _verify_public_ledger(
+    raw: bytes,
+    artifact: str,
+    expected_cell_id: str,
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="router_bundle_verify_") as tmp:
+        path = Path(tmp) / "ledger.jsonl"
+        path.write_bytes(raw)
+        rows = _load_jsonl(path, artifact)
+    if rows[-1].get("record_type") != "ledger_seal":
+        raise RouterPublishError(f"{artifact} has no terminal seal")
+    requests = rows[:-1]
+    previous = hashlib.sha256(b"").hexdigest()
+    for sequence, row in enumerate(requests, 1):
+        expected_keys = {
+            "record_type", "sequence", "previous_hash", "record_hash",
+            *_LEDGER_REQUEST_SCHEMA,
+        }
+        if set(row) - expected_keys:
+            raise RouterPublishError(f"{artifact} request {sequence} has extra fields")
+        public_fields = {
+            key: value for key, value in row.items()
+            if key not in {"record_type", "sequence", "previous_hash", "record_hash"}
+        }
+        _require_projected(public_fields, _LEDGER_REQUEST_SCHEMA, f"{artifact}[{sequence}]")
+        if row.get("record_type") != "request" or row.get("sequence") != sequence:
+            raise RouterPublishError(f"{artifact} has invalid sequence {sequence}")
+        if row.get("previous_hash") != previous:
+            raise RouterPublishError(f"{artifact} has a broken hash chain")
+        unhashed = {key: value for key, value in row.items() if key != "record_hash"}
+        expected_hash = _sha256(_canonical_bytes(unhashed))
+        if row.get("record_hash") != expected_hash:
+            raise RouterPublishError(f"{artifact} request {sequence} is tampered")
+        previous = expected_hash
+    seal = rows[-1]
+    expected_body = {
+        "record_type": "ledger_seal",
+        "state": "SEALED",
+        "cell_id": expected_cell_id,
+        "record_count": len(requests),
+        "last_sequence": len(requests),
+        "root_hash": previous,
+    }
+    expected_seal = dict(
+        expected_body,
+        seal_sha256=_sha256(_canonical_bytes(expected_body)),
+    )
+    if seal != expected_seal:
+        raise RouterPublishError(f"{artifact} has an invalid seal or cell binding")
+    _assert_safe(rows, artifact)
+    return seal
+
+
+def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
+    """Verify a complete bundle, returning provenance or raising on any failure."""
+    root = Path(bundle_dir)
+    if root.is_symlink() or not root.is_dir():
+        raise RouterPublishError(f"bundle is not a non-symlink directory: {root}")
+    provenance = _read_json(root / PROVENANCE_FILE)
+    if not isinstance(provenance, dict):
+        raise RouterPublishError("provenance must be an object")
+    expected_provenance_keys = {
+        "schema_version", "bundle_kind", "result_schema_version",
+        "result_count", "snapshot_digests", "artifacts", "ledgers",
+    }
+    if set(provenance) != expected_provenance_keys:
+        raise RouterPublishError("provenance has missing or extra fields")
+    if (
+        provenance["schema_version"] != BUNDLE_SCHEMA_VERSION
+        or provenance["bundle_kind"] != "router_bench"
+        or provenance["result_schema_version"] != results.CURRENT_SCHEMA_VERSION
+    ):
+        raise RouterPublishError("unsupported bundle schema")
+    artifacts = provenance["artifacts"]
+    if not isinstance(artifacts, dict) or not artifacts:
+        raise RouterPublishError("provenance artifacts must be a non-empty object")
+    required = {RESULTS_FILE, *SNAPSHOT_FILES.values()}
+    if not required.issubset(artifacts):
+        raise RouterPublishError("provenance is missing required artifacts")
+
+    actual_files = set()
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise RouterPublishError(f"bundle contains symlink: {path}")
+        if path.is_file():
+            actual_files.add(path.relative_to(root).as_posix())
+    expected_files = set(artifacts) | {PROVENANCE_FILE}
+    if actual_files != expected_files:
+        raise RouterPublishError(
+            f"bundle artifact set mismatch; missing={sorted(expected_files - actual_files)!r} "
+            f"extra={sorted(actual_files - expected_files)!r}"
+        )
+    for relative, expected_digest in artifacts.items():
+        _require_digest(expected_digest, f"artifacts[{relative!r}]")
+        if Path(relative).is_absolute() or ".." in Path(relative).parts:
+            raise RouterPublishError(f"unsafe artifact path: {relative!r}")
+        actual = _sha256((root / relative).read_bytes())
+        if actual != expected_digest:
+            raise RouterPublishError(f"artifact digest mismatch: {relative}")
+
+    snapshot_digests = provenance["snapshot_digests"]
+    if not isinstance(snapshot_digests, dict) or set(snapshot_digests) != set(SNAPSHOT_FILES):
+        raise RouterPublishError("invalid snapshot digest provenance")
+    for kind, relative in SNAPSHOT_FILES.items():
+        expected = _require_digest(snapshot_digests[kind], f"{kind} source digest")
+        snapshot = _read_json(root / relative)
+        if not isinstance(snapshot, dict) or snapshot.get("source_digest") != expected:
+            raise RouterPublishError(f"{kind} snapshot digest binding mismatch")
+        if kind == "experiment":
+            _require_projected(snapshot, _EXPERIMENT_PUBLIC_SCHEMA, kind)
+        else:
+            expected_keys = {"kind", "source_digest", "data"}
+            if set(snapshot) != expected_keys or snapshot.get("kind") != kind:
+                raise RouterPublishError(f"{kind} snapshot has an invalid public DTO")
+            schemas = {
+                "policy": _POLICY_SCHEMA,
+                "catalog": _CATALOG_SCHEMA,
+                "price": _PRICE_SCHEMA,
+            }
+            _require_projected(snapshot["data"], schemas[kind], f"{kind}.data")
+        _assert_safe(snapshot, f"{kind} snapshot")
+
+    result_rows = _load_jsonl(root / RESULTS_FILE, RESULTS_FILE)
+    if provenance["result_count"] != len(result_rows):
+        raise RouterPublishError("result count does not match provenance")
+    ledger_meta = provenance["ledgers"]
+    if not isinstance(ledger_meta, dict):
+        raise RouterPublishError("ledger provenance must be an object")
+    seen_cells = set()
+    for row in result_rows:
+        if set(row) - {
+            "schema_version", "benchmark", "identity", "run_id", "cell_id",
+            *_RESULT_SCHEMA, "ledger",
+        }:
+            raise RouterPublishError("public result has extra fields")
+        public_fields = {
+            key: value for key, value in row.items()
+            if key in _RESULT_SCHEMA
+        }
+        _require_projected(public_fields, _RESULT_SCHEMA, "result")
+        try:
+            cell_id = results.result_cell_id(row)
+        except results.ResultError as exc:
+            raise RouterPublishError(f"invalid public result identity: {exc}") from exc
+        if cell_id in seen_cells:
+            raise RouterPublishError(f"duplicate public result cell: {cell_id}")
+        seen_cells.add(cell_id)
+        identity = results.router_identity_from_row(row)
+        expected_snapshots = {
+            "experiment": identity.experiment_digest,
+            "policy": identity.policy_digest,
+            "catalog": identity.catalog_digest,
+            "price": identity.price_digest,
+        }
+        if expected_snapshots != snapshot_digests:
+            raise RouterPublishError(f"result {cell_id} snapshot binding mismatch")
+        binding = row.get("ledger")
+        meta = ledger_meta.get(cell_id)
+        if not isinstance(binding, dict) or binding != meta:
+            raise RouterPublishError(f"result {cell_id} ledger binding mismatch")
+        _assert_safe(row, f"result {cell_id}")
+    if seen_cells != set(ledger_meta):
+        raise RouterPublishError("result and ledger cell sets do not match")
+
+    for cell_id, binding in ledger_meta.items():
+        if not isinstance(binding, dict) or set(binding) != {
+            "artifact", "root_hash", "seal_sha256", "record_count",
+        }:
+            raise RouterPublishError(f"invalid ledger provenance for {cell_id}")
+        artifact = binding["artifact"]
+        if not isinstance(artifact, str) or artifact not in artifacts:
+            raise RouterPublishError(f"missing ledger artifact for {cell_id}")
+        seal = _verify_public_ledger(
+            (root / artifact).read_bytes(),
+            artifact,
+            cell_id,
+        )
+        expected_binding = {
+            "artifact": artifact,
+            "root_hash": seal["root_hash"],
+            "seal_sha256": seal["seal_sha256"],
+            "record_count": seal["record_count"],
+        }
+        if binding != expected_binding:
+            raise RouterPublishError(f"ledger root/seal mismatch for {cell_id}")
+
+    _assert_safe(provenance, "provenance")
+    return provenance
+
+
+PublishError = RouterPublishError

--- a/obench/router_publish.py
+++ b/obench/router_publish.py
@@ -175,6 +175,11 @@ _RESULT_SCHEMA = {
     "result": _CANONICAL_RESULT_SCHEMA,
     "route_integrity": _ROUTE_EVIDENCE_SCHEMA,
     "proxy_metrics": {"calls": [_PROXY_CALL_SCHEMA]},
+    "route_isolation": {
+        "classification": _SCALAR,
+        "lane": _SCALAR,
+        "egress_enforced": _SCALAR,
+    },
 }
 _SAMPLING_SCHEMA = {
     "model": _SCALAR,
@@ -291,6 +296,7 @@ _EXPERIMENT_ARM_SCHEMA = {
     "route_kind": _SCALAR,
     "protocol": _SCALAR,
     "baseline": _SCALAR,
+    "canonical_model": _SCALAR,
     "requested_model": _SCALAR,
     "requested_provider": _SCALAR,
     "allowed_models": [_SCALAR],
@@ -409,7 +415,10 @@ def _require_projected(value: Any, schema: Any, path: str) -> None:
 
 def _require_public_result_shape(value: Mapping[str, Any], path: str) -> None:
     _require_projected(value, _RESULT_SCHEMA, path)
-    required = {"arm_role", "baseline", "result", "route_integrity", "proxy_metrics"}
+    required = {
+        "arm_role", "baseline", "result", "route_integrity", "proxy_metrics",
+        "route_isolation",
+    }
     missing = sorted(required - set(value))
     if missing:
         raise RouterPublishError(f"{path} is missing required fields: {missing!r}")

--- a/obench/router_publish.py
+++ b/obench/router_publish.py
@@ -64,6 +64,12 @@ _FORBIDDEN_EXACT_KEYS = {
 
 _SCALAR = object()
 
+
+class _NullableSchema:
+    def __init__(self, schema: Any):
+        self.schema = schema
+
+
 _USAGE_SCHEMA = {
     "input_tokens": _SCALAR,
     "output_tokens": _SCALAR,
@@ -118,31 +124,57 @@ _STREAM_SCHEMA = {
     "ignored_events": _SCALAR,
 }
 _METRICS_SCHEMA = {
-    "timing": _TIMING_SCHEMA,
-    "usage": _USAGE_SCHEMA,
-    "generation": _GENERATION_SCHEMA,
-    "route": _ROUTE_SCHEMA,
-    "route_evidence": _ROUTE_EVIDENCE_SCHEMA,
-    "coverage": _COVERAGE_SCHEMA,
-    "stream": _STREAM_SCHEMA,
+    "timing": _NullableSchema(_TIMING_SCHEMA),
+    "usage": _NullableSchema(_USAGE_SCHEMA),
+    "generation": _NullableSchema(_GENERATION_SCHEMA),
+    "route": _NullableSchema(_ROUTE_SCHEMA),
+    "route_evidence": _NullableSchema(_ROUTE_EVIDENCE_SCHEMA),
+    "coverage": _NullableSchema(_COVERAGE_SCHEMA),
+    "stream": _NullableSchema(_STREAM_SCHEMA),
+}
+_COST_ITEM_SCHEMA = {
+    "amount_usd": _SCALAR,
+    "currency": _SCALAR,
+    "effective_at": _SCALAR,
+}
+_COSTS_SCHEMA = {
+    "router_reported": _COST_ITEM_SCHEMA,
+    "invoice_reconciled": _COST_ITEM_SCHEMA,
+    "frozen_list_estimate": _COST_ITEM_SCHEMA,
+}
+_REPORT_TIMING_SCHEMA = {
+    "ttfb_s": _SCALAR,
+    "semantic_ttft_s": _SCALAR,
+}
+_REPORT_GENERATION_SCHEMA = {
+    "output_tokens": _SCALAR,
+    "duration_s": _SCALAR,
+}
+_REPORT_ROUTE_SCHEMA = {
+    "served_model": _SCALAR,
+    "provider": _SCALAR,
+}
+_PROXY_CALL_SCHEMA = {
+    "timing": _NullableSchema(_REPORT_TIMING_SCHEMA),
+    "generation": _NullableSchema(_REPORT_GENERATION_SCHEMA),
+    "route": _NullableSchema(_REPORT_ROUTE_SCHEMA),
+    "costs": _NullableSchema(_COSTS_SCHEMA),
+}
+_CANONICAL_RESULT_SCHEMA = {
+    "solved": _SCALAR,
+    "checker_score": _SCALAR,
+    "available": _SCALAR,
+    "duration_s": _SCALAR,
+    "timed_out": _SCALAR,
+    "infrastructure_invalid_reason": _SCALAR,
+    "infrastructure_valid": _SCALAR,
 }
 _RESULT_SCHEMA = {
-    "completed": _SCALAR,
-    "success": _SCALAR,
-    "score": _SCALAR,
-    "failure_class": _SCALAR,
-    "wall_time_s": _SCALAR,
-    "checker_exit_code": _SCALAR,
-    "checker_timed_out": _SCALAR,
-    "cost_usd": _SCALAR,
-    "timing": _TIMING_SCHEMA,
-    "usage": _USAGE_SCHEMA,
-    "generation": _GENERATION_SCHEMA,
-    "route": _ROUTE_SCHEMA,
-    "route_evidence": _ROUTE_EVIDENCE_SCHEMA,
-    "coverage": _COVERAGE_SCHEMA,
-    "stream": _STREAM_SCHEMA,
-    "router_metrics": _METRICS_SCHEMA,
+    "arm_role": _SCALAR,
+    "baseline": _SCALAR,
+    "result": _CANONICAL_RESULT_SCHEMA,
+    "route_integrity": _ROUTE_EVIDENCE_SCHEMA,
+    "proxy_metrics": {"calls": [_PROXY_CALL_SCHEMA]},
 }
 _SAMPLING_SCHEMA = {
     "model": _SCALAR,
@@ -164,13 +196,13 @@ _ROUTER_ARM_SCHEMA = {
 _LEDGER_REQUEST_SCHEMA = {
     "ts": _SCALAR,
     "status": _SCALAR,
-    "usage": _USAGE_SCHEMA,
+    "usage": _NullableSchema(_USAGE_SCHEMA),
     "model": _SCALAR,
     "sampling_observed": _SAMPLING_SCHEMA,
     "sampling_source": _SCALAR,
     "duration_ms": _SCALAR,
     "router_arm": _ROUTER_ARM_SCHEMA,
-    "router_metrics": _METRICS_SCHEMA,
+    "router_metrics": _NullableSchema(_METRICS_SCHEMA),
     "session_hash": _SCALAR,
     "previous_response_hash": _SCALAR,
     "response_hash": _SCALAR,
@@ -352,6 +384,10 @@ def _json_scalar(value: Any, path: str) -> Any:
 def _project(value: Any, schema: Any, path: str) -> Any:
     if schema is _SCALAR:
         return _json_scalar(value, path)
+    if isinstance(schema, _NullableSchema):
+        if value is None:
+            return None
+        return _project(value, schema.schema, path)
     if isinstance(schema, list):
         if not isinstance(value, list):
             raise RouterPublishError(f"{path} must be an array")
@@ -369,6 +405,27 @@ def _project(value: Any, schema: Any, path: str) -> Any:
 def _require_projected(value: Any, schema: Any, path: str) -> None:
     if _project(value, schema, path) != value:
         raise RouterPublishError(f"{path} contains missing or extra public DTO fields")
+
+
+def _require_public_result_shape(value: Mapping[str, Any], path: str) -> None:
+    _require_projected(value, _RESULT_SCHEMA, path)
+    required = {"arm_role", "baseline", "result", "route_integrity", "proxy_metrics"}
+    missing = sorted(required - set(value))
+    if missing:
+        raise RouterPublishError(f"{path} is missing required fields: {missing!r}")
+
+    required_result = {"solved", "checker_score", "available"}
+    missing = sorted(required_result - set(value["result"]))
+    if missing:
+        raise RouterPublishError(
+            f"{path}.result is missing required fields: {missing!r}"
+        )
+    if set(value["route_integrity"]) != {"pass", "reasons"}:
+        raise RouterPublishError(
+            f"{path}.route_integrity must contain pass and reasons"
+        )
+    if set(value["proxy_metrics"]) != {"calls"}:
+        raise RouterPublishError(f"{path}.proxy_metrics must contain calls")
 
 
 def _assert_safe(value: Any, artifact: str) -> None:
@@ -576,17 +633,24 @@ def _result_dto(
     ledger_binding: Mapping[str, Any],
 ) -> dict[str, Any]:
     identity = results.router_identity_from_row(row)
+    public_result = _project(row, _RESULT_SCHEMA, "result")
+    for call in public_result.get("proxy_metrics", {}).get("calls", []):
+        for field in ("timing", "route"):
+            if call.get(field) is None:
+                call.pop(field)
     dto = {
         "schema_version": results.CURRENT_SCHEMA_VERSION,
         "benchmark": results.ROUTER_BENCHMARK,
         "identity": identity.as_dict(),
         "run_id": results.make_router_run_id(identity),
         "cell_id": results.make_router_cell_id(identity),
-        **_project(row, _RESULT_SCHEMA, "result"),
+        **public_result,
         "ledger": dict(ledger_binding),
     }
     if row.get("run_id") != dto["run_id"] or row.get("cell_id") != dto["cell_id"]:
         raise RouterPublishError(f"result {dto['cell_id']} has inconsistent IDs")
+    public_fields = {key: dto[key] for key in _RESULT_SCHEMA if key in dto}
+    _require_public_result_shape(public_fields, f"result {dto['cell_id']}")
     _assert_safe(dto, f"result {dto['cell_id']}")
     return dto
 
@@ -865,7 +929,7 @@ def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
             key: value for key, value in row.items()
             if key in _RESULT_SCHEMA
         }
-        _require_projected(public_fields, _RESULT_SCHEMA, "result")
+        _require_public_result_shape(public_fields, "result")
         try:
             cell_id = results.result_cell_id(row)
         except results.ResultError as exc:

--- a/obench/router_report.py
+++ b/obench/router_report.py
@@ -1,0 +1,967 @@
+"""Matched, task-weighted reporting for schema-v2 Gateway Tax rows.
+
+The report consumes canonical router identities from :mod:`obench.results` plus
+these result fields:
+
+* ``arm_role`` (``"direct"`` or ``"gateway"``) and boolean ``baseline``;
+* ``result`` with ``solved``, ``checker_score``, ``available``, optional
+  ``duration_s``, and optional ``infrastructure_invalid_reason``;
+* ``route_integrity`` with boolean ``pass`` and a list of reason strings;
+* ``proxy_metrics.calls``, where each call may contain ``timing`` (``ttfb_s``
+  and ``semantic_ttft_s``), ``generation`` (paired ``output_tokens`` and
+  ``duration_s``), ``route`` (``provider`` and ``served_model``), and ``costs``.
+
+``costs`` maps a basis name to an object containing ``amount_usd``, ``currency``
+and ``effective_at``. Missing conditional timing or cost evidence affects only
+that metric's coverage. Invalid infrastructure, route-integrity, and incomplete
+all-arm blocks are excluded as whole matched blocks and counted by reason.
+Router/provider outcomes remain ordinary attempted cells.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+import json
+import math
+import random
+from typing import Any
+
+from obench import results
+
+
+DEFAULT_BOOTSTRAP_REPLICATES = 10_000
+DEFAULT_BOOTSTRAP_SEED = 20_260_722
+_COST_BASES = (
+    "router_reported",
+    "invoice_reconciled",
+    "frozen_list_estimate",
+)
+_ROLES = frozenset({"direct", "gateway"})
+
+
+class RouterReportError(ValueError):
+    """Raised when router rows cannot support an unambiguous report."""
+
+
+def _number(value: Any, name: str, *, minimum: float = 0.0) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < minimum
+    ):
+        raise RouterReportError(f"{name} must be a finite number >= {minimum}")
+    return float(value)
+
+
+def _optional_number(value: Any, name: str, *, minimum: float = 0.0) -> float | None:
+    if value is None:
+        return None
+    return _number(value, name, minimum=minimum)
+
+
+def _object(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RouterReportError(f"{name} must be an object")
+    return value
+
+
+def _string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RouterReportError(f"{name} must be a non-empty string")
+    return value
+
+
+def _bool(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise RouterReportError(f"{name} must be a boolean")
+    return value
+
+
+def _mean(values: Sequence[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _percentile(sorted_values: Sequence[float], probability: float) -> float:
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    position = probability * (len(sorted_values) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    fraction = position - lower
+    return sorted_values[lower] * (1.0 - fraction) + sorted_values[upper] * fraction
+
+
+def _interval(
+    task_values: Mapping[str, float],
+    *,
+    replicates: int,
+    seed: int,
+) -> dict[str, float] | None:
+    if not task_values:
+        return None
+    ordered = [task_values[task] for task in sorted(task_values)]
+    rng = random.Random(seed)
+    samples = []
+    for _ in range(replicates):
+        samples.append(sum(rng.choice(ordered) for _ in ordered) / len(ordered))
+    samples.sort()
+    return {
+        "confidence": 0.95,
+        "low": _percentile(samples, 0.025),
+        "high": _percentile(samples, 0.975),
+    }
+
+
+def _ratio_interval(
+    numerators: Mapping[str, float],
+    denominators: Mapping[str, float],
+    *,
+    replicates: int,
+    seed: int,
+) -> dict[str, float] | None:
+    tasks = sorted(set(numerators) & set(denominators))
+    if not tasks:
+        return None
+    rng = random.Random(seed)
+    samples = []
+    for _ in range(replicates):
+        selected = [rng.choice(tasks) for _ in tasks]
+        denominator = sum(denominators[task] for task in selected)
+        if denominator > 0:
+            samples.append(sum(numerators[task] for task in selected) / denominator)
+    if not samples:
+        return None
+    samples.sort()
+    return {
+        "confidence": 0.95,
+        "low": _percentile(samples, 0.025),
+        "high": _percentile(samples, 0.975),
+    }
+
+
+def _metric(
+    task_values: Mapping[str, float],
+    *,
+    eligible_tasks: int,
+    cells_covered: int,
+    cells_total: int,
+    replicates: int,
+    seed: int,
+) -> dict[str, Any]:
+    values = list(task_values.values())
+    return {
+        "estimate": _mean(values),
+        "interval": _interval(task_values, replicates=replicates, seed=seed),
+        "task_coverage": {
+            "covered": len(task_values),
+            "total": eligible_tasks,
+            "ratio": len(task_values) / eligible_tasks if eligible_tasks else 0.0,
+        },
+        "cell_coverage": {
+            "covered": cells_covered,
+            "total": cells_total,
+            "ratio": cells_covered / cells_total if cells_total else 0.0,
+        },
+    }
+
+
+def _arm_metadata(row: Mapping[str, Any], row_number: int) -> tuple[str, bool]:
+    role = row.get("arm_role")
+    baseline = row.get("baseline")
+    if role is None and isinstance(row.get("arm"), Mapping):
+        role = row["arm"].get("role")
+        baseline = row["arm"].get("baseline", baseline)
+    if baseline is None:
+        baseline = row.get("is_baseline")
+    role = _string(role, f"row {row_number} arm_role")
+    if role not in _ROLES:
+        raise RouterReportError(
+            f"row {row_number} arm_role must be one of {sorted(_ROLES)}"
+        )
+    return role, _bool(baseline, f"row {row_number} baseline")
+
+
+def _stratum(identity: results.CellIdentity) -> tuple[Any, ...]:
+    return (
+        identity.policy_digest,
+        identity.catalog_digest,
+        identity.price_digest,
+        identity.sampling_digest,
+        identity.schedule_digest,
+        identity.harness,
+        identity.candidate,
+        identity.harness_version,
+        identity.execution_lane,
+        identity.image_digest,
+        identity.budget_timeout_s,
+        identity.budget_max_calls,
+        identity.budget_max_output_tokens,
+        identity.budget_usd_cap,
+        identity.adapter_timeout_s,
+        identity.checker_timeout_s,
+    )
+
+
+def _block_key(identity: results.CellIdentity) -> tuple[Any, ...]:
+    return (
+        identity.task,
+        identity.window_id,
+        identity.repetition,
+        identity.block_attempt,
+    )
+
+
+def _logical_cell_key(identity: results.CellIdentity) -> tuple[Any, ...]:
+    return (*_block_key(identity), identity.arm_id)
+
+
+def _infrastructure_reason(row: Mapping[str, Any], row_number: int) -> str | None:
+    result = _object(row.get("result"), f"row {row_number} result")
+    reason = result.get("infrastructure_invalid_reason")
+    if reason is None:
+        valid = result.get("infrastructure_valid", True)
+        if not isinstance(valid, bool):
+            raise RouterReportError(
+                f"row {row_number} result.infrastructure_valid must be a boolean"
+            )
+        return None if valid else "unspecified_infrastructure"
+    return _string(reason, f"row {row_number} infrastructure_invalid_reason")
+
+
+def _route_reasons(row: Mapping[str, Any], row_number: int) -> list[str]:
+    integrity = _object(row.get("route_integrity"), f"row {row_number} route_integrity")
+    passed = _bool(integrity.get("pass"), f"row {row_number} route_integrity.pass")
+    raw_reasons = integrity.get("reasons", [])
+    if not isinstance(raw_reasons, list) or not all(
+        isinstance(reason, str) and reason for reason in raw_reasons
+    ):
+        raise RouterReportError(
+            f"row {row_number} route_integrity.reasons must be non-empty strings"
+        )
+    if passed and raw_reasons:
+        raise RouterReportError(
+            f"row {row_number} route integrity passes but contains failure reasons"
+        )
+    if not passed and not raw_reasons:
+        return ["unspecified"]
+    return raw_reasons
+
+
+def _costs(
+    call: Mapping[str, Any], row_number: int, call_number: int
+) -> dict[str, tuple[float, str, str]]:
+    raw = call.get("costs", {})
+    if raw is None:
+        raw = {}
+    raw = _object(raw, f"row {row_number} call {call_number} costs")
+    unknown = sorted(set(raw) - set(_COST_BASES))
+    if unknown:
+        raise RouterReportError(
+            f"row {row_number} call {call_number} has unknown cost bases: "
+            + ", ".join(unknown)
+        )
+    parsed = {}
+    for basis, item in raw.items():
+        item = _object(item, f"row {row_number} call {call_number} costs.{basis}")
+        amount = _number(
+            item.get("amount_usd"),
+            f"row {row_number} call {call_number} costs.{basis}.amount_usd",
+        )
+        currency = _string(
+            item.get("currency"),
+            f"row {row_number} call {call_number} costs.{basis}.currency",
+        )
+        if currency != "USD":
+            raise RouterReportError(
+                f"row {row_number} call {call_number} costs.{basis}.currency "
+                "must be USD for amount_usd"
+            )
+        effective_at = _string(
+            item.get("effective_at"),
+            f"row {row_number} call {call_number} costs.{basis}.effective_at",
+        )
+        parsed[basis] = (amount, currency, effective_at)
+    return parsed
+
+
+def _cell(row: Mapping[str, Any], row_number: int) -> dict[str, Any]:
+    result = _object(row.get("result"), f"row {row_number} result")
+    solved = _bool(result.get("solved"), f"row {row_number} result.solved")
+    score = _number(
+        result.get("checker_score"),
+        f"row {row_number} result.checker_score",
+    )
+    available = _bool(
+        result.get("available"),
+        f"row {row_number} result.available",
+    )
+    duration = _optional_number(
+        result.get("duration_s"),
+        f"row {row_number} result.duration_s",
+    )
+    timed_out = result.get("timed_out", False)
+    if not isinstance(timed_out, bool):
+        raise RouterReportError(f"row {row_number} result.timed_out must be a boolean")
+    proxy = _object(row.get("proxy_metrics"), f"row {row_number} proxy_metrics")
+    raw_calls = proxy.get("calls")
+    if not isinstance(raw_calls, list):
+        raise RouterReportError(f"row {row_number} proxy_metrics.calls must be a list")
+
+    calls = []
+    for call_number, raw_call in enumerate(raw_calls, 1):
+        call = _object(raw_call, f"row {row_number} call {call_number}")
+        timing = _object(
+            call.get("timing", {}),
+            f"row {row_number} call {call_number} timing",
+        )
+        generation = call.get("generation")
+        if generation is not None:
+            generation = _object(
+                generation,
+                f"row {row_number} call {call_number} generation",
+            )
+        route = _object(
+            call.get("route", {}),
+            f"row {row_number} call {call_number} route",
+        )
+        provider = route.get("provider")
+        model = route.get("served_model")
+        if provider is not None:
+            provider = _string(
+                provider, f"row {row_number} call {call_number} route.provider"
+            )
+        if model is not None:
+            model = _string(
+                model, f"row {row_number} call {call_number} route.served_model"
+            )
+        output_tokens = generation_duration = None
+        if generation is not None:
+            output_tokens = _optional_number(
+                generation.get("output_tokens"),
+                f"row {row_number} call {call_number} generation.output_tokens",
+            )
+            generation_duration = _optional_number(
+                generation.get("duration_s"),
+                f"row {row_number} call {call_number} generation.duration_s",
+            )
+            if (output_tokens is None) != (generation_duration is None):
+                raise RouterReportError(
+                    f"row {row_number} call {call_number} generation evidence "
+                    "must pair output_tokens with duration_s"
+                )
+        calls.append(
+            {
+                "ttfb": _optional_number(
+                    timing.get("ttfb_s"),
+                    f"row {row_number} call {call_number} timing.ttfb_s",
+                ),
+                "ttft": _optional_number(
+                    timing.get("semantic_ttft_s"),
+                    f"row {row_number} call {call_number} timing.semantic_ttft_s",
+                ),
+                "output_tokens": output_tokens,
+                "generation_duration": generation_duration,
+                "route": (
+                    f"{provider}/{model}"
+                    if provider is not None and model is not None
+                    else provider or model or "unknown"
+                ),
+                "costs": _costs(call, row_number, call_number),
+            }
+        )
+
+    identity = results.router_identity_from_row(row)
+    timeout = float(identity.budget_timeout_s)
+    return {
+        "solved": 1.0 if solved else 0.0,
+        "score": score,
+        "availability": 1.0 if available else 0.0,
+        "latency": (
+            min(duration, timeout)
+            if duration is not None
+            else timeout if timed_out else None
+        ),
+        "calls": calls,
+    }
+
+
+def _cell_call_metric(cell: Mapping[str, Any], name: str) -> float | None:
+    values = [call[name] for call in cell["calls"] if call[name] is not None]
+    return _mean(values)
+
+
+def _cell_throughput(cell: Mapping[str, Any]) -> float | None:
+    paired = [
+        (call["output_tokens"], call["generation_duration"])
+        for call in cell["calls"]
+        if call["output_tokens"] is not None and call["generation_duration"] is not None
+    ]
+    if not paired:
+        return None
+    duration = sum(item[1] for item in paired)
+    if duration <= 0:
+        return None
+    return sum(item[0] for item in paired) / duration
+
+
+def _cell_cost(cell: Mapping[str, Any], basis: str) -> float | None:
+    calls = cell["calls"]
+    if not calls or any(basis not in call["costs"] for call in calls):
+        return None
+    return sum(call["costs"][basis][0] for call in calls)
+
+
+def _task_values(
+    cells_by_task: Mapping[str, Sequence[Mapping[str, Any]]],
+    getter: Any,
+) -> tuple[dict[str, float], int]:
+    values = {}
+    covered_cells = 0
+    for task, cells in cells_by_task.items():
+        cell_values = [getter(cell) for cell in cells]
+        covered = [value for value in cell_values if value is not None]
+        covered_cells += len(covered)
+        if covered:
+            values[task] = sum(covered) / len(covered)
+    return values, covered_cells
+
+
+def _seed(base: int, label: str) -> int:
+    value = base & ((1 << 64) - 1)
+    for byte in label.encode("utf-8"):
+        value = ((value * 1_000_003) ^ byte) & ((1 << 64) - 1)
+    return value
+
+
+def aggregate(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    expected_arm_ids: Iterable[str] | None = None,
+    bootstrap_replicates: int = DEFAULT_BOOTSTRAP_REPLICATES,
+    bootstrap_seed: int = DEFAULT_BOOTSTRAP_SEED,
+) -> dict[str, Any]:
+    """Build a JSON-safe Gateway Tax report DTO from schema-v2 router rows."""
+    if (
+        not isinstance(bootstrap_replicates, int)
+        or isinstance(bootstrap_replicates, bool)
+        or bootstrap_replicates < 1
+    ):
+        raise RouterReportError("bootstrap_replicates must be a positive integer")
+    if not isinstance(bootstrap_seed, int) or isinstance(bootstrap_seed, bool):
+        raise RouterReportError("bootstrap_seed must be an integer")
+
+    materialized = list(rows)
+    if not materialized:
+        raise RouterReportError("at least one router row is required")
+
+    parsed = []
+    experiment_ids = set()
+    experiment_digests = set()
+    tracks = set()
+    strata = set()
+    cell_ids = {}
+    logical_cells = {}
+    arm_metadata: dict[str, tuple[str, bool, str]] = {}
+    task_metadata: dict[str, tuple[str, str, str]] = {}
+    block_coordinates: dict[str, tuple[Any, ...]] = {}
+    coordinate_block_ids: dict[tuple[Any, ...], str] = {}
+    for row_number, row in enumerate(materialized, 1):
+        if not isinstance(row, Mapping):
+            raise RouterReportError(f"row {row_number} must be an object")
+        try:
+            identity = results.router_identity_from_row(row)
+            cell_id = results.result_cell_id(row)
+        except results.ResultError as exc:
+            raise RouterReportError(f"row {row_number} has invalid identity: {exc}") from exc
+        tracks.add(identity.track)
+        experiment_ids.add(identity.experiment_id)
+        experiment_digests.add(identity.experiment_digest)
+        strata.add(_stratum(identity))
+        if cell_id in cell_ids:
+            raise RouterReportError(
+                f"duplicate cell_id {cell_id!r} on rows {cell_ids[cell_id]} and {row_number}"
+            )
+        cell_ids[cell_id] = row_number
+        logical = _logical_cell_key(identity)
+        if logical in logical_cells:
+            raise RouterReportError(
+                "duplicate logical cell on rows "
+                f"{logical_cells[logical]} and {row_number}"
+            )
+        logical_cells[logical] = row_number
+        role, baseline = _arm_metadata(row, row_number)
+        metadata = (role, baseline, identity.arm_digest)
+        previous = arm_metadata.setdefault(identity.arm_id, metadata)
+        if previous != metadata:
+            raise RouterReportError(f"arm {identity.arm_id!r} metadata is inconsistent")
+        task_provenance = (
+            identity.task_digest,
+            identity.checker_digest,
+            identity.workspace_source_sha,
+        )
+        previous_task = task_metadata.setdefault(identity.task, task_provenance)
+        if previous_task != task_provenance:
+            raise RouterReportError(f"task {identity.task!r} provenance is inconsistent")
+        coordinates = (
+            identity.task,
+            identity.window_id,
+            identity.repetition,
+            identity.block_attempt,
+        )
+        previous_coordinates = block_coordinates.setdefault(identity.block_id, coordinates)
+        if previous_coordinates != coordinates:
+            raise RouterReportError(
+                f"block_id {identity.block_id!r} maps to mixed schedule coordinates"
+            )
+        coordinate_key = _block_key(identity)
+        previous_block_id = coordinate_block_ids.setdefault(
+            coordinate_key, identity.block_id
+        )
+        if previous_block_id != identity.block_id:
+            raise RouterReportError(
+                "one logical block maps to multiple block_id values"
+            )
+        infrastructure_reason = _infrastructure_reason(row, row_number)
+        route_reasons = _route_reasons(row, row_number)
+        parsed.append(
+            {
+                "identity": identity,
+                "row": row,
+                "row_number": row_number,
+                "infrastructure_reason": infrastructure_reason,
+                "route_reasons": route_reasons,
+            }
+        )
+
+    if len(experiment_ids) != 1 or len(experiment_digests) != 1:
+        raise RouterReportError("rows mix experiments")
+    if tracks != {"gateway_tax"}:
+        raise RouterReportError("rows must contain only the gateway_tax track")
+    if len(strata) != 1:
+        raise RouterReportError("rows mix comparison strata")
+
+    baseline_arms = [
+        arm_id for arm_id, (role, baseline, _digest) in arm_metadata.items() if baseline
+    ]
+    if len(baseline_arms) != 1:
+        raise RouterReportError("gateway_tax requires exactly one baseline arm")
+    baseline_arm = baseline_arms[0]
+    if arm_metadata[baseline_arm][0] != "direct":
+        raise RouterReportError("the gateway_tax baseline arm must be direct")
+    if any(
+        role == "direct" and arm_id != baseline_arm
+        for arm_id, (role, _baseline, _digest) in arm_metadata.items()
+    ):
+        raise RouterReportError("gateway_tax allows exactly one direct arm")
+    if not any(role == "gateway" for role, _baseline, _digest in arm_metadata.values()):
+        raise RouterReportError("gateway_tax requires at least one gateway arm")
+
+    if expected_arm_ids is None:
+        expected_arms = frozenset(arm_metadata)
+    else:
+        expected_list = list(expected_arm_ids)
+        if not expected_list or not all(
+            isinstance(arm_id, str) and arm_id for arm_id in expected_list
+        ):
+            raise RouterReportError("expected_arm_ids must contain non-empty strings")
+        if len(set(expected_list)) != len(expected_list):
+            raise RouterReportError("expected_arm_ids contains duplicates")
+        expected_arms = frozenset(expected_list)
+        unknown = sorted(expected_arms - set(arm_metadata))
+        extra = sorted(set(arm_metadata) - expected_arms)
+        if unknown or extra:
+            raise RouterReportError(
+                "observed arms do not match expected_arm_ids"
+                + (f"; missing: {', '.join(unknown)}" if unknown else "")
+                + (f"; unexpected: {', '.join(extra)}" if extra else "")
+            )
+
+    blocks: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+    for item in parsed:
+        blocks[_block_key(item["identity"])].append(item)
+
+    exclusions = Counter()
+    included_blocks = []
+    for block_key in sorted(blocks):
+        block = blocks[block_key]
+        observed = {item["identity"].arm_id for item in block}
+        if observed != expected_arms or len(block) != len(expected_arms):
+            exclusions["incomplete_all_arm_block"] += 1
+            continue
+        reasons = {
+            item["infrastructure_reason"]
+            for item in block
+            if item["infrastructure_reason"] is not None
+        }
+        if reasons:
+            for reason in sorted(reasons):
+                exclusions[f"infrastructure:{reason}"] += 1
+            continue
+        route_reasons = {
+            reason
+            for item in block
+            for reason in item["route_reasons"]
+        }
+        if route_reasons:
+            for reason in sorted(route_reasons):
+                exclusions[f"route_integrity:{reason}"] += 1
+            continue
+        included_blocks.append(block)
+
+    arm_cells: dict[str, dict[str, list[dict[str, Any]]]] = {
+        arm_id: defaultdict(list) for arm_id in sorted(expected_arms)
+    }
+    analyzed_blocks = []
+    for block in included_blocks:
+        analyzed = {"task": block[0]["identity"].task, "cells": {}}
+        for item in block:
+            arm_id = item["identity"].arm_id
+            cell = _cell(item["row"], item["row_number"])
+            arm_cells[arm_id][item["identity"].task].append(cell)
+            analyzed["cells"][arm_id] = cell
+        analyzed_blocks.append(analyzed)
+
+    task_names = sorted(
+        {item["identity"].task for block in included_blocks for item in block}
+    )
+    eligible_tasks = len(task_names)
+    report_arms = {}
+    for arm_id in sorted(expected_arms):
+        cells_by_task = arm_cells[arm_id]
+        cells_total = sum(len(cells) for cells in cells_by_task.values())
+        getters = {
+            "solve_rate": lambda cell: cell["solved"],
+            "mean_checker_score": lambda cell: cell["score"],
+            "availability": lambda cell: cell["availability"],
+            "latency_s": lambda cell: cell["latency"],
+            "ttfb_s": lambda cell: _cell_call_metric(cell, "ttfb"),
+            "semantic_ttft_s": lambda cell: _cell_call_metric(cell, "ttft"),
+            "throughput_tokens_per_s": _cell_throughput,
+        }
+        metrics = {}
+        for name, getter in getters.items():
+            values, covered_cells = _task_values(cells_by_task, getter)
+            metrics[name] = _metric(
+                values,
+                eligible_tasks=eligible_tasks,
+                cells_covered=covered_cells,
+                cells_total=cells_total,
+                replicates=bootstrap_replicates,
+                seed=_seed(bootstrap_seed, f"arm:{arm_id}:{name}"),
+            )
+            if name in ("ttfb_s", "semantic_ttft_s", "throughput_tokens_per_s"):
+                call_total = sum(
+                    len(cell["calls"])
+                    for cells in cells_by_task.values()
+                    for cell in cells
+                )
+                if name == "throughput_tokens_per_s":
+                    covered_calls = sum(
+                        1
+                        for cells in cells_by_task.values()
+                        for cell in cells
+                        for call in cell["calls"]
+                        if call["output_tokens"] is not None
+                        and call["generation_duration"] is not None
+                        and call["generation_duration"] > 0
+                    )
+                else:
+                    call_name = "ttfb" if name == "ttfb_s" else "ttft"
+                    covered_calls = sum(
+                        1
+                        for cells in cells_by_task.values()
+                        for cell in cells
+                        for call in cell["calls"]
+                        if call[call_name] is not None
+                    )
+                metrics[name]["call_coverage"] = {
+                    "covered": covered_calls,
+                    "total": call_total,
+                    "ratio": covered_calls / call_total if call_total else 0.0,
+                }
+
+        costs = {}
+        for basis in _COST_BASES:
+            values, covered_cells = _task_values(
+                cells_by_task, lambda cell, basis=basis: _cell_cost(cell, basis)
+            )
+            call_total = sum(
+                len(cell["calls"])
+                for cells in cells_by_task.values()
+                for cell in cells
+            )
+            covered_calls = sum(
+                1
+                for cells in cells_by_task.values()
+                for cell in cells
+                for call in cell["calls"]
+                if basis in call["costs"]
+            )
+            currencies = sorted(
+                {
+                    call["costs"][basis][1]
+                    for cells in cells_by_task.values()
+                    for cell in cells
+                    for call in cell["calls"]
+                    if basis in call["costs"]
+                }
+            )
+            effective_at = sorted(
+                {
+                    call["costs"][basis][2]
+                    for cells in cells_by_task.values()
+                    for cell in cells
+                    for call in cell["calls"]
+                    if basis in call["costs"]
+                }
+            )
+            attempted = _metric(
+                values,
+                eligible_tasks=eligible_tasks,
+                cells_covered=covered_cells,
+                cells_total=cells_total,
+                replicates=bootstrap_replicates,
+                seed=_seed(bootstrap_seed, f"arm:{arm_id}:cost:{basis}"),
+            )
+            solve_rate = metrics["solve_rate"]["estimate"]
+            complete_coverage = (
+                cells_total > 0
+                and covered_cells == cells_total
+                and covered_calls == call_total
+            )
+            solve_values, _covered_solve_cells = _task_values(
+                cells_by_task, lambda cell: cell["solved"]
+            )
+            cost_per_solve = (
+                attempted["estimate"] / solve_rate
+                if complete_coverage
+                and attempted["estimate"] is not None
+                and solve_rate is not None
+                and solve_rate > 0
+                else None
+            )
+            costs[basis] = {
+                "attempted_cost_usd": attempted,
+                "cost_per_solve_usd": cost_per_solve,
+                "cost_per_solve_interval": (
+                    _ratio_interval(
+                        values,
+                        solve_values,
+                        replicates=bootstrap_replicates,
+                        seed=_seed(
+                            bootstrap_seed,
+                            f"arm:{arm_id}:cost_per_solve:{basis}",
+                        ),
+                    )
+                    if complete_coverage
+                    else None
+                ),
+                "basis_coverage": {
+                    "covered_calls": covered_calls,
+                    "total_calls": call_total,
+                    "ratio": covered_calls / call_total if call_total else 0.0,
+                    "covered_cells": covered_cells,
+                    "total_cells": cells_total,
+                    "complete": complete_coverage,
+                },
+                "currencies": currencies,
+                "effective_at": effective_at,
+            }
+
+        task_routes: dict[str, Counter[str]] = defaultdict(Counter)
+        for task, cells in cells_by_task.items():
+            for cell in cells:
+                task_routes[task].update(call["route"] for call in cell["calls"])
+        route_names = sorted({route for counts in task_routes.values() for route in counts})
+        distribution = {}
+        for route in route_names:
+            values = {
+                task: counts[route] / sum(counts.values())
+                for task, counts in task_routes.items()
+                if counts
+            }
+            distribution[route] = {
+                "share": _mean(list(values.values())),
+                "interval": _interval(
+                    values,
+                    replicates=bootstrap_replicates,
+                    seed=_seed(bootstrap_seed, f"arm:{arm_id}:route:{route}"),
+                ),
+                "task_coverage": {
+                    "covered": len(values),
+                    "total": eligible_tasks,
+                    "ratio": len(values) / eligible_tasks if eligible_tasks else 0.0,
+                },
+            }
+
+        report_arms[arm_id] = {
+            "role": arm_metadata[arm_id][0],
+            "baseline": arm_metadata[arm_id][1],
+            "arm_digest": arm_metadata[arm_id][2],
+            "attempted_cells": cells_total,
+            "metrics": metrics,
+            "costs": costs,
+            "route_distribution": distribution,
+        }
+
+    contrasts = {}
+    contrast_getters = {
+        "solve_rate": lambda cell: cell["solved"],
+        "mean_checker_score": lambda cell: cell["score"],
+        "availability": lambda cell: cell["availability"],
+        "latency_s": lambda cell: cell["latency"],
+        "ttfb_s": lambda cell: _cell_call_metric(cell, "ttfb"),
+        "semantic_ttft_s": lambda cell: _cell_call_metric(cell, "ttft"),
+        "throughput_tokens_per_s": _cell_throughput,
+        **{
+            f"cost:{basis}": (lambda cell, basis=basis: _cell_cost(cell, basis))
+            for basis in _COST_BASES
+        },
+    }
+    for arm_id in sorted(expected_arms):
+        if arm_id == baseline_arm:
+            continue
+        metrics = {}
+        for name, getter in contrast_getters.items():
+            block_differences: dict[str, list[float]] = defaultdict(list)
+            covered_blocks = 0
+            for block in analyzed_blocks:
+                gateway = getter(block["cells"][arm_id])
+                direct = getter(block["cells"][baseline_arm])
+                if gateway is not None and direct is not None:
+                    block_differences[block["task"]].append(gateway - direct)
+                    covered_blocks += 1
+            paired = {
+                task: sum(values) / len(values)
+                for task, values in sorted(block_differences.items())
+            }
+            metrics[name] = {
+                "estimate": _mean(list(paired.values())),
+                "interval": _interval(
+                    paired,
+                    replicates=bootstrap_replicates,
+                    seed=_seed(bootstrap_seed, f"contrast:{arm_id}:{name}"),
+                ),
+                "paired_task_coverage": {
+                    "covered": len(paired),
+                    "total": eligible_tasks,
+                    "ratio": len(paired) / eligible_tasks if eligible_tasks else 0.0,
+                },
+                "paired_block_coverage": {
+                    "covered": covered_blocks,
+                    "total": len(analyzed_blocks),
+                    "ratio": (
+                        covered_blocks / len(analyzed_blocks)
+                        if analyzed_blocks
+                        else 0.0
+                    ),
+                },
+            }
+        contrasts[arm_id] = {
+            "gateway_arm": arm_id,
+            "direct_arm": baseline_arm,
+            "direction": "gateway_minus_direct",
+            "metrics": metrics,
+        }
+
+    dto = {
+        "schema_version": 1,
+        "benchmark": "router",
+        "track": "gateway_tax",
+        "experiment_id": next(iter(experiment_ids)),
+        "experiment_digest": next(iter(experiment_digests)),
+        "analysis": {
+            "weighting": "calls_to_cell_complete_blocks_to_task_tasks_equal",
+            "interval": "task_cluster_bootstrap_percentile",
+            "bootstrap_seed": bootstrap_seed,
+            "bootstrap_replicates": bootstrap_replicates,
+            "wilson_intervals": False,
+            "composite_score": False,
+        },
+        "blocks": {
+            "observed": len(blocks),
+            "included": len(included_blocks),
+            "excluded": len(blocks) - len(included_blocks),
+            "excluded_by_reason": dict(sorted(exclusions.items())),
+        },
+        "tasks": {"included": eligible_tasks, "names": task_names},
+        "baseline_arm": baseline_arm,
+        "arms": report_arms,
+        "paired_contrasts": contrasts,
+    }
+    json.dumps(dto, allow_nan=False, sort_keys=True)
+    return dto
+
+
+def render_text(report: Mapping[str, Any]) -> str:
+    """Render a compact human-readable summary of an aggregate report DTO."""
+    blocks = report["blocks"]
+    lines = [
+        f"Router Bench: {report['track']} ({report['experiment_digest'][:12]})",
+        (
+            f"Blocks: {blocks['included']}/{blocks['observed']} included; "
+            f"tasks: {report['tasks']['included']}"
+        ),
+    ]
+    if blocks["excluded_by_reason"]:
+        reasons = ", ".join(
+            f"{reason}={count}"
+            for reason, count in blocks["excluded_by_reason"].items()
+        )
+        lines.append(f"Excluded: {reasons}")
+    for arm_id, arm in report["arms"].items():
+        metrics = arm["metrics"]
+        solve = metrics["solve_rate"]["estimate"]
+        score = metrics["mean_checker_score"]["estimate"]
+        availability = metrics["availability"]["estimate"]
+        latency = metrics["latency_s"]["estimate"]
+        lines.append(
+            f"{arm_id} ({arm['role']}): solve {_format_percent(solve)}, "
+            f"score {_format_number(score)}, availability {_format_percent(availability)}, "
+            f"latency {_format_seconds(latency)}"
+        )
+        for basis, cost in arm["costs"].items():
+            attempted = cost["attempted_cost_usd"]["estimate"]
+            if attempted is None and cost["basis_coverage"]["covered_calls"] == 0:
+                continue
+            lines.append(
+                f"  {basis}: attempted ${_format_number(attempted, 4)}, "
+                f"cost/solve {_format_cost(cost['cost_per_solve_usd'])}, "
+                f"coverage {_format_percent(cost['basis_coverage']['ratio'])}"
+            )
+    for arm_id, contrast in report["paired_contrasts"].items():
+        latency = contrast["metrics"]["latency_s"]["estimate"]
+        solve = contrast["metrics"]["solve_rate"]["estimate"]
+        lines.append(
+            f"{arm_id} - {contrast['direct_arm']}: "
+            f"solve {_format_signed(solve)}, latency {_format_signed(latency, 's')}"
+        )
+    return "\n".join(lines)
+
+
+def _format_number(value: float | None, places: int = 3) -> str:
+    return "n/a" if value is None else f"{value:.{places}f}"
+
+
+def _format_percent(value: float | None) -> str:
+    return "n/a" if value is None else f"{value * 100:.1f}%"
+
+
+def _format_seconds(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.3f}s"
+
+
+def _format_cost(value: float | None) -> str:
+    return "n/a" if value is None else f"${value:.4f}"
+
+
+def _format_signed(value: float | None, suffix: str = "") -> str:
+    return "n/a" if value is None else f"{value:+.3f}{suffix}"
+
+
+build_report = aggregate
+generate_report = aggregate

--- a/obench/router_report.py
+++ b/obench/router_report.py
@@ -288,6 +288,15 @@ def _costs(
     return parsed
 
 
+def _route_label(provider: str | None, model: str | None) -> str:
+    if provider is None or model is None:
+        return provider or model or "unknown"
+    prefix = provider + "/"
+    if model.casefold().startswith(prefix.casefold()):
+        return model
+    return f"{provider}/{model}"
+
+
 def _cell(row: Mapping[str, Any], row_number: int) -> dict[str, Any]:
     result = _object(row.get("result"), f"row {row_number} result")
     solved = _bool(result.get("solved"), f"row {row_number} result.solved")
@@ -365,11 +374,7 @@ def _cell(row: Mapping[str, Any], row_number: int) -> dict[str, Any]:
                 ),
                 "output_tokens": output_tokens,
                 "generation_duration": generation_duration,
-                "route": (
-                    f"{provider}/{model}"
-                    if provider is not None and model is not None
-                    else provider or model or "unknown"
-                ),
+                "route": _route_label(provider, model),
                 "costs": _costs(call, row_number, call_number),
             }
         )

--- a/obench/router_report.py
+++ b/obench/router_report.py
@@ -215,6 +215,10 @@ def _block_key(identity: results.CellIdentity) -> tuple[Any, ...]:
     )
 
 
+def _block_coordinate(identity: results.CellIdentity) -> tuple[Any, ...]:
+    return identity.task, identity.window_id, identity.repetition
+
+
 def _logical_cell_key(identity: results.CellIdentity) -> tuple[Any, ...]:
     return (*_block_key(identity), identity.arm_id)
 
@@ -585,9 +589,20 @@ def aggregate(
                 + (f"; unexpected: {', '.join(extra)}" if extra else "")
             )
 
+    latest_attempts: dict[tuple[Any, ...], int] = {}
+    for item in parsed:
+        identity = item["identity"]
+        coordinate = _block_coordinate(identity)
+        latest_attempts[coordinate] = max(
+            latest_attempts.get(coordinate, -1), identity.block_attempt
+        )
+
     blocks: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
     for item in parsed:
-        blocks[_block_key(item["identity"])].append(item)
+        identity = item["identity"]
+        coordinate = _block_coordinate(identity)
+        if identity.block_attempt == latest_attempts[coordinate]:
+            blocks[coordinate].append(item)
 
     exclusions = Counter()
     included_blocks = []

--- a/obench/router_report.py
+++ b/obench/router_report.py
@@ -327,8 +327,9 @@ def _cell(row: Mapping[str, Any], row_number: int) -> dict[str, Any]:
     calls = []
     for call_number, raw_call in enumerate(raw_calls, 1):
         call = _object(raw_call, f"row {row_number} call {call_number}")
+        timing_value = call.get("timing")
         timing = _object(
-            call.get("timing", {}),
+            {} if timing_value is None else timing_value,
             f"row {row_number} call {call_number} timing",
         )
         generation = call.get("generation")

--- a/obench/router_run.py
+++ b/obench/router_run.py
@@ -653,6 +653,17 @@ def _route_reasons(metrics: Mapping[str, Any], plan: router_spec.RoutePlan) -> l
     if not isinstance(route, Mapping):
         return ["missing_route_evidence"]
     reasons = []
+    evidence = metrics.get("route_evidence")
+    if not isinstance(evidence, Mapping):
+        reasons.append("missing_route_evidence_verdict")
+    elif evidence.get("pass") is not True:
+        evidence_reasons = evidence.get("reasons")
+        if isinstance(evidence_reasons, list) and all(
+            isinstance(reason, str) and reason for reason in evidence_reasons
+        ):
+            reasons.extend(evidence_reasons)
+        else:
+            reasons.append("route_evidence_failed")
     if route.get("requested_model") != plan.requested_model:
         reasons.append("requested_model_conflict")
     if route.get("served_model") != plan.requested_model:
@@ -698,12 +709,34 @@ def _proxy_evidence(
     total_output = 0
     total_cost = Decimal(0)
     priced_calls = 0
+    successful_calls = 0
     for row in ledger_rows:
+        status = row.get("status")
+        if isinstance(status, int) and 400 <= status <= 599:
+            calls.append({
+                "timing": None,
+                "generation": None,
+                "route": {
+                    "provider": plan.requested_provider,
+                    "served_model": plan.requested_model,
+                },
+                "costs": None,
+            })
+            continue
         metrics = row.get("router_metrics")
         if not isinstance(metrics, dict):
             reasons.append("missing_router_metrics")
-            calls.append({})
+            calls.append({
+                "timing": None,
+                "generation": None,
+                "route": {
+                    "provider": plan.requested_provider,
+                    "served_model": plan.requested_model,
+                },
+                "costs": None,
+            })
             continue
+        successful_calls += 1
         reasons.extend(_route_reasons(metrics, plan))
         usage = metrics.get("usage") if isinstance(metrics.get("usage"), dict) else {}
         output_tokens = usage.get("output_tokens")
@@ -731,7 +764,7 @@ def _proxy_evidence(
         infrastructure_reason = "max_calls_exceeded"
     elif total_output > budget.max_output_tokens:
         infrastructure_reason = "max_output_tokens_exceeded"
-    elif ledger_rows and priced_calls != len(ledger_rows):
+    elif successful_calls and priced_calls != successful_calls:
         infrastructure_reason = "usd_cap_unenforceable_no_frozen_price"
     elif total_cost > Decimal(budget.usd_cap):
         infrastructure_reason = "usd_cap_exceeded"

--- a/obench/router_run.py
+++ b/obench/router_run.py
@@ -1,0 +1,1110 @@
+"""Gateway Tax experiment runner.
+
+Every routed cell gets a fresh task workspace, a sanitized adapter subprocess,
+and a lifecycle-managed proxy ledger.  The ledger is sealed before the checker
+runs and before the result row is serialized.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import os
+import random
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+from datetime import datetime, timezone
+
+from . import proxy, results, router_spec
+from .adapters import pi
+from .publish import task_content_digest
+from .run import read_instruction, run_checker
+from .workspace import WorkspaceError, materialize_workspace
+
+
+CHECKER_TIMEOUT_S = 120
+FROZEN_PRICES_ENV = "OPENBENCH_ROUTER_FROZEN_PRICES_JSON"
+ADAPTERS_DIR_ENV = "OPENBENCH_ROUTER_ADAPTERS_DIR"
+LOCAL_LANE = "local-exploratory-route-isolation"
+DOCKER_LANE = "docker-exploratory-route-isolation"
+_RESULT_SENTINEL = "__BENCH_RESULT__"
+_EMPTY_HASH = hashlib.sha256(b"").hexdigest()
+_POLICY = {
+    "track": "gateway_tax",
+    "fallback": False,
+    "retries": 0,
+    "cache": False,
+    "checker_authority": True,
+    "replacement_unit": "complete_all_arm_block_attempt",
+}
+
+
+class RouterRunError(RuntimeError):
+    """Raised when an experiment cannot be run without ambiguous evidence."""
+
+
+@dataclass(frozen=True, slots=True)
+class TaskProvenance:
+    name: str
+    path: Path
+    task_digest: str
+    checker_digest: str
+    workspace_source_sha: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScheduleBlock:
+    task: str
+    window_id: str
+    repetition: int
+    arm_ids: tuple[str, ...]
+
+    @property
+    def coordinate(self) -> tuple[str, str, int]:
+        return self.task, self.window_id, self.repetition
+
+
+@dataclass(frozen=True, slots=True)
+class Price:
+    input_per_million: Decimal
+    output_per_million: Decimal
+    effective_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class RunSummary:
+    results_path: Path
+    rows_appended: int
+    blocks_completed: int
+    blocks_replaced: int
+    blocks_skipped: int
+
+
+def _digest_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _digest_file(path: Path) -> str:
+    return _digest_bytes(path.read_bytes())
+
+
+def _tree_digest(root: Path) -> str:
+    hasher = hashlib.sha256()
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise RouterRunError(f"workspace contains a symlink: {relative}")
+        if path.is_dir():
+            continue
+        encoded = relative.encode("utf-8")
+        data = path.read_bytes()
+        hasher.update(len(encoded).to_bytes(8, "big"))
+        hasher.update(encoded)
+        hasher.update(len(data).to_bytes(8, "big"))
+        hasher.update(data)
+    return hasher.hexdigest()
+
+
+def _task_path(tasks_dir: str | os.PathLike[str], task: str) -> Path:
+    root = Path(tasks_dir).resolve()
+    path = (root / task).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise RouterRunError(f"task escapes --tasks-dir: {task!r}") from exc
+    if not path.is_dir():
+        raise RouterRunError(f"task directory does not exist: {path}")
+    if (path / "DROPPED.md").exists():
+        raise RouterRunError(f"task {task!r} is dropped")
+    for name in ("instruction.md", "checker.sh"):
+        if not (path / name).is_file():
+            raise RouterRunError(f"task {task!r} is missing {name}")
+    return path
+
+
+def inspect_tasks(
+    experiment: router_spec.RouterExperiment,
+    tasks_dir: str | os.PathLike[str],
+) -> dict[str, TaskProvenance]:
+    """Validate task inputs and freeze provenance before scheduling."""
+    inspected = {}
+    for task in experiment.tasks:
+        path = _task_path(tasks_dir, task)
+        with tempfile.TemporaryDirectory(prefix="obench_router_probe_") as temp:
+            try:
+                materialize_workspace(str(path), temp)
+            except WorkspaceError as exc:
+                raise RouterRunError(
+                    f"task {task!r} workspace materialization failed: {exc}"
+                ) from exc
+            workspace_sha = _tree_digest(Path(temp))
+        inspected[task] = TaskProvenance(
+            name=task,
+            path=path,
+            task_digest=task_content_digest(str(path)),
+            checker_digest=_digest_file(path / "checker.sh"),
+            workspace_source_sha=workspace_sha,
+        )
+    return inspected
+
+
+def build_schedule(experiment: router_spec.RouterExperiment) -> tuple[ScheduleBlock, ...]:
+    """Return deterministic complete blocks with cyclic arm counterbalancing."""
+    arm_ids = [arm.arm_id for arm in experiment.arms]
+    rng = random.Random(experiment.schedule_seed)
+    rng.shuffle(arm_ids)
+    coordinates = [
+        (task, window.window_id, repetition)
+        for window in experiment.windows
+        for repetition in range(1, experiment.repetitions_per_window + 1)
+        for task in experiment.tasks
+    ]
+    blocks = []
+    for index, (task, window_id, repetition) in enumerate(coordinates):
+        rotation = index % len(arm_ids)
+        order = arm_ids[rotation:] + arm_ids[:rotation]
+        if (index // len(arm_ids)) % 2:
+            order = list(reversed(order))
+        blocks.append(ScheduleBlock(task, window_id, repetition, tuple(order)))
+    return tuple(blocks)
+
+
+def _active_schedule(
+    experiment: router_spec.RouterExperiment,
+    schedule: Sequence[ScheduleBlock],
+    now: datetime | None = None,
+) -> tuple[ScheduleBlock, ...]:
+    now = now or datetime.now(timezone.utc)
+    active = {
+        window.window_id
+        for window in experiment.windows
+        if (
+            datetime.fromisoformat(window.start.replace("Z", "+00:00"))
+            <= now
+            < datetime.fromisoformat(window.end.replace("Z", "+00:00"))
+        )
+    }
+    return tuple(block for block in schedule if block.window_id in active)
+
+
+def _load_prices(environ: Mapping[str, str]) -> tuple[dict[str, Price], dict[str, Any]]:
+    raw = environ.get(FROZEN_PRICES_ENV)
+    if not raw:
+        return {}, {"status": "unavailable", "source": FROZEN_PRICES_ENV}
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RouterRunError(f"{FROZEN_PRICES_ENV} is not valid JSON: {exc}") from exc
+    if not isinstance(decoded, dict) or not decoded:
+        raise RouterRunError(f"{FROZEN_PRICES_ENV} must be a non-empty JSON object")
+    prices = {}
+    canonical = []
+    for key, item in sorted(decoded.items()):
+        if not isinstance(key, str) or "/" not in key or not isinstance(item, dict):
+            raise RouterRunError(
+                f"{FROZEN_PRICES_ENV} entries must be provider/model objects"
+            )
+        try:
+            input_rate = Decimal(str(item["input_per_million"]))
+            output_rate = Decimal(str(item["output_per_million"]))
+            effective_at = item["effective_at"]
+        except (KeyError, InvalidOperation) as exc:
+            raise RouterRunError(f"invalid frozen price for {key!r}") from exc
+        if (
+            not input_rate.is_finite()
+            or not output_rate.is_finite()
+            or input_rate < 0
+            or output_rate < 0
+            or not isinstance(effective_at, str)
+            or not effective_at
+        ):
+            raise RouterRunError(f"invalid frozen price for {key!r}")
+        prices[key] = Price(input_rate, output_rate, effective_at)
+        canonical.append({
+            "model": key,
+            "input_per_million": str(input_rate),
+            "output_per_million": str(output_rate),
+            "effective_at": effective_at,
+            "currency": "USD",
+        })
+    return prices, {
+        "schema_version": 1,
+        "price_id": "frozen-env-v1",
+        "currency": "USD",
+        "prices": canonical,
+    }
+
+
+def load_frozen_prices(
+    environ: Mapping[str, str],
+) -> tuple[dict[str, Price], dict[str, Any]]:
+    return _load_prices(environ)
+
+
+def _price_snapshot_path(results_path: Path) -> Path:
+    return results_path.parent / f".{results_path.stem}.router-prices.json"
+
+
+def persist_price_snapshot(results_path: Path, snapshot: Mapping[str, Any]) -> Path:
+    path = _price_snapshot_path(results_path)
+    raw = results.canonical_json(snapshot) + "\n"
+    if path.exists():
+        if path.read_text(encoding="utf-8") != raw:
+            raise RouterRunError("persisted frozen price snapshot does not match this run")
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("x", encoding="utf-8") as handle:
+        handle.write(raw)
+        handle.flush()
+        os.fsync(handle.fileno())
+    directory_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+    return path
+
+
+def load_persisted_price_snapshot(results_path: Path) -> dict[str, Any]:
+    path = _price_snapshot_path(results_path)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RouterRunError(f"cannot load persisted frozen prices from {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RouterRunError(f"persisted frozen prices in {path} are malformed")
+    return value
+
+
+def policy_snapshot() -> dict[str, Any]:
+    return dict(_POLICY)
+
+
+def catalog_snapshot(experiment: router_spec.RouterExperiment) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "catalog_id": experiment.digest,
+        "name": "frozen-router-arm-catalog",
+        "entries": [
+            {
+                "model": arm.canonical_model,
+                "model_id": arm.requested_model,
+                "provider": arm.requested_provider,
+            }
+            for arm in experiment.arms
+        ],
+    }
+
+
+def _comparison_digests(
+    experiment: router_spec.RouterExperiment,
+    schedule: Sequence[ScheduleBlock],
+    price_snapshot: Mapping[str, Any],
+) -> dict[str, str]:
+    return {
+        "policy_digest": results.canonical_digest(policy_snapshot()),
+        "catalog_digest": results.canonical_digest(catalog_snapshot(experiment)),
+        "price_digest": results.canonical_digest(price_snapshot),
+        "sampling_digest": results.canonical_digest(
+            {
+                arm.arm_id: arm.sampling.to_dict()
+                for arm in experiment.arms
+            }
+        ),
+        "schedule_digest": results.canonical_digest(
+            [dataclasses.asdict(block) for block in schedule]
+        ),
+    }
+
+
+def _lane(exec_mode: str) -> str:
+    return LOCAL_LANE if exec_mode == "local" else DOCKER_LANE
+
+
+def _identity(
+    *,
+    experiment: router_spec.RouterExperiment,
+    arm: router_spec.Arm,
+    task: TaskProvenance,
+    block: ScheduleBlock,
+    attempt: int,
+    digests: Mapping[str, str],
+    harness_version: str,
+    exec_mode: str,
+    image_digest: str | None,
+) -> results.CellIdentity:
+    block_data = {
+        "experiment": experiment.digest,
+        "task": block.task,
+        "window": block.window_id,
+        "repetition": block.repetition,
+        "attempt": attempt,
+    }
+    block_id = "router-block-" + results.canonical_digest(block_data)
+    return results.CellIdentity.for_router(
+        track=experiment.track,
+        experiment_id=experiment.experiment_id,
+        experiment_digest=experiment.digest,
+        arm_id=arm.arm_id,
+        arm_digest=arm.digest,
+        task=task.name,
+        task_digest=task.task_digest,
+        checker_digest=task.checker_digest,
+        workspace_source_sha=task.workspace_source_sha,
+        harness=experiment.harness,
+        candidate=None,
+        harness_version=harness_version,
+        execution_lane=_lane(exec_mode),
+        image_digest=image_digest,
+        budget_timeout_s=experiment.budget.timeout_s,
+        budget_max_calls=experiment.budget.max_calls,
+        budget_max_output_tokens=experiment.budget.max_output_tokens,
+        budget_usd_cap=experiment.budget.usd_cap,
+        adapter_timeout_s=experiment.budget.timeout_s,
+        checker_timeout_s=CHECKER_TIMEOUT_S,
+        window_id=block.window_id,
+        repetition=block.repetition,
+        block_id=block_id,
+        block_attempt=attempt,
+        **digests,
+    )
+
+
+def _existing_attempts(
+    state: results.ResumeState,
+    experiment: router_spec.RouterExperiment,
+    expected_arms: set[str],
+) -> dict[tuple[str, str, int], dict[int, list[dict[str, Any]]]]:
+    attempts: dict[tuple[str, str, int], dict[int, list[dict[str, Any]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for row in state.rows:
+        identity = results.router_identity_from_row(row)
+        if identity.experiment_digest != experiment.digest:
+            raise RouterRunError(
+                "results file contains a different Router Bench experiment"
+            )
+        coordinate = (identity.task, identity.window_id, identity.repetition)
+        attempts[coordinate][identity.block_attempt].append(row)
+    for coordinate, by_attempt in attempts.items():
+        numbers = sorted(by_attempt)
+        if numbers != list(range(numbers[-1] + 1)):
+            raise RouterRunError(
+                f"results have non-contiguous block attempts for {coordinate}"
+            )
+        for attempt, rows_for_attempt in by_attempt.items():
+            arm_ids = {
+                results.router_identity_from_row(row).arm_id
+                for row in rows_for_attempt
+            }
+            if not arm_ids <= expected_arms:
+                raise RouterRunError(
+                    f"results contain unknown arms for {coordinate} attempt {attempt}"
+                )
+    return attempts
+
+
+def _validate_resume_identities(
+    state: results.ResumeState,
+    *,
+    experiment: router_spec.RouterExperiment,
+    schedule: Sequence[ScheduleBlock],
+    tasks: Mapping[str, TaskProvenance],
+    arms: Mapping[str, router_spec.Arm],
+    digests: Mapping[str, str],
+    harness_version: str,
+    exec_mode: str,
+    image_digest: str | None,
+) -> None:
+    blocks = {block.coordinate: block for block in schedule}
+    for row in state.rows:
+        actual = results.router_identity_from_row(row)
+        coordinate = (actual.task, actual.window_id, actual.repetition)
+        try:
+            expected = _identity(
+                experiment=experiment,
+                arm=arms[actual.arm_id],
+                task=tasks[actual.task],
+                block=blocks[coordinate],
+                attempt=actual.block_attempt,
+                digests=digests,
+                harness_version=harness_version,
+                exec_mode=exec_mode,
+                image_digest=image_digest,
+            )
+        except KeyError as exc:
+            raise RouterRunError(
+                f"results contain an unscheduled cell: {coordinate} arm={actual.arm_id}"
+            ) from exc
+        if actual != expected:
+            raise RouterRunError(
+                f"results identity does not match the current run for "
+                f"{coordinate} arm={actual.arm_id} attempt={actual.block_attempt}"
+            )
+
+
+def _attempt_complete_and_valid(
+    rows_for_attempt: Sequence[Mapping[str, Any]], expected_arms: set[str]
+) -> bool:
+    if {
+        results.router_identity_from_row(row).arm_id for row in rows_for_attempt
+    } != expected_arms:
+        return False
+    return all(
+        row.get("result", {}).get("infrastructure_invalid_reason") is None
+        and row.get("route_integrity", {}).get("pass") is True
+        for row in rows_for_attempt
+    )
+
+
+def _next_attempt(
+    by_attempt: Mapping[int, Sequence[Mapping[str, Any]]],
+    expected_arms: set[str],
+    force: bool,
+) -> tuple[int | None, bool]:
+    if not by_attempt:
+        return 0, False
+    latest = max(by_attempt)
+    valid = _attempt_complete_and_valid(by_attempt[latest], expected_arms)
+    if valid and not force:
+        return None, True
+    return latest + 1, False
+
+
+def _sanitized_env(
+    *,
+    adapters_dir: Path,
+    instruction_path: Path,
+    workdir: Path,
+    route_plan_path: Path,
+    proxy_base_url: str,
+    token: str,
+) -> dict[str, str]:
+    package_root = str(Path(__file__).resolve().parent.parent)
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": package_root,
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        "LC_ALL": os.environ.get("LC_ALL", ""),
+        "BENCH_ADAPTERS_DIR": str(adapters_dir),
+        "BENCH_INSTRUCTION_PATH": str(instruction_path),
+        "BENCH_WORKDIR": str(workdir),
+        "OPENBENCH_ROUTE_PLAN_PATH": str(route_plan_path),
+        "OPENBENCH_PROXY": "1",
+        "OPENBENCH_PROXY_BASE_URL": proxy_base_url,
+        "OPENBENCH_PROXY_CELL_TOKEN": token,
+    }
+    if os.environ.get("TMPDIR"):
+        env["TMPDIR"] = os.environ["TMPDIR"]
+    return {key: value for key, value in env.items() if value}
+
+
+def _parse_entry_result(stdout: str) -> dict[str, Any]:
+    for line in reversed(stdout.splitlines()):
+        if line.startswith(_RESULT_SENTINEL):
+            try:
+                value = json.loads(line[len(_RESULT_SENTINEL):].strip())
+            except json.JSONDecodeError as exc:
+                raise RouterRunError("routed entry emitted invalid result JSON") from exc
+            if not isinstance(value, dict):
+                raise RouterRunError("routed entry result must be an object")
+            return value
+    raise RouterRunError("routed entry emitted no result sentinel")
+
+
+def _invoke_local(
+    *,
+    plan_path: Path,
+    instruction_path: Path,
+    workdir: Path,
+    proxy_base_url: str,
+    token: str,
+    timeout_s: int,
+    adapters_dir: Path,
+) -> dict[str, Any]:
+    env = _sanitized_env(
+        adapters_dir=adapters_dir,
+        instruction_path=instruction_path,
+        workdir=workdir,
+        route_plan_path=plan_path,
+        proxy_base_url=proxy_base_url,
+        token=token,
+    )
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "obench.entry",
+            "pi",
+            "routed",
+            str(timeout_s),
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_s + 10)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        stdout, stderr = proc.communicate()
+        return {
+            "completed": False,
+            "error": f"entry timeout after {timeout_s}s",
+            "output_tail": (stdout + stderr)[-2000:],
+            "entry_timed_out": True,
+        }
+    if proc.returncode != 0:
+        raise RouterRunError(
+            f"routed entry exited {proc.returncode}: {(stderr or stdout)[-1000:]}"
+        )
+    return _parse_entry_result(stdout)
+
+
+def _read_sealed_ledger(seal: proxy.LedgerSeal, arm_digest: str) -> list[dict[str, Any]]:
+    try:
+        rows = [
+            json.loads(line)
+            for line in seal.path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RouterRunError(f"cannot read sealed proxy ledger: {exc}") from exc
+    if not rows or rows[-1].get("record_type") != "ledger_seal":
+        raise RouterRunError("proxy ledger has no terminal seal")
+    terminal = rows[-1]
+    if (
+        terminal.get("record_count") != seal.record_count
+        or terminal.get("last_sequence") != seal.last_sequence
+        or terminal.get("root_hash") != seal.root_hash
+        or len(rows) != seal.record_count + 1
+    ):
+        raise RouterRunError("proxy ledger terminal seal does not match")
+    previous = _EMPTY_HASH
+    for sequence, row in enumerate(rows[:-1], 1):
+        record = dict(row)
+        record_hash = record.pop("record_hash", None)
+        if (
+            record.get("record_type") != "request"
+            or record.get("sequence") != sequence
+            or record.get("previous_hash") != previous
+            or row.get("router_arm", {}).get("arm_digest") != arm_digest
+        ):
+            raise RouterRunError("proxy ledger chain or arm binding is invalid")
+        expected = _digest_bytes(
+            json.dumps(record, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        )
+        if record_hash != expected:
+            raise RouterRunError("proxy ledger record hash is invalid")
+        previous = record_hash
+    if previous != seal.root_hash:
+        raise RouterRunError("proxy ledger root hash is invalid")
+    return rows[:-1]
+
+
+def _price_call(
+    metrics: Mapping[str, Any],
+    prices: Mapping[str, Price],
+    plan: router_spec.RoutePlan,
+) -> tuple[dict[str, Any], Decimal | None]:
+    route = metrics.get("route") if isinstance(metrics.get("route"), dict) else {}
+    usage = metrics.get("usage") if isinstance(metrics.get("usage"), dict) else {}
+    price = prices.get(plan.canonical_model)
+    if price is None:
+        return {}, None
+    input_tokens = usage.get("input_tokens")
+    output_tokens = usage.get("output_tokens")
+    if (
+        not isinstance(input_tokens, int)
+        or isinstance(input_tokens, bool)
+        or not isinstance(output_tokens, int)
+        or isinstance(output_tokens, bool)
+    ):
+        return {}, None
+    amount = (
+        Decimal(input_tokens) * price.input_per_million
+        + Decimal(output_tokens) * price.output_per_million
+    ) / Decimal(1_000_000)
+    evidence = {
+        "frozen_list_estimate": {
+            "amount_usd": float(amount),
+            "currency": "USD",
+            "effective_at": price.effective_at,
+        }
+    }
+    return evidence, amount
+
+
+def _route_reasons(metrics: Mapping[str, Any], plan: router_spec.RoutePlan) -> list[str]:
+    route = metrics.get("route")
+    stream = metrics.get("stream")
+    if not isinstance(route, Mapping):
+        return ["missing_route_evidence"]
+    reasons = []
+    if route.get("requested_model") != plan.requested_model:
+        reasons.append("requested_model_conflict")
+    if route.get("served_model") != plan.requested_model:
+        reasons.append("served_model_conflict")
+    provider = route.get("provider")
+    if (
+        plan.route_kind == "gateway"
+        and (
+            not isinstance(provider, str)
+            or provider.casefold() != plan.requested_provider.casefold()
+        )
+    ):
+        reasons.append("provider_conflict")
+    if not isinstance(stream, Mapping) or stream.get("done") is not True:
+        reasons.append("stream_not_done")
+    attempts = route.get("attempts")
+    if plan.route_kind == "gateway":
+        if route.get("metadata_requested_model") != plan.requested_model:
+            reasons.append("metadata_requested_model_conflict")
+        if attempts is not None:
+            if not isinstance(attempts, list):
+                reasons.append("malformed_attempts")
+                return sorted(set(reasons))
+            for attempt in attempts:
+                if not isinstance(attempt, Mapping):
+                    reasons.append("malformed_attempt")
+                    continue
+                if str(attempt.get("provider", "")).casefold() != plan.requested_provider.casefold():
+                    reasons.append("attempt_provider_conflict")
+                if attempt.get("model") != plan.requested_model:
+                    reasons.append("attempt_model_conflict")
+    return sorted(set(reasons))
+
+
+def _proxy_evidence(
+    ledger_rows: Sequence[Mapping[str, Any]],
+    prices: Mapping[str, Price],
+    budget: router_spec.Budget,
+    plan: router_spec.RoutePlan,
+) -> tuple[list[dict[str, Any]], dict[str, Any], str | None]:
+    calls = []
+    reasons = []
+    total_output = 0
+    total_cost = Decimal(0)
+    priced_calls = 0
+    for row in ledger_rows:
+        metrics = row.get("router_metrics")
+        if not isinstance(metrics, dict):
+            reasons.append("missing_router_metrics")
+            calls.append({})
+            continue
+        reasons.extend(_route_reasons(metrics, plan))
+        usage = metrics.get("usage") if isinstance(metrics.get("usage"), dict) else {}
+        output_tokens = usage.get("output_tokens")
+        if isinstance(output_tokens, int) and not isinstance(output_tokens, bool):
+            total_output += output_tokens
+        costs, amount = _price_call(metrics, prices, plan)
+        if amount is not None:
+            total_cost += amount
+            priced_calls += 1
+        normalized_route = metrics.get("route")
+        if isinstance(normalized_route, dict):
+            normalized_route = dict(normalized_route)
+            if plan.route_kind == "direct" and not normalized_route.get("provider"):
+                normalized_route["provider"] = plan.requested_provider
+        calls.append(
+            {
+                "timing": metrics.get("timing"),
+                "generation": metrics.get("generation"),
+                "route": normalized_route,
+                "costs": costs,
+            }
+        )
+    infrastructure_reason = None
+    if len(ledger_rows) > budget.max_calls:
+        infrastructure_reason = "max_calls_exceeded"
+    elif total_output > budget.max_output_tokens:
+        infrastructure_reason = "max_output_tokens_exceeded"
+    elif ledger_rows and priced_calls != len(ledger_rows):
+        infrastructure_reason = "usd_cap_unenforceable_no_frozen_price"
+    elif total_cost > Decimal(budget.usd_cap):
+        infrastructure_reason = "usd_cap_exceeded"
+    route_integrity = {
+        "pass": not reasons,
+        "reasons": sorted(set(reasons)),
+    }
+    return calls, route_integrity, infrastructure_reason
+
+
+def _append_row(path: Path, row: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(
+        row, allow_nan=False, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ) + "\n"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+        handle.flush()
+        os.fsync(handle.fileno())
+    directory_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _run_cell(
+    *,
+    experiment: router_spec.RouterExperiment,
+    arm: router_spec.Arm,
+    plan: router_spec.RoutePlan,
+    secret_plan: router_spec.SecretPlan,
+    task: TaskProvenance,
+    block: ScheduleBlock,
+    attempt: int,
+    identity: results.CellIdentity,
+    server: proxy.CountingProxyServer,
+    proxy_base_url: str,
+    prices: Mapping[str, Price],
+    exec_mode: str,
+    adapters_dir: Path,
+) -> dict[str, Any]:
+    token = "cell-" + hashlib.sha256(
+        f"{results.make_router_cell_id(identity)}:{time.time_ns()}".encode()
+    ).hexdigest()[:32]
+    server.register_cell(token)
+    server.register_route(token, plan, secret_plan)
+    started = time.monotonic()
+    infrastructure_reason = None
+    adapter_result: dict[str, Any] = {}
+    seal = None
+    ledger_rows: list[dict[str, Any]] = []
+    route_integrity = {"pass": False, "reasons": ["ledger_not_sealed"]}
+    calls: list[dict[str, Any]] = []
+    checker_exit: int | str | None = None
+    checker_score = 0.0
+    checker_stdout = ""
+    checker_stderr = ""
+    with tempfile.TemporaryDirectory(prefix="obench_router_cell_") as temp:
+        cell_root = Path(temp)
+        workdir = cell_root / "workspace"
+        workdir.mkdir()
+        plan_path = cell_root / "route-plan.json"
+        instruction_path = cell_root / "instruction.txt"
+        plan_path.write_text(plan.canonical_json + "\n", encoding="utf-8")
+        instruction = read_instruction(str(task.path))
+        instruction_path.write_text(instruction, encoding="utf-8")
+        try:
+            materialize_workspace(str(task.path), str(workdir))
+            if _tree_digest(workdir) != task.workspace_source_sha:
+                raise RouterRunError("materialized workspace differs from frozen provenance")
+        except (WorkspaceError, RouterRunError) as exc:
+            infrastructure_reason = "workspace_materialization"
+            adapter_result = {"completed": False, "error": str(exc)}
+        else:
+            try:
+                adapter_result = _invoke_local(
+                    plan_path=plan_path,
+                    instruction_path=instruction_path,
+                    workdir=workdir,
+                    proxy_base_url=proxy_base_url,
+                    token=token,
+                    timeout_s=experiment.budget.timeout_s,
+                    adapters_dir=adapters_dir,
+                )
+            except Exception as exc:  # noqa: BLE001 - row records infra failure
+                infrastructure_reason = "adapter_entry_failure"
+                adapter_result = {"completed": False, "error": str(exc)}
+        try:
+            seal = server.seal_cell(token, timeout_s=10)
+            ledger_rows = _read_sealed_ledger(seal, arm.digest)
+            calls, route_integrity, budget_reason = _proxy_evidence(
+                ledger_rows, prices, experiment.budget, plan
+            )
+            infrastructure_reason = infrastructure_reason or budget_reason
+        except Exception as exc:  # noqa: BLE001 - sealing is evidence-critical
+            infrastructure_reason = infrastructure_reason or "ledger_seal_failure"
+            adapter_result.setdefault("error", str(exc))
+
+        if not ledger_rows and infrastructure_reason is None:
+            infrastructure_reason = "adapter_no_routed_calls"
+        if (
+            adapter_result.get("entry_timed_out")
+            and not ledger_rows
+            and infrastructure_reason is None
+        ):
+            infrastructure_reason = "adapter_entry_timeout"
+
+        # Checker authority begins only after the proxy has reached terminal state.
+        if seal is not None:
+            try:
+                checker_home = cell_root / "checker-home"
+                checker_home.mkdir()
+                checker_env = {
+                    key: os.environ[key]
+                    for key in ("PATH", "LANG", "LC_ALL", "TMPDIR")
+                    if os.environ.get(key)
+                }
+                checker_env["HOME"] = str(checker_home)
+                checker_exit, raw_score, checker_stdout, checker_stderr = run_checker(
+                    str(task.path), str(workdir), CHECKER_TIMEOUT_S, checker_env
+                )
+                checker_score = (
+                    1.0
+                    if checker_exit == 0
+                    else raw_score if raw_score is not None else 0.0
+                )
+                if checker_exit == "timeout":
+                    infrastructure_reason = infrastructure_reason or "checker_timeout"
+            except Exception as exc:  # noqa: BLE001
+                infrastructure_reason = infrastructure_reason or "checker_failure"
+                checker_stderr = str(exc)
+    duration = time.monotonic() - started
+    solved = checker_exit == 0
+    available = bool(ledger_rows) and all(
+        isinstance(row.get("status"), int) and 200 <= row["status"] < 300
+        for row in ledger_rows
+    )
+    timed_out = bool(adapter_result.get("entry_timed_out")) or "timeout" in str(
+        adapter_result.get("error", "")
+    ).lower()
+    if not adapter_result.get("completed", False) and not ledger_rows:
+        infrastructure_reason = infrastructure_reason or "adapter_failed_before_route"
+    failure_class = (
+        "infrastructure"
+        if infrastructure_reason is not None
+        else "treatment"
+        if not solved or not available or not adapter_result.get("completed", False)
+        else None
+    )
+    expected_arm_ids = [item.arm_id for item in experiment.arms]
+    row = {
+        "schema_version": results.CURRENT_SCHEMA_VERSION,
+        "benchmark": results.ROUTER_BENCHMARK,
+        "run_id": results.make_router_run_id(identity),
+        "cell_id": results.make_router_cell_id(identity),
+        "identity": identity.as_dict(),
+        "expected_arm_ids": expected_arm_ids,
+        "arm_role": arm.route_kind,
+        "baseline": arm.baseline,
+        "result": {
+            "solved": solved,
+            "checker_score": checker_score,
+            "available": available,
+            "duration_s": duration,
+            "timed_out": timed_out,
+            "infrastructure_invalid_reason": infrastructure_reason,
+            "failure_class": failure_class,
+            "adapter_completed": bool(adapter_result.get("completed", False)),
+            "adapter_error": adapter_result.get("error"),
+            "checker_exit": checker_exit,
+        },
+        "route_integrity": route_integrity,
+        "proxy_metrics": {"calls": calls},
+        "ledger_seal": (
+            {
+                "record_count": seal.record_count,
+                "last_sequence": seal.last_sequence,
+                "root_hash": seal.root_hash,
+                "ledger_file": seal.path.name,
+            }
+            if seal is not None
+            else None
+        ),
+        "checker": {
+            "stdout_tail": checker_stdout[-4000:],
+            "stderr_tail": checker_stderr[-4000:],
+        },
+        "route_isolation": {
+            "classification": "exploratory",
+            "lane": _lane(exec_mode),
+            "egress_enforced": False,
+        },
+        "schedule_order": list(block.arm_ids),
+        "block_attempt": attempt,
+    }
+    results.result_cell_id(row)
+    return row
+
+
+def validate_experiment(
+    experiment_path: str | os.PathLike[str],
+    *,
+    tasks_dir: str | os.PathLike[str],
+) -> tuple[router_spec.RouterExperiment, dict[str, TaskProvenance]]:
+    experiment = router_spec.load_experiment(experiment_path)
+    tasks = inspect_tasks(experiment, tasks_dir)
+    build_schedule(experiment)
+    return experiment, tasks
+
+
+def doctor_experiment(
+    experiment_path: str | os.PathLike[str],
+    *,
+    tasks_dir: str | os.PathLike[str],
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    environ = os.environ if environ is None else environ
+    experiment, tasks = validate_experiment(experiment_path, tasks_dir=tasks_dir)
+    admitted = {arm.auth_env for arm in experiment.arms}
+    router_spec.compile_route_plans(
+        experiment, environ=environ, admitted_auth_envs=admitted
+    )
+    prices, price_snapshot = _load_prices(environ)
+    version = pi.version()
+    if not version:
+        raise RouterRunError("Pi CLI is unavailable or did not report a version")
+    return {
+        "experiment_id": experiment.experiment_id,
+        "experiment_digest": experiment.digest,
+        "tasks": len(tasks),
+        "arms": len(experiment.arms),
+        "pi_version": version,
+        "prices": "frozen" if prices else "unavailable",
+        "usd_cap_enforceable": bool(prices),
+        "route_isolation": "exploratory",
+    }
+
+
+def run_experiment(
+    experiment_path: str | os.PathLike[str],
+    *,
+    results_path: str | os.PathLike[str],
+    tasks_dir: str | os.PathLike[str],
+    exec_mode: str | None = None,
+    force: bool = False,
+    environ: Mapping[str, str] | None = None,
+    adapters_dir: str | os.PathLike[str] | None = None,
+) -> RunSummary:
+    """Run or safely resume one Gateway Tax experiment."""
+    environ = os.environ if environ is None else environ
+    experiment, tasks = validate_experiment(experiment_path, tasks_dir=tasks_dir)
+    exec_mode = exec_mode or experiment.execution_lane
+    if exec_mode not in {"local", "docker"}:
+        raise RouterRunError("exec_mode must be 'local' or 'docker'")
+    if exec_mode == "docker":
+        raise RouterRunError(
+            "Docker Gateway Tax execution is exploratory and unsupported in this MVP"
+        )
+    admitted = {arm.auth_env for arm in experiment.arms}
+    plans, secret_plan = router_spec.compile_route_plans(
+        experiment, environ=environ, admitted_auth_envs=admitted
+    )
+    prices, price_snapshot = _load_prices(environ)
+    if not prices:
+        raise RouterRunError(
+            f"USD cap cannot be enforced without {FROZEN_PRICES_ENV}; refusing to run"
+        )
+    full_schedule = build_schedule(experiment)
+    schedule = _active_schedule(experiment, full_schedule)
+    if not schedule:
+        raise RouterRunError("no experiment window is currently active")
+    digests = _comparison_digests(experiment, full_schedule, price_snapshot)
+    path = Path(results_path).resolve()
+    persist_price_snapshot(path, price_snapshot)
+    state = results.read_jsonl_for_resume(path)
+    expected_arms = {arm.arm_id for arm in experiment.arms}
+    by_arm = {arm.arm_id: arm for arm in experiment.arms}
+    plans_by_arm = {plan.arm_id: plan for plan in plans}
+    version = pi.version() or "unknown"
+    image = None
+    _validate_resume_identities(
+        state,
+        experiment=experiment,
+        schedule=full_schedule,
+        tasks=tasks,
+        arms=by_arm,
+        digests=digests,
+        harness_version=version,
+        exec_mode=exec_mode,
+        image_digest=image,
+    )
+    attempts = _existing_attempts(state, experiment, expected_arms)
+    adapters = (
+        Path(adapters_dir).resolve()
+        if adapters_dir is not None
+        else Path(environ.get(ADAPTERS_DIR_ENV, Path(__file__).resolve().parent / "adapters"))
+        .resolve()
+    )
+    if not (adapters / "pi.py").is_file():
+        raise RouterRunError(f"Pi adapter not found in {adapters}")
+
+    ledger_dir = path.parent / f".{path.stem}.router-ledgers"
+    server, thread = proxy.start_in_thread(
+        "127.0.0.1",
+        0,
+        ledger_dir,
+        require_registered_tokens=False,
+        timeout_s=experiment.budget.timeout_s,
+    )
+    port = server.server_address[1]
+    local_base = f"http://127.0.0.1:{port}"
+    rows_appended = 0
+    blocks_completed = 0
+    blocks_replaced = 0
+    blocks_skipped = 0
+    try:
+        for block in schedule:
+            by_attempt = attempts.get(block.coordinate, {})
+            attempt, skipped = _next_attempt(by_attempt, expected_arms, force)
+            if skipped:
+                blocks_skipped += 1
+                continue
+            assert attempt is not None
+            if attempt > 0:
+                blocks_replaced += 1
+            block_rows = []
+            for arm_id in block.arm_ids:
+                arm = by_arm[arm_id]
+                identity = _identity(
+                    experiment=experiment,
+                    arm=arm,
+                    task=tasks[block.task],
+                    block=block,
+                    attempt=attempt,
+                    digests=digests,
+                    harness_version=version,
+                    exec_mode=exec_mode,
+                    image_digest=image,
+                )
+                row = _run_cell(
+                    experiment=experiment,
+                    arm=arm,
+                    plan=plans_by_arm[arm_id],
+                    secret_plan=secret_plan,
+                    task=tasks[block.task],
+                    block=block,
+                    attempt=attempt,
+                    identity=identity,
+                    server=server,
+                    proxy_base_url=local_base,
+                    prices=prices,
+                    exec_mode=exec_mode,
+                    adapters_dir=adapters,
+                )
+                _append_row(path, row)
+                rows_appended += 1
+                block_rows.append(row)
+            if _attempt_complete_and_valid(block_rows, expected_arms):
+                blocks_completed += 1
+            else:
+                raise RouterRunError(
+                    f"block {block.coordinate} attempt {attempt} is invalid; "
+                    "paid replacement requires an explicit rerun"
+                )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    return RunSummary(
+        results_path=path,
+        rows_appended=rows_appended,
+        blocks_completed=blocks_completed,
+        blocks_replaced=blocks_replaced,
+        blocks_skipped=blocks_skipped,
+    )

--- a/obench/router_run.py
+++ b/obench/router_run.py
@@ -251,6 +251,14 @@ def load_frozen_prices(
     return _load_prices(environ)
 
 
+def _missing_price_models(
+    experiment: router_spec.RouterExperiment,
+    prices: Mapping[str, Price],
+) -> list[str]:
+    required = {arm.canonical_model for arm in experiment.arms}
+    return sorted(required - set(prices))
+
+
 def _price_snapshot_path(results_path: Path) -> Path:
     return results_path.parent / f".{results_path.stem}.router-prices.json"
 
@@ -710,9 +718,12 @@ def _proxy_evidence(
     total_cost = Decimal(0)
     priced_calls = 0
     successful_calls = 0
+    auth_failure = False
     for row in ledger_rows:
         status = row.get("status")
         if isinstance(status, int) and 400 <= status <= 599:
+            if status in {401, 403, 407}:
+                auth_failure = True
             calls.append({
                 "timing": None,
                 "generation": None,
@@ -760,7 +771,9 @@ def _proxy_evidence(
             }
         )
     infrastructure_reason = None
-    if len(ledger_rows) > budget.max_calls:
+    if auth_failure:
+        infrastructure_reason = "upstream_auth_failure"
+    elif len(ledger_rows) > budget.max_calls:
         infrastructure_reason = "max_calls_exceeded"
     elif total_output > budget.max_output_tokens:
         infrastructure_reason = "max_output_tokens_exceeded"
@@ -989,6 +1002,7 @@ def doctor_experiment(
         experiment, environ=environ, admitted_auth_envs=admitted
     )
     prices, price_snapshot = _load_prices(environ)
+    missing_prices = _missing_price_models(experiment, prices)
     version = pi.version()
     if not version:
         raise RouterRunError("Pi CLI is unavailable or did not report a version")
@@ -998,8 +1012,9 @@ def doctor_experiment(
         "tasks": len(tasks),
         "arms": len(experiment.arms),
         "pi_version": version,
-        "prices": "frozen" if prices else "unavailable",
-        "usd_cap_enforceable": bool(prices),
+        "prices": "frozen" if prices and not missing_prices else "incomplete",
+        "missing_price_models": missing_prices,
+        "usd_cap_enforceable": bool(prices) and not missing_prices,
         "route_isolation": "exploratory",
     }
 
@@ -1032,6 +1047,12 @@ def run_experiment(
     if not prices:
         raise RouterRunError(
             f"USD cap cannot be enforced without {FROZEN_PRICES_ENV}; refusing to run"
+        )
+    missing_prices = _missing_price_models(experiment, prices)
+    if missing_prices:
+        raise RouterRunError(
+            "USD cap cannot be enforced; frozen prices are missing: "
+            + ", ".join(missing_prices)
         )
     full_schedule = build_schedule(experiment)
     schedule = _active_schedule(experiment, full_schedule)

--- a/obench/router_spec.py
+++ b/obench/router_spec.py
@@ -117,6 +117,7 @@ class Arm:
     endpoint: str
     protocol: str
     baseline: bool
+    canonical_model: str
     requested_model: str
     requested_provider: str
     allowed_models: tuple[str, ...]
@@ -135,6 +136,7 @@ class Arm:
             "endpoint": self.endpoint,
             "protocol": self.protocol,
             "baseline": self.baseline,
+            "canonical_model": self.canonical_model,
             "requested_model": self.requested_model,
             "requested_provider": self.requested_provider,
             "allowed_models": list(self.allowed_models),
@@ -207,6 +209,7 @@ class RoutePlan:
     route_kind: str
     endpoint: str
     protocol: str
+    canonical_model: str
     requested_model: str
     requested_provider: str
     allowed_models: tuple[str, ...]
@@ -229,6 +232,7 @@ class RoutePlan:
             "route_kind": self.route_kind,
             "endpoint": self.endpoint,
             "protocol": self.protocol,
+            "canonical_model": self.canonical_model,
             "requested_model": self.requested_model,
             "requested_provider": self.requested_provider,
             "allowed_models": list(self.allowed_models),
@@ -293,7 +297,7 @@ _BUDGET_FIELDS = {"timeout_s", "max_calls", "max_output_tokens", "usd_cap"}
 _SAMPLING_FIELDS = {"temperature", "top_p", "seed"}
 _ARM_FIELDS = {
     "arm_id", "route_kind", "endpoint", "protocol", "baseline",
-    "requested_model", "requested_provider", "allowed_models",
+    "canonical_model", "requested_model", "requested_provider", "allowed_models",
     "allowed_providers", "fallback_enabled", "retry_count", "cache_enabled",
     "auth_env", "sampling", "direct_control_arm_id",
 }
@@ -509,6 +513,8 @@ def _parse_arm(
                                     private_hosts, private_cidrs),
         protocol=protocol,
         baseline=_boolean(_required(table, "baseline", path), f"{path}.baseline"),
+        canonical_model=_string(_required(table, "canonical_model", path),
+                                f"{path}.canonical_model"),
         requested_model=_string(_required(table, "requested_model", path),
                                 f"{path}.requested_model"),
         requested_provider=_string(_required(table, "requested_provider", path),
@@ -565,7 +571,7 @@ def _validate_gateway_controls(arms: tuple[Arm, ...]) -> None:
                 f"{arm.direct_control_arm_id!r}"
             )
         comparable = (
-            "protocol", "requested_model", "requested_provider", "allowed_models",
+            "protocol", "canonical_model", "requested_provider",
             "allowed_providers", "sampling",
         )
         for field in comparable:
@@ -735,6 +741,7 @@ def compile_route_plans(
             route_kind=arm.route_kind,
             endpoint=arm.endpoint,
             protocol=arm.protocol,
+            canonical_model=arm.canonical_model,
             requested_model=arm.requested_model,
             requested_provider=arm.requested_provider,
             allowed_models=arm.allowed_models,

--- a/obench/router_spec.py
+++ b/obench/router_spec.py
@@ -537,6 +537,10 @@ def _parse_arm(
         raise RouterSpecError(f"{path}.allowed_models must contain requested_model")
     if arm.requested_provider not in arm.allowed_providers:
         raise RouterSpecError(f"{path}.allowed_providers must contain requested_provider")
+    if arm.allowed_providers != (arm.requested_provider,):
+        raise RouterSpecError(
+            f"{path}.allowed_providers must contain only requested_provider"
+        )
     if arm.route_kind == "direct" and arm.direct_control_arm_id is not None:
         raise RouterSpecError(f"{path}: direct arm cannot set direct_control_arm_id")
     if arm.route_kind == "gateway" and arm.direct_control_arm_id is None:

--- a/obench/router_spec.py
+++ b/obench/router_spec.py
@@ -1,0 +1,757 @@
+"""Immutable Router Bench experiment schema and route-plan compilation.
+
+The MVP intentionally accepts only the Pi/OpenAI Chat ``gateway_tax`` track.
+TOML contains credential environment-variable names; credential values enter an
+in-memory ``SecretPlan`` only after explicit admission.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as dt
+import hashlib
+import ipaddress
+import json
+import math
+import os
+import re
+import tomllib
+import urllib.parse
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+TRACK = "gateway_tax"
+HARNESS = "pi"
+PROTOCOL = "openai_chat"
+
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_./@:-]*$")
+_ENV_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_HOST_LABEL_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+_RFC3339_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+class RouterSpecError(ValueError):
+    """Raised when a Router Bench experiment is malformed or unsafe."""
+
+
+def _canonical_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise RouterSpecError("canonical JSON does not permit non-finite numbers")
+        return value
+    if isinstance(value, Decimal):
+        return _decimal_text(value)
+    if isinstance(value, (list, tuple)):
+        return [_canonical_value(item) for item in value]
+    if isinstance(value, Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise RouterSpecError("canonical JSON object keys must be strings")
+        return {key: _canonical_value(item) for key, item in value.items()}
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        return _canonical_value(to_dict())
+    raise TypeError(f"unsupported canonical JSON value: {type(value).__name__}")
+
+
+def canonical_json(value: Any) -> str:
+    """Return deterministic UTF-8 JSON text for public, nonsecret objects."""
+    return json.dumps(
+        _canonical_value(value),
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def canonical_digest(value: Any) -> str:
+    """Return the SHA-256 hex digest of ``canonical_json(value)``."""
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class Window:
+    window_id: str
+    start: str
+    end: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class Budget:
+    timeout_s: int
+    max_calls: int
+    max_output_tokens: int
+    usd_cap: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class Sampling:
+    temperature: float
+    top_p: float
+    seed: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class Arm:
+    arm_id: str
+    route_kind: str
+    endpoint: str
+    protocol: str
+    baseline: bool
+    requested_model: str
+    requested_provider: str
+    allowed_models: tuple[str, ...]
+    allowed_providers: tuple[str, ...]
+    fallback_enabled: bool
+    retry_count: int
+    cache_enabled: bool
+    auth_env: str
+    sampling: Sampling
+    direct_control_arm_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "arm_id": self.arm_id,
+            "route_kind": self.route_kind,
+            "endpoint": self.endpoint,
+            "protocol": self.protocol,
+            "baseline": self.baseline,
+            "requested_model": self.requested_model,
+            "requested_provider": self.requested_provider,
+            "allowed_models": list(self.allowed_models),
+            "allowed_providers": list(self.allowed_providers),
+            "fallback_enabled": self.fallback_enabled,
+            "retry_count": self.retry_count,
+            "cache_enabled": self.cache_enabled,
+            "auth_env": self.auth_env,
+            "sampling": self.sampling.to_dict(),
+            "direct_control_arm_id": self.direct_control_arm_id,
+        }
+
+    @property
+    def digest(self) -> str:
+        return canonical_digest(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RouterExperiment:
+    schema_version: int
+    experiment_id: str
+    track: str
+    harness: str
+    tasks: tuple[str, ...]
+    repetitions_per_window: int
+    schedule_seed: int
+    execution_lane: str
+    private_router: bool
+    private_host_allowlist: tuple[str, ...]
+    private_cidr_allowlist: tuple[str, ...]
+    windows: tuple[Window, ...]
+    budget: Budget
+    arms: tuple[Arm, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "experiment_id": self.experiment_id,
+            "track": self.track,
+            "harness": self.harness,
+            "tasks": list(self.tasks),
+            "repetitions_per_window": self.repetitions_per_window,
+            "schedule_seed": self.schedule_seed,
+            "execution_lane": self.execution_lane,
+            "private_router": self.private_router,
+            "private_host_allowlist": list(self.private_host_allowlist),
+            "private_cidr_allowlist": list(self.private_cidr_allowlist),
+            "windows": [window.to_dict() for window in self.windows],
+            "budget": self.budget.to_dict(),
+            "arms": [arm.to_dict() for arm in self.arms],
+        }
+
+    @property
+    def canonical_json(self) -> str:
+        return canonical_json(self)
+
+    @property
+    def digest(self) -> str:
+        return canonical_digest(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RoutePlan:
+    """Sanitized plan that may be persisted and passed to an adapter."""
+
+    schema_version: int
+    experiment_digest: str
+    arm_digest: str
+    arm_id: str
+    route_kind: str
+    endpoint: str
+    protocol: str
+    requested_model: str
+    requested_provider: str
+    allowed_models: tuple[str, ...]
+    allowed_providers: tuple[str, ...]
+    fallback_enabled: bool
+    retry_count: int
+    cache_enabled: bool
+    auth_env: str
+    sampling: Sampling
+    private_router: bool
+    private_host_allowlist: tuple[str, ...]
+    private_cidr_allowlist: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "experiment_digest": self.experiment_digest,
+            "arm_digest": self.arm_digest,
+            "arm_id": self.arm_id,
+            "route_kind": self.route_kind,
+            "endpoint": self.endpoint,
+            "protocol": self.protocol,
+            "requested_model": self.requested_model,
+            "requested_provider": self.requested_provider,
+            "allowed_models": list(self.allowed_models),
+            "allowed_providers": list(self.allowed_providers),
+            "fallback_enabled": self.fallback_enabled,
+            "retry_count": self.retry_count,
+            "cache_enabled": self.cache_enabled,
+            "auth_env": self.auth_env,
+            "sampling": self.sampling.to_dict(),
+            "private_router": self.private_router,
+            "private_host_allowlist": list(self.private_host_allowlist),
+            "private_cidr_allowlist": list(self.private_cidr_allowlist),
+        }
+
+    @property
+    def canonical_json(self) -> str:
+        return canonical_json(self)
+
+    @property
+    def digest(self) -> str:
+        return canonical_digest(self)
+
+
+@dataclass(frozen=True, repr=False, slots=True)
+class _ArmSecret:
+    arm_id: str
+    env_name: str
+    value: str = dataclasses.field(repr=False)
+
+
+@dataclass(frozen=True, repr=False, slots=True)
+class SecretPlan:
+    """Credential material that must remain in memory and must not be serialized."""
+
+    _secrets: tuple[_ArmSecret, ...]
+
+    def value_for(self, arm_id: str) -> str:
+        for secret in self._secrets:
+            if secret.arm_id == arm_id:
+                return secret.value
+        raise KeyError(arm_id)
+
+    def env_name_for(self, arm_id: str) -> str:
+        for secret in self._secrets:
+            if secret.arm_id == arm_id:
+                return secret.env_name
+        raise KeyError(arm_id)
+
+    def __repr__(self) -> str:
+        arms = ", ".join(secret.arm_id for secret in self._secrets)
+        return f"SecretPlan(arms=[{arms}], values=<redacted>)"
+
+
+_ROOT_FIELDS = {
+    "schema_version", "experiment_id", "track", "harness", "tasks",
+    "repetitions_per_window", "schedule_seed", "execution_lane",
+    "private_router", "private_host_allowlist", "private_cidr_allowlist",
+    "windows", "budget", "arms",
+}
+_WINDOW_FIELDS = {"window_id", "start", "end"}
+_BUDGET_FIELDS = {"timeout_s", "max_calls", "max_output_tokens", "usd_cap"}
+_SAMPLING_FIELDS = {"temperature", "top_p", "seed"}
+_ARM_FIELDS = {
+    "arm_id", "route_kind", "endpoint", "protocol", "baseline",
+    "requested_model", "requested_provider", "allowed_models",
+    "allowed_providers", "fallback_enabled", "retry_count", "cache_enabled",
+    "auth_env", "sampling", "direct_control_arm_id",
+}
+
+
+def _table(value: Any, path: str, fields: set[str]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RouterSpecError(f"{path} must be a TOML table")
+    unknown = sorted(set(value) - fields)
+    if unknown:
+        noun = "field" if len(unknown) == 1 else "fields"
+        raise RouterSpecError(f"{path} has unknown {noun}: {', '.join(unknown)}")
+    return value
+
+
+def _required(table: Mapping[str, Any], key: str, path: str) -> Any:
+    if key not in table:
+        raise RouterSpecError(f"{path} missing required field: {key}")
+    return table[key]
+
+
+def _string(value: Any, path: str, pattern: re.Pattern[str] | None = None) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RouterSpecError(f"{path} must be a non-empty string")
+    result = value.strip()
+    if pattern is not None and not pattern.fullmatch(result):
+        raise RouterSpecError(f"{path} has invalid format: {result!r}")
+    return result
+
+
+def _integer(value: Any, path: str, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RouterSpecError(f"{path} must be an integer")
+    if minimum is not None and value < minimum:
+        raise RouterSpecError(f"{path} must be at least {minimum}")
+    return value
+
+
+def _boolean(value: Any, path: str) -> bool:
+    if not isinstance(value, bool):
+        raise RouterSpecError(f"{path} must be a boolean")
+    return value
+
+
+def _string_tuple(value: Any, path: str, *, pattern: re.Pattern[str] | None = None) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise RouterSpecError(f"{path} must be a non-empty array")
+    result = tuple(_string(item, f"{path}[{index}]", pattern)
+                   for index, item in enumerate(value))
+    if len(set(result)) != len(result):
+        raise RouterSpecError(f"{path} must not contain duplicates")
+    return result
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    return "0" if text in {"-0", ""} else text
+
+
+def _positive_decimal(value: Any, path: str) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise RouterSpecError(f"{path} must be a positive decimal")
+    try:
+        parsed = Decimal(str(value))
+    except InvalidOperation as exc:
+        raise RouterSpecError(f"{path} must be a positive decimal") from exc
+    if not parsed.is_finite() or parsed <= 0:
+        raise RouterSpecError(f"{path} must be greater than zero")
+    return _decimal_text(parsed)
+
+
+def _timestamp(value: Any, path: str) -> tuple[str, dt.datetime]:
+    text = _string(value, path)
+    if not _RFC3339_RE.fullmatch(text):
+        raise RouterSpecError(f"{path} must be an RFC3339 timestamp")
+    try:
+        parsed = dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RouterSpecError(f"{path} must be an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise RouterSpecError(f"{path} must include a UTC offset")
+    utc = parsed.astimezone(dt.timezone.utc)
+    normalized = utc.isoformat().replace("+00:00", "Z")
+    return normalized, utc
+
+
+def _parse_windows(value: Any) -> tuple[Window, ...]:
+    if not isinstance(value, list) or not value:
+        raise RouterSpecError("windows must be a non-empty array of tables")
+    parsed: list[tuple[Window, dt.datetime, dt.datetime]] = []
+    ids: set[str] = set()
+    for index, raw in enumerate(value):
+        path = f"windows[{index}]"
+        table = _table(raw, path, _WINDOW_FIELDS)
+        window_id = _string(_required(table, "window_id", path),
+                            f"{path}.window_id", _ID_RE)
+        if window_id in ids:
+            raise RouterSpecError(f"windows has duplicate window_id: {window_id}")
+        ids.add(window_id)
+        start_text, start = _timestamp(_required(table, "start", path), f"{path}.start")
+        end_text, end = _timestamp(_required(table, "end", path), f"{path}.end")
+        if start >= end:
+            raise RouterSpecError(f"{path} start must be before end")
+        parsed.append((Window(window_id, start_text, end_text), start, end))
+    ordered = sorted(parsed, key=lambda item: item[1])
+    for previous, current in zip(ordered, ordered[1:]):
+        if current[1] < previous[2]:
+            raise RouterSpecError(
+                f"windows overlap: {previous[0].window_id} and {current[0].window_id}"
+            )
+    return tuple(item[0] for item in parsed)
+
+
+def _parse_budget(value: Any) -> Budget:
+    table = _table(value, "budget", _BUDGET_FIELDS)
+    return Budget(
+        timeout_s=_integer(_required(table, "timeout_s", "budget"),
+                           "budget.timeout_s", minimum=1),
+        max_calls=_integer(_required(table, "max_calls", "budget"),
+                           "budget.max_calls", minimum=1),
+        max_output_tokens=_integer(_required(table, "max_output_tokens", "budget"),
+                                   "budget.max_output_tokens", minimum=1),
+        usd_cap=_positive_decimal(_required(table, "usd_cap", "budget"),
+                                  "budget.usd_cap"),
+    )
+
+
+def _number(value: Any, path: str, minimum: float, maximum: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RouterSpecError(f"{path} must be a number")
+    result = float(value)
+    if not math.isfinite(result) or not minimum <= result <= maximum:
+        raise RouterSpecError(f"{path} must be between {minimum} and {maximum}")
+    return result
+
+
+def _parse_sampling(value: Any, path: str) -> Sampling:
+    table = _table(value, path, _SAMPLING_FIELDS)
+    return Sampling(
+        temperature=_number(_required(table, "temperature", path),
+                            f"{path}.temperature", 0.0, 2.0),
+        top_p=_number(_required(table, "top_p", path),
+                      f"{path}.top_p", 0.0, 1.0),
+        seed=_integer(_required(table, "seed", path), f"{path}.seed", minimum=0),
+    )
+
+
+def _validate_endpoint(
+    value: Any,
+    path: str,
+    private_router: bool,
+    private_hosts: tuple[str, ...],
+    private_cidrs: tuple[str, ...],
+) -> str:
+    endpoint = _string(value, path)
+    parsed = urllib.parse.urlsplit(endpoint)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise RouterSpecError(f"{path} must be an absolute HTTPS URL")
+    if parsed.username or parsed.password or parsed.fragment or parsed.query:
+        raise RouterSpecError(f"{path} must not contain credentials, query, or fragment")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise RouterSpecError(f"{path} has an invalid port") from exc
+    hostname = _normalize_hostname(parsed.hostname, path, allow_ip=True)
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        address = None
+    if address is None:
+        if (hostname == "localhost" or hostname.endswith(".localhost")
+                or "." not in hostname or hostname.isdigit()):
+            if not private_router or hostname not in private_hosts:
+                raise RouterSpecError(
+                    f"{path} is not a public hostname; set private_router and allow it explicitly"
+                )
+    elif not address.is_global:
+        if not private_router:
+            raise RouterSpecError(
+                f"{path} targets a non-public address; set private_router with allowlists"
+            )
+        networks = tuple(ipaddress.ip_network(cidr) for cidr in private_cidrs)
+        if hostname not in private_hosts and not any(address in network for network in networks):
+            raise RouterSpecError(
+                f"{path} address is not covered by a private router allowlist"
+            )
+    return endpoint
+
+
+def _parse_arm(
+    value: Any,
+    index: int,
+    private_router: bool,
+    private_hosts: tuple[str, ...],
+    private_cidrs: tuple[str, ...],
+) -> Arm:
+    path = f"arms[{index}]"
+    table = _table(value, path, _ARM_FIELDS)
+    route_kind = _string(_required(table, "route_kind", path), f"{path}.route_kind")
+    if route_kind not in {"direct", "gateway"}:
+        raise RouterSpecError(f"{path}.route_kind must be 'direct' or 'gateway'")
+    protocol = _string(_required(table, "protocol", path), f"{path}.protocol")
+    if protocol != PROTOCOL:
+        raise RouterSpecError(f"{path}.protocol must be {PROTOCOL!r} for the MVP")
+    direct_control = table.get("direct_control_arm_id")
+    if direct_control is not None:
+        direct_control = _string(direct_control, f"{path}.direct_control_arm_id", _ID_RE)
+    arm = Arm(
+        arm_id=_string(_required(table, "arm_id", path), f"{path}.arm_id", _ID_RE),
+        route_kind=route_kind,
+        endpoint=_validate_endpoint(_required(table, "endpoint", path),
+                                    f"{path}.endpoint", private_router,
+                                    private_hosts, private_cidrs),
+        protocol=protocol,
+        baseline=_boolean(_required(table, "baseline", path), f"{path}.baseline"),
+        requested_model=_string(_required(table, "requested_model", path),
+                                f"{path}.requested_model"),
+        requested_provider=_string(_required(table, "requested_provider", path),
+                                   f"{path}.requested_provider", _ID_RE),
+        allowed_models=_string_tuple(_required(table, "allowed_models", path),
+                                     f"{path}.allowed_models"),
+        allowed_providers=_string_tuple(_required(table, "allowed_providers", path),
+                                        f"{path}.allowed_providers", pattern=_ID_RE),
+        fallback_enabled=_boolean(_required(table, "fallback_enabled", path),
+                                  f"{path}.fallback_enabled"),
+        retry_count=_integer(_required(table, "retry_count", path),
+                             f"{path}.retry_count", minimum=0),
+        cache_enabled=_boolean(_required(table, "cache_enabled", path),
+                               f"{path}.cache_enabled"),
+        auth_env=_string(_required(table, "auth_env", path), f"{path}.auth_env", _ENV_RE),
+        sampling=_parse_sampling(_required(table, "sampling", path), f"{path}.sampling"),
+        direct_control_arm_id=direct_control,
+    )
+    if arm.requested_model not in arm.allowed_models:
+        raise RouterSpecError(f"{path}.allowed_models must contain requested_model")
+    if arm.requested_provider not in arm.allowed_providers:
+        raise RouterSpecError(f"{path}.allowed_providers must contain requested_provider")
+    if arm.route_kind == "direct" and arm.direct_control_arm_id is not None:
+        raise RouterSpecError(f"{path}: direct arm cannot set direct_control_arm_id")
+    if arm.route_kind == "gateway" and arm.direct_control_arm_id is None:
+        raise RouterSpecError(f"{path}: gateway arm requires direct_control_arm_id")
+    if arm.fallback_enabled:
+        raise RouterSpecError(f"{path}.fallback_enabled must be false for gateway_tax")
+    if arm.retry_count != 0:
+        raise RouterSpecError(f"{path}.retry_count must be 0 for gateway_tax")
+    if arm.cache_enabled:
+        raise RouterSpecError(f"{path}.cache_enabled must be false for gateway_tax")
+    return arm
+
+
+def _validate_gateway_controls(arms: tuple[Arm, ...]) -> None:
+    by_id = {arm.arm_id: arm for arm in arms}
+    if len(by_id) != len(arms):
+        raise RouterSpecError("arms must have unique arm_id values")
+    baselines = [arm for arm in arms if arm.baseline]
+    if len(baselines) != 1 or baselines[0].route_kind != "direct":
+        raise RouterSpecError("gateway_tax requires exactly one baseline direct arm")
+    if not any(arm.route_kind == "gateway" for arm in arms):
+        raise RouterSpecError("gateway_tax requires at least one gateway arm")
+    for arm in arms:
+        if arm.route_kind == "direct" and not arm.baseline:
+            raise RouterSpecError("gateway_tax direct arm must be the baseline")
+        if arm.route_kind != "gateway":
+            continue
+        control = by_id.get(arm.direct_control_arm_id)
+        if control is None or control.route_kind != "direct":
+            raise RouterSpecError(
+                f"arm {arm.arm_id!r} references unknown direct control "
+                f"{arm.direct_control_arm_id!r}"
+            )
+        comparable = (
+            "protocol", "requested_model", "requested_provider", "allowed_models",
+            "allowed_providers", "sampling",
+        )
+        for field in comparable:
+            if getattr(arm, field) != getattr(control, field):
+                raise RouterSpecError(
+                    f"arm {arm.arm_id!r} {field} must match direct control {control.arm_id!r}"
+                )
+
+
+def _parse_allowlists(table: Mapping[str, Any], private_router: bool) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    hosts_raw = table.get("private_host_allowlist", [])
+    cidrs_raw = table.get("private_cidr_allowlist", [])
+    if not isinstance(hosts_raw, list) or any(not isinstance(item, str) for item in hosts_raw):
+        raise RouterSpecError("private_host_allowlist must be an array of hostnames")
+    hosts = tuple(
+        _normalize_hostname(item, f"private_host_allowlist[{index}]")
+        for index, item in enumerate(hosts_raw)
+    )
+    if len(set(hosts)) != len(hosts):
+        raise RouterSpecError("private_host_allowlist must not contain duplicates")
+    if not isinstance(cidrs_raw, list) or any(not isinstance(item, str) for item in cidrs_raw):
+        raise RouterSpecError("private_cidr_allowlist must be an array of CIDRs")
+    cidrs: list[str] = []
+    for item in cidrs_raw:
+        try:
+            cidrs.append(str(ipaddress.ip_network(item, strict=True)))
+        except ValueError as exc:
+            raise RouterSpecError(f"invalid private_cidr_allowlist entry: {item!r}") from exc
+    if len(set(cidrs)) != len(cidrs):
+        raise RouterSpecError("private_cidr_allowlist must not contain duplicates")
+    if private_router and not (hosts or cidrs):
+        raise RouterSpecError("private_router=true requires a hostname or CIDR allowlist")
+    if not private_router and (hosts or cidrs):
+        raise RouterSpecError("private router allowlists require private_router=true")
+    return hosts, tuple(cidrs)
+
+
+def _normalize_hostname(value: str, path: str, *, allow_ip: bool = False) -> str:
+    hostname = value.strip().rstrip(".").lower()
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        if allow_ip:
+            return hostname
+        raise RouterSpecError(f"{path} must use private_cidr_allowlist for IP addresses")
+    labels = hostname.split(".")
+    if (not hostname or len(hostname) > 253 or hostname.isdigit()
+            or any(not _HOST_LABEL_RE.fullmatch(label) for label in labels)):
+        raise RouterSpecError(f"{path} must be a bare DNS hostname")
+    return hostname
+
+
+def parse_experiment(data: Mapping[str, Any]) -> RouterExperiment:
+    """Validate an already-decoded TOML experiment mapping."""
+    table = _table(data, "experiment", _ROOT_FIELDS)
+    schema_version = _integer(_required(table, "schema_version", "experiment"),
+                              "schema_version", minimum=1)
+    if schema_version != SCHEMA_VERSION:
+        raise RouterSpecError(f"schema_version must be {SCHEMA_VERSION}")
+    track = _string(_required(table, "track", "experiment"), "track")
+    if track != TRACK:
+        raise RouterSpecError(f"track must be {TRACK!r} for the MVP")
+    harness = _string(_required(table, "harness", "experiment"), "harness")
+    if harness != HARNESS:
+        raise RouterSpecError(f"harness must be {HARNESS!r} for the MVP")
+    private_router = _boolean(table.get("private_router", False), "private_router")
+    hosts, cidrs = _parse_allowlists(table, private_router)
+    tasks = _string_tuple(_required(table, "tasks", "experiment"), "tasks", pattern=_TASK_RE)
+    if any(".." in task.split("/") for task in tasks):
+        raise RouterSpecError("tasks must not contain '..' path segments")
+    raw_arms = _required(table, "arms", "experiment")
+    if not isinstance(raw_arms, list) or len(raw_arms) < 2:
+        raise RouterSpecError("arms must contain at least two arm tables")
+    arms = tuple(_parse_arm(raw, index, private_router, hosts, cidrs)
+                 for index, raw in enumerate(raw_arms))
+    _validate_gateway_controls(arms)
+    lane = _string(_required(table, "execution_lane", "experiment"), "execution_lane")
+    if lane not in {"local", "docker"}:
+        raise RouterSpecError("execution_lane must be 'local' or 'docker'")
+    return RouterExperiment(
+        schema_version=schema_version,
+        experiment_id=_string(_required(table, "experiment_id", "experiment"),
+                              "experiment_id", _ID_RE),
+        track=track,
+        harness=harness,
+        tasks=tasks,
+        repetitions_per_window=_integer(
+            _required(table, "repetitions_per_window", "experiment"),
+            "repetitions_per_window", minimum=1,
+        ),
+        schedule_seed=_integer(_required(table, "schedule_seed", "experiment"),
+                               "schedule_seed", minimum=0),
+        execution_lane=lane,
+        private_router=private_router,
+        private_host_allowlist=hosts,
+        private_cidr_allowlist=cidrs,
+        windows=_parse_windows(_required(table, "windows", "experiment")),
+        budget=_parse_budget(_required(table, "budget", "experiment")),
+        arms=arms,
+    )
+
+
+def parse_experiment_toml(text: str, *, source: str = "<string>") -> RouterExperiment:
+    """Decode and validate Router Bench TOML text."""
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    try:
+        raw = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise RouterSpecError(f"invalid Router Bench TOML in {source}: {exc}") from exc
+    try:
+        return parse_experiment(raw)
+    except RouterSpecError as exc:
+        raise RouterSpecError(f"invalid Router Bench experiment in {source}: {exc}") from exc
+
+
+def load_experiment(path: str | os.PathLike[str]) -> RouterExperiment:
+    """Load and validate a Router Bench experiment TOML file."""
+    resolved = Path(path)
+    try:
+        text = resolved.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise RouterSpecError(f"cannot read Router Bench experiment {resolved}: {exc}") from exc
+    return parse_experiment_toml(text, source=str(resolved))
+
+
+def compile_route_plans(
+    experiment: RouterExperiment,
+    *,
+    environ: Mapping[str, str],
+    admitted_auth_envs: set[str] | frozenset[str],
+) -> tuple[tuple[RoutePlan, ...], SecretPlan]:
+    """Compile sanitized route plans and admitted in-memory credentials."""
+    if not isinstance(experiment, RouterExperiment):
+        raise TypeError("experiment must be a RouterExperiment")
+    # Public dataclasses are convenient value types, but parsing remains the
+    # validation boundary. Reparse here so hand-built instances cannot bypass it.
+    experiment = parse_experiment(experiment.to_dict())
+    admitted = frozenset(admitted_auth_envs)
+    if any(not isinstance(name, str) for name in admitted):
+        raise RouterSpecError("admitted_auth_envs must contain environment variable names")
+    declared = frozenset(arm.auth_env for arm in experiment.arms)
+    unexpected = sorted(admitted - declared)
+    if unexpected:
+        raise RouterSpecError(
+            f"admitted_auth_envs contains undeclared names: {', '.join(unexpected)}"
+        )
+    plans: list[RoutePlan] = []
+    secrets: list[_ArmSecret] = []
+    for arm in experiment.arms:
+        if arm.auth_env not in admitted:
+            raise RouterSpecError(
+                f"auth environment variable {arm.auth_env!r} is not explicitly admitted"
+            )
+        value = environ.get(arm.auth_env)
+        if not isinstance(value, str) or not value:
+            raise RouterSpecError(
+                f"auth environment variable {arm.auth_env!r} is missing or empty"
+            )
+        plans.append(RoutePlan(
+            schema_version=SCHEMA_VERSION,
+            experiment_digest=experiment.digest,
+            arm_digest=arm.digest,
+            arm_id=arm.arm_id,
+            route_kind=arm.route_kind,
+            endpoint=arm.endpoint,
+            protocol=arm.protocol,
+            requested_model=arm.requested_model,
+            requested_provider=arm.requested_provider,
+            allowed_models=arm.allowed_models,
+            allowed_providers=arm.allowed_providers,
+            fallback_enabled=arm.fallback_enabled,
+            retry_count=arm.retry_count,
+            cache_enabled=arm.cache_enabled,
+            auth_env=arm.auth_env,
+            sampling=arm.sampling,
+            private_router=experiment.private_router,
+            private_host_allowlist=experiment.private_host_allowlist,
+            private_cidr_allowlist=experiment.private_cidr_allowlist,
+        ))
+        secrets.append(_ArmSecret(arm.arm_id, arm.auth_env, value))
+    return tuple(plans), SecretPlan(tuple(secrets))
+
+
+# Explicit aliases make call sites readable while retaining one parser contract.
+load_router_experiment = load_experiment
+parse_router_experiment = parse_experiment

--- a/obench/run.py
+++ b/obench/run.py
@@ -1026,7 +1026,7 @@ def _close_pipe(pipe):
         pass
 
 
-def run_checker(task_dir, workdir, timeout_s):
+def run_checker(task_dir, workdir, timeout_s, checker_env=None):
     """Run ``<task_dir>/checker.sh`` with cwd=workdir and TASK_DIR set.
 
     Returns ``(checker_exit, raw_score, stdout, stderr)`` where
@@ -1034,9 +1034,10 @@ def run_checker(task_dir, workdir, timeout_s):
     ``raw_score`` is the float from the checker's last parseable ``SCORE:`` line,
     or None if it printed none. Captured stdout/stderr are bounded tails. The
     checker decides task success (exit 0 == success); the adapter never does.
+    ``checker_env`` may provide a caller-owned sanitized environment.
     """
     checker = os.path.join(task_dir, "checker.sh")
-    env = dict(os.environ)
+    env = dict(os.environ) if checker_env is None else dict(checker_env)
     env["TASK_DIR"] = os.path.abspath(task_dir)
     env.pop("OPENBENCH_SOLUTION_OVERLAY", None)
     stdout_capture = TailCapture()

--- a/obench/tests/test_grokbuild_adapter.py
+++ b/obench/tests/test_grokbuild_adapter.py
@@ -273,6 +273,7 @@ class TestRunConstruction(unittest.TestCase):
                     "DEEPSEEK_API_KEY": "deepseek-test",
                     "ZAI_API_KEY": "zai-test",
                     "MOONSHOT_API_KEY": "moonshot-test",
+                    "CLIPROXYAPI_API_KEY": "ob-test-synthetic-ingress",
                     # This sentinel must be stripped from the gpt-5.6 child.
                     "OPENAI_API_KEY": "must-not-reach-subbridge",
                 })
@@ -311,7 +312,7 @@ class TestRunConstruction(unittest.TestCase):
             self.assertEqual(kwargs["env"]["GROK_SUBAGENTS"], "0")
             if model == "gpt-5.6-sol":
                 self.assertNotIn("OPENAI_API_KEY", kwargs["env"])
-                self.assertEqual(kwargs["env"]["CLIPROXYAPI_API_KEY"], "openbench-local-ingress")
+                self.assertEqual(kwargs["env"]["CLIPROXYAPI_API_KEY"], "ob-test-synthetic-ingress")
             self.assertIn(f'model = "{spec["model_id"]}"', cfg)
             self.assertIn(f'base_url = "{spec["base_url"]}"', cfg)
             self.assertIn(f'env_key = "{spec["env_key"]}"', cfg)

--- a/obench/tests/test_pi_routed.py
+++ b/obench/tests/test_pi_routed.py
@@ -1,0 +1,124 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from obench import entry
+from obench.adapters import pi
+from obench.router_spec import RoutePlan, RouterSpecError, Sampling
+
+
+def plan_dict(**updates):
+    plan = RoutePlan(
+        schema_version=1,
+        experiment_digest="a" * 64,
+        arm_digest="b" * 64,
+        arm_id="gateway",
+        route_kind="gateway",
+        endpoint="https://openrouter.ai/api/v1/chat/completions",
+        protocol="openai_chat",
+        requested_model="vendor/model-new",
+        requested_provider="provider-a",
+        allowed_models=("vendor/model-new",),
+        allowed_providers=("provider-a",),
+        fallback_enabled=False,
+        retry_count=0,
+        cache_enabled=False,
+        auth_env="ROUTER_API_KEY",
+        sampling=Sampling(0.25, 0.9, 42),
+        private_router=False,
+        private_host_allowlist=(),
+        private_cidr_allowlist=(),
+    ).to_dict()
+    plan.update(updates)
+    return plan
+
+
+class PiRoutedTests(unittest.TestCase):
+    def _write_plan(self, directory, data=None):
+        path = Path(directory, "route-plan.json")
+        path.write_text(json.dumps(data or plan_dict()), encoding="utf-8")
+        return str(path)
+
+    def test_capabilities_are_strict_v2(self):
+        self.assertEqual(pi.ADAPTER_API_VERSION, 2)
+        self.assertEqual(pi.ROUTED_CAPABILITIES, {
+            "protocols": ["openai_chat"],
+            "execution_lanes": ["local", "docker"],
+            "streaming": True,
+            "dynamic_model_ids": True,
+            "route_plan_transport": "sanitized_file",
+        })
+
+    def test_routed_launch_uses_digest_route_and_sanitized_env(self):
+        captured = {}
+
+        def fake_run(cmd, cwd, timeout_s, env):
+            captured.update(cmd=cmd, cwd=cwd, timeout=timeout_s, env=env)
+            captured["extension"] = Path(cmd[cmd.index("-e") + 1]).read_text()
+            return "", "", 0, False
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_plan(tmp)
+            env = {
+                "OPENBENCH_PROXY": "1",
+                "OPENBENCH_PROXY_BASE_URL": "http://127.0.0.1:8123",
+                "OPENBENCH_PROXY_CELL_TOKEN": "cell-1",
+                "PATH": os.environ.get("PATH", ""),
+                "OPENAI_API_KEY": "sk-inherited",
+                "ROUTER_API_KEY": "router-secret",
+                "AWS_SECRET_ACCESS_KEY": "aws-secret",
+            }
+            with mock.patch.dict(os.environ, env, clear=True), \
+                    mock.patch.object(pi, "_run_streaming", side_effect=fake_run):
+                result = pi.run_routed("fix it", tmp, path, 17)
+
+        self.assertTrue(result["completed"])
+        self.assertIn("vendor/model-new", captured["cmd"])
+        self.assertEqual(captured["cwd"], tmp)
+        self.assertNotIn("OPENAI_API_KEY", captured["env"])
+        self.assertNotIn("ROUTER_API_KEY", captured["env"])
+        self.assertNotIn("AWS_SECRET_ACCESS_KEY", captured["env"])
+        extension = captured["extension"]
+        self.assertIn(
+            "http://127.0.0.1:8123/cell/cell-1/route/" + "b" * 64,
+            extension,
+        )
+        self.assertNotIn("openRouterRouting", extension)
+        self.assertNotIn('"provider"', extension)
+        self.assertNotIn('"temperature"', extension)
+        self.assertNotIn('"top_p"', extension)
+        self.assertNotIn('"seed"', extension)
+        self.assertNotIn("router-secret", extension)
+        self.assertNotIn("sk-inherited", extension)
+
+    def test_malformed_and_unsupported_plans_fail_before_launch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            malformed = self._write_plan(tmp, {**plan_dict(), "secret": "no"})
+            unsupported = Path(tmp, "unsupported.json")
+            unsupported.write_text(json.dumps({
+                **plan_dict(), "protocol": "anthropic_messages",
+            }), encoding="utf-8")
+            for path in (malformed, unsupported):
+                with self.subTest(path=path), \
+                        mock.patch.object(pi, "_run_streaming") as launch:
+                    with self.assertRaises(RouterSpecError):
+                        pi.run_routed("x", tmp, path, 1)
+                    launch.assert_not_called()
+
+    def test_entry_rejects_incompatible_capabilities_before_dispatch(self):
+        adapter = mock.Mock(
+            ADAPTER_API_VERSION=1,
+            ROUTED_CAPABILITIES=pi.ROUTED_CAPABILITIES,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write_plan(tmp)
+            with self.assertRaisesRegex(ValueError, "ADAPTER_API_VERSION"):
+                entry._validate_routed_adapter(adapter, path)
+            adapter.run_routed.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_pi_routed.py
+++ b/obench/tests/test_pi_routed.py
@@ -19,6 +19,7 @@ def plan_dict(**updates):
         route_kind="gateway",
         endpoint="https://openrouter.ai/api/v1/chat/completions",
         protocol="openai_chat",
+        canonical_model="provider-a/model-new",
         requested_model="vendor/model-new",
         requested_provider="provider-a",
         allowed_models=("vendor/model-new",),
@@ -91,6 +92,8 @@ class PiRoutedTests(unittest.TestCase):
         self.assertNotIn('"temperature"', extension)
         self.assertNotIn('"top_p"', extension)
         self.assertNotIn('"seed"', extension)
+        self.assertIn('maxTokensField: "max_tokens"', extension)
+        self.assertIn("contextWindow: 128000, maxTokens: 16384", extension)
         self.assertNotIn("router-secret", extension)
         self.assertNotIn("sk-inherited", extension)
 

--- a/obench/tests/test_results.py
+++ b/obench/tests/test_results.py
@@ -1,0 +1,326 @@
+import dataclasses
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from obench import results
+
+
+def digest(label):
+    return results.canonical_digest({"identity": label})
+
+
+def router_identity():
+    return results.CellIdentity.for_router(
+        track="gateway_tax",
+        experiment_id="gateway-tax-smoke",
+        experiment_digest=digest("experiment"),
+        arm_id="via-openrouter",
+        arm_digest=digest("arm"),
+        policy_digest=digest("policy"),
+        catalog_digest=digest("catalog"),
+        price_digest=digest("price"),
+        sampling_digest=digest("sampling"),
+        schedule_digest=digest("schedule"),
+        task="make-it-run",
+        task_digest=digest("task"),
+        checker_digest=digest("checker"),
+        workspace_source_sha="a" * 40,
+        harness="pi",
+        candidate="openrouter-candidate",
+        harness_version="0.80.10",
+        execution_lane="docker",
+        image_digest=digest("image"),
+        budget_timeout_s=300,
+        budget_max_calls=8,
+        budget_max_output_tokens=16000,
+        budget_usd_cap="2.50",
+        adapter_timeout_s=240,
+        checker_timeout_s=60,
+        window_id="morning",
+        repetition=1,
+        block_id="block-001",
+        block_attempt=0,
+    )
+
+
+SHARED_CHANGES = {
+    "track": "model_router",
+    "experiment_id": "other-experiment",
+    "experiment_digest": digest("experiment-changed"),
+    "policy_digest": digest("policy-changed"),
+    "catalog_digest": digest("catalog-changed"),
+    "price_digest": digest("price-changed"),
+    "sampling_digest": digest("sampling-changed"),
+    "schedule_digest": digest("schedule-changed"),
+    "harness": "other-harness",
+    "candidate": "other-candidate",
+    "harness_version": "0.80.11",
+    "execution_lane": "local",
+    "image_digest": digest("image-changed"),
+    "budget_timeout_s": 301,
+    "budget_max_calls": 9,
+    "budget_max_output_tokens": 16001,
+    "budget_usd_cap": "2.51",
+    "adapter_timeout_s": 241,
+    "checker_timeout_s": 61,
+}
+
+CELL_ONLY_CHANGES = {
+    "arm_id": "direct-openai",
+    "arm_digest": digest("arm-changed"),
+    "task": "other-task",
+    "task_digest": digest("task-changed"),
+    "checker_digest": digest("checker-changed"),
+    "workspace_source_sha": "b" * 40,
+    "window_id": "evening",
+    "repetition": 2,
+    "block_id": "block-002",
+    "block_attempt": 1,
+}
+
+
+class CanonicalJsonTests(unittest.TestCase):
+    def test_canonical_json_is_stable_compact_and_utf8(self):
+        left = {"z": [3, 2], "a": {"unicode": "caf\u00e9"}}
+        right = {"a": {"unicode": "caf\u00e9"}, "z": [3, 2]}
+
+        self.assertEqual(results.canonical_json(left), results.canonical_json(right))
+        self.assertEqual(results.canonical_digest(left), results.canonical_digest(right))
+        self.assertEqual(
+            results.canonical_json(left),
+            '{"a":{"unicode":"caf\u00e9"},"z":[3,2]}',
+        )
+
+    def test_canonical_json_rejects_non_json_floats(self):
+        with self.assertRaises(ValueError):
+            results.canonical_json({"value": float("nan")})
+
+
+class RouterIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.identity = router_identity()
+
+    def test_schema_v2_identity_is_immutable_and_canonically_nested(self):
+        self.assertEqual(self.identity.schema_version, 2)
+        self.assertEqual(
+            set(self.identity.as_dict()),
+            {
+                "schema_version", "benchmark", "experiment", "arm", "comparison",
+                "task", "harness", "execution", "schedule",
+            },
+        )
+        self.assertEqual(
+            self.identity.as_dict()["execution"]["budget"],
+            {
+                "timeout_s": 300,
+                "max_calls": 8,
+                "max_output_tokens": 16000,
+                "usd_cap": "2.50",
+            },
+        )
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            self.identity.task = "other"
+
+    def test_every_normative_dimension_changes_cell_id(self):
+        original = results.make_router_cell_id(self.identity)
+        for field, replacement in {**SHARED_CHANGES, **CELL_ONLY_CHANGES}.items():
+            with self.subTest(field=field):
+                changed = dataclasses.replace(self.identity, **{field: replacement})
+                self.assertNotEqual(original, results.make_router_cell_id(changed))
+
+    def test_comparison_shared_dimensions_change_run_id(self):
+        original = results.make_router_run_id(self.identity)
+        for field, replacement in SHARED_CHANGES.items():
+            with self.subTest(field=field):
+                changed = dataclasses.replace(self.identity, **{field: replacement})
+                self.assertNotEqual(original, results.make_router_run_id(changed))
+
+    def test_cell_specific_dimensions_do_not_split_run_id(self):
+        original = results.make_router_run_id(self.identity)
+        for field, replacement in CELL_ONLY_CHANGES.items():
+            with self.subTest(field=field):
+                changed = dataclasses.replace(self.identity, **{field: replacement})
+                self.assertEqual(original, results.make_router_run_id(changed))
+
+    def test_fixed_benchmark_and_schema_are_normative(self):
+        for changes in (
+            {"schema_version": 1},
+            {"benchmark": "harness"},
+        ):
+            with self.subTest(changes=changes):
+                with self.assertRaises(results.ResultIdentityError):
+                    dataclasses.replace(self.identity, **changes)
+
+    def test_nested_validation_round_trips_and_rejects_shape_drift(self):
+        nested = self.identity.as_dict()
+        self.assertEqual(results.validate_router_identity(nested), self.identity)
+
+        missing = dict(nested)
+        missing.pop("comparison")
+        extra = dict(nested)
+        extra["label"] = "not normative"
+        bad_nested = dict(nested)
+        bad_nested["task"] = dict(nested["task"], extra="not normative")
+        for candidate in (missing, extra, bad_nested):
+            with self.subTest(candidate=candidate):
+                with self.assertRaises(results.ResultIdentityError):
+                    results.validate_router_identity(candidate)
+
+
+class DispatchTests(unittest.TestCase):
+    def test_metadata_free_rows_dispatch_as_legacy_harness_results(self):
+        row = {"run_id": "pi:task:model:trial1"}
+
+        self.assertEqual(results.result_kind(row), (0, "harness"))
+        self.assertEqual(
+            results.dispatch_result(
+                row,
+                {(0, "harness"): lambda value: value["run_id"]},
+            ),
+            row["run_id"],
+        )
+
+    def test_router_results_dispatch_as_schema_v2(self):
+        row = {"schema_version": 2, "benchmark": "router"}
+
+        self.assertEqual(results.result_kind(row), (2, "router"))
+        with self.assertRaises(results.UnsupportedResultError):
+            results.dispatch_result(row, {(1, "router"): lambda value: value})
+
+    def test_invalid_schema_version_fails_closed(self):
+        for version in (True, -1, "2"):
+            with self.subTest(version=version):
+                with self.assertRaises(results.ResultError):
+                    results.result_kind({
+                        "schema_version": version,
+                        "benchmark": "router",
+                    })
+
+
+class ResumeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.path = Path(self.temp_dir.name) / "results.jsonl"
+        self.identity = router_identity()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def router_row(self, identity=None):
+        identity = identity or self.identity
+        return {
+            "schema_version": 2,
+            "benchmark": "router",
+            "identity": identity.as_dict(),
+            "run_id": results.make_router_run_id(identity),
+            "cell_id": results.make_router_cell_id(identity),
+        }
+
+    def write_rows(self, rows):
+        self.path.write_text(
+            "".join(json.dumps(row) + "\n" for row in rows),
+            encoding="utf-8",
+        )
+
+    def test_missing_file_is_empty_resume_state(self):
+        self.assertEqual(
+            results.read_jsonl_for_resume(self.path),
+            results.ResumeState((), frozenset()),
+        )
+
+    def test_reads_legacy_and_nested_v2_rows(self):
+        legacy = {"run_id": "pi:task:model:trial1", "success": True}
+        router = self.router_row()
+        self.write_rows([legacy, router])
+
+        state = results.read_jsonl_for_resume(self.path)
+
+        self.assertEqual(state.rows, (legacy, router))
+        self.assertEqual(
+            state.cell_ids,
+            frozenset({legacy["run_id"], router["cell_id"]}),
+        )
+
+    def test_router_row_requires_canonical_nested_identity(self):
+        row = self.router_row()
+        row.pop("identity")
+        self.write_rows([row])
+
+        with self.assertRaisesRegex(results.ResultsLogError, "identity is required"):
+            results.read_jsonl_for_resume(self.path)
+
+    def test_same_run_id_is_allowed_for_distinct_cells(self):
+        other = dataclasses.replace(
+            self.identity,
+            arm_id="direct-openai",
+            arm_digest=digest("direct-arm"),
+            task="other-task",
+            task_digest=digest("other-task"),
+            checker_digest=digest("other-checker"),
+            workspace_source_sha="b" * 40,
+            window_id="evening",
+            repetition=2,
+            block_id="block-002",
+        )
+        rows = [self.router_row(), self.router_row(other)]
+        self.assertEqual(rows[0]["run_id"], rows[1]["run_id"])
+        self.write_rows(rows)
+
+        self.assertEqual(len(results.read_jsonl_for_resume(self.path).cell_ids), 2)
+
+    def test_duplicate_legacy_or_router_cells_are_rejected(self):
+        cases = (
+            [{"run_id": "same"}, {"run_id": "same"}],
+            [self.router_row(), self.router_row()],
+        )
+        for rows in cases:
+            with self.subTest(rows=rows):
+                self.write_rows(rows)
+                with self.assertRaises(results.DuplicateResultError):
+                    results.read_jsonl_for_resume(self.path)
+
+    def test_corrupt_truncated_and_ambiguous_lines_fail_closed(self):
+        cases = (
+            b'{"run_id":"ok"}\n{"run_id":',
+            b'{"run_id":"valid-json-but-no-append-boundary"}',
+            b'{"run_id":"ok"}\n[]\n',
+            b'{"run_id":"ok"}\n\xff\n',
+            b'{"run_id":"first","run_id":"second"}\n',
+            b'{"run_id":"ok","value":NaN}\n',
+        )
+        for raw in cases:
+            with self.subTest(raw=raw):
+                self.path.write_bytes(raw)
+                with self.assertRaises(results.ResultsLogError):
+                    results.read_jsonl_for_resume(self.path)
+
+    def test_invalid_path_and_legacy_identity_fail_closed(self):
+        self.path.mkdir()
+        with self.assertRaisesRegex(results.ResultsLogError, "not a regular file"):
+            results.read_jsonl_for_resume(self.path)
+
+        self.path.rmdir()
+        self.write_rows([{"success": True}])
+        with self.assertRaisesRegex(results.ResultsLogError, "legacy row run_id"):
+            results.read_jsonl_for_resume(self.path)
+
+    def test_router_ids_and_dispatch_metadata_must_match_identity(self):
+        cases = (
+            ("cell_id", "router-cell-v2-wrong", "cell_id does not match"),
+            ("run_id", "router-run-v2-wrong", "run_id does not match"),
+            ("schema_version", 1, "schema_version conflicts"),
+            ("benchmark", "harness", "benchmark conflicts"),
+        )
+        for field, value, message in cases:
+            with self.subTest(field=field):
+                row = self.router_row()
+                row[field] = value
+                self.write_rows([row])
+                with self.assertRaisesRegex(results.ResultsLogError, message):
+                    results.read_jsonl_for_resume(self.path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_router_metrics.py
+++ b/obench/tests/test_router_metrics.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Contract tests for protocol-aware, privacy-safe router metrics."""
+
+import json
+import unittest
+
+from obench import router_metrics
+
+
+def sse(*objects, newline="\n"):
+    events = []
+    for obj in objects:
+        data = obj if isinstance(obj, str) else json.dumps(obj, separators=(",", ":"))
+        events.append(f"data: {data}{newline}{newline}")
+    return "".join(events).encode()
+
+
+class RouterMetricsTests(unittest.TestCase):
+    def setUp(self):
+        self.secret = "RAW_GENERATED_CONTENT_MUST_NOT_SURVIVE"
+        self.role = {
+            "model": "openai/gpt-4o-mini",
+            "provider": "OpenAI",
+            "choices": [{"delta": {"role": "assistant", "content": ""}}],
+        }
+        self.token = {
+            "model": "openai/gpt-4o-mini",
+            "provider": "OpenAI",
+            "choices": [{"delta": {"content": self.secret}}],
+        }
+        self.final = {
+            "model": "openai/gpt-4o-mini",
+            "choices": [{"delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 4, "total_tokens": 15},
+            "openrouter_metadata": {
+                "requested": "openai/gpt-4o-mini",
+                "attempt": 2,
+                "endpoints": {"available": [
+                    {"provider": "Other", "model": "openai/gpt-4o-mini", "selected": False},
+                    {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "selected": True},
+                ]},
+                "attempts": [
+                    {"provider": "Other", "model": "openai/gpt-4o-mini", "status": 503,
+                     "private_detail": self.secret},
+                    {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "status": 200},
+                ],
+                "summary": self.secret,
+            },
+        }
+
+    def payload(self, newline="\n"):
+        prefix = f": keepalive{newline}{newline}event: ping{newline}{newline}"
+        empty = {"choices": [{"delta": {"content": ""}}]}
+        return prefix.encode() + sse(self.role, empty, self.token, self.final, "[DONE]", newline=newline)
+
+    def parse(self, chunks, completed_at=16.0):
+        return router_metrics.parse_chat_sse(
+            chunks,
+            requested_model="openai/gpt-4o-mini",
+            started_at=10.0,
+            completed_at=completed_at,
+        )
+
+    def test_fragmented_and_coalesced_frames_have_identical_evidence(self):
+        payload = self.payload()
+        expected = self.parse([(12.0, payload)])
+        for split in range(len(payload) + 1):
+            with self.subTest(split=split):
+                actual = self.parse([(12.0, payload[:split]), (12.0, payload[split:])])
+                self.assertEqual(actual, expected)
+        bytewise = self.parse([(12.0, payload[index:index + 1]) for index in range(len(payload))])
+        self.assertEqual(bytewise, expected)
+
+    def test_crlf_delimiters_can_split_between_cr_and_lf(self):
+        payload = self.payload(newline="\r\n")
+        parser = router_metrics.OpenAIChatSSEParser(
+            requested_model="openai/gpt-4o-mini", started_at=10.0
+        )
+        for index, byte in enumerate(payload):
+            parser.feed(bytes([byte]), 11.0 + index / 1000)
+        result = parser.finalize(14.0)
+        self.assertTrue(result["stream"]["done"])
+        self.assertEqual(result["usage"]["output_tokens"], 4)
+        self.assertTrue(result["route_evidence"]["pass"])
+
+    def test_ttfb_and_semantic_ttft_use_observation_timestamps(self):
+        parser = router_metrics.ChatSSEMetricsParser(
+            requested_model="openai/gpt-4o-mini", started_at=100.0
+        )
+        parser.feed(b": comment\n\n", 100.25)
+        parser.feed(sse(self.role), 100.5)
+        parser.feed(sse(self.token), 101.75)
+        parser.feed(sse(self.final, "[DONE]"), 103.0)
+        result = parser.finalize(104.0)
+        self.assertEqual(result["timing"], {
+            "ttfb_s": 0.25,
+            "semantic_ttft_s": 1.75,
+            "total_s": 4.0,
+        })
+        self.assertEqual(result["generation"], {
+            "output_tokens": 4,
+            "duration_s": 2.25,
+            "tokens_per_second": 4 / 2.25,
+        })
+
+    def test_ttft_uses_data_timestamp_not_later_event_delimiter(self):
+        event = sse(self.token)
+        delimiter = event[-1:]
+        parser = router_metrics.OpenAIChatSSEParser(
+            requested_model="openai/gpt-4o-mini", started_at=10.0
+        )
+        parser.feed(event[:-1], 11.25)
+        parser.feed(delimiter, 14.0)
+        parser.feed(sse(self.final, "[DONE]"), 15.0)
+        result = parser.finalize(16.0)
+        self.assertEqual(result["timing"]["semantic_ttft_s"], 1.25)
+        self.assertEqual(result["generation"]["duration_s"], 4.75)
+
+    def test_zero_timestamp_is_not_replaced_by_delimiter_timestamp(self):
+        event = sse(self.token)
+        parser = router_metrics.OpenAIChatSSEParser(
+            requested_model="openai/gpt-4o-mini", started_at=-1.0
+        )
+        parser.feed(event[:-1], 0.0)
+        parser.feed(event[-1:], 2.0)
+        result = parser.finalize(3.0)
+        self.assertEqual(result["timing"]["semantic_ttft_s"], 1.0)
+
+    def test_comments_role_only_and_empty_events_do_not_count_as_ttft(self):
+        result = self.parse([(11.0, (
+            b": comment\n\n"
+            + sse(self.role)
+            + b"data:\n\n"
+            + sse({"choices": [{"delta": {"content": []}}]}, "[DONE]")
+        ))])
+        self.assertIsNone(result["timing"]["semantic_ttft_s"])
+        self.assertFalse(result["coverage"]["semantic_ttft"])
+        self.assertGreaterEqual(result["stream"]["ignored_events"], 2)
+
+    def test_tool_call_function_delta_establishes_semantic_ttft(self):
+        tool_call = {
+            "choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "function": {"name": "lookup", "arguments": ""},
+            }]}}],
+        }
+        result = self.parse([(11.5, sse(self.role, tool_call, "[DONE]"))])
+        self.assertEqual(result["timing"]["semantic_ttft_s"], 1.5)
+        self.assertTrue(result["coverage"]["semantic_ttft"])
+
+    def test_usage_is_paired_with_generation_duration(self):
+        result = self.parse([
+            (10.2, sse(self.token)),
+            (12.2, sse(self.final, "[DONE]")),
+        ], completed_at=13.2)
+        self.assertEqual(result["usage"], {
+            "input_tokens": 11,
+            "output_tokens": 4,
+            "total_tokens": 15,
+        })
+        self.assertEqual(result["generation"]["output_tokens"], 4)
+        self.assertEqual(result["generation"]["duration_s"], 3.0)
+        self.assertEqual(result["generation"]["tokens_per_second"], 4 / 3)
+
+    def test_route_evidence_extracts_provider_attempts_and_passes(self):
+        result = self.parse([(11.0, self.payload())])
+        self.assertEqual(result["route"], {
+            "requested_model": "openai/gpt-4o-mini",
+            "metadata_requested_model": "openai/gpt-4o-mini",
+            "served_model": "openai/gpt-4o-mini",
+            "provider": "OpenAI",
+            "attempts": [
+                {"provider": "Other", "model": "openai/gpt-4o-mini", "status": 503},
+                {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "status": 200},
+            ],
+        })
+        self.assertEqual(result["route_evidence"], {"pass": True, "verdict": "pass", "reasons": []})
+        self.assertEqual(result["coverage"]["covered"], result["coverage"]["total"])
+
+    def test_route_evidence_fails_closed_when_metadata_is_missing(self):
+        payload = sse(self.token, {
+            "model": "openai/gpt-4o-mini",
+            "choices": [{"delta": {}}],
+            "usage": {"completion_tokens": 1},
+        }, "[DONE]")
+        result = self.parse([(11.0, payload)])
+        self.assertFalse(result["route_evidence"]["pass"])
+        self.assertEqual(result["route_evidence"]["verdict"], "fail")
+        self.assertIn("missing_openrouter_metadata", result["route_evidence"]["reasons"])
+        self.assertIn("missing_metadata_requested_model", result["route_evidence"]["reasons"])
+        self.assertIn("missing_attempts", result["route_evidence"]["reasons"])
+
+    def test_route_evidence_fails_closed_on_conflicting_attempt(self):
+        final = dict(self.final)
+        final["openrouter_metadata"] = dict(self.final["openrouter_metadata"])
+        final["openrouter_metadata"]["attempts"] = [
+            {"provider": "Different", "model": "other/model", "status": 200}
+        ]
+        result = self.parse([(11.0, sse(self.token, final, "[DONE]"))])
+        self.assertFalse(result["route_evidence"]["pass"])
+        self.assertIn("provider_conflict", result["route_evidence"]["reasons"])
+        self.assertIn("served_model_conflict", result["route_evidence"]["reasons"])
+
+    def test_malformed_event_does_not_poison_later_events(self):
+        payload = b"data: {not-json}\n\n" + self.payload()
+        result = self.parse([(11.0, payload)])
+        self.assertEqual(result["stream"]["malformed_events"], 1)
+        self.assertEqual(result["usage"]["output_tokens"], 4)
+        self.assertFalse(result["route_evidence"]["pass"])
+        self.assertIn("malformed_events", result["route_evidence"]["reasons"])
+
+    def test_route_evidence_requires_done_marker(self):
+        result = self.parse([(11.0, sse(self.token, self.final))])
+        self.assertFalse(result["route_evidence"]["pass"])
+        self.assertIn("stream_not_done", result["route_evidence"]["reasons"])
+
+    def test_no_raw_prompt_or_output_content_is_retained(self):
+        parser = router_metrics.OpenAIChatSSEParser(
+            requested_model="openai/gpt-4o-mini", started_at=10.0
+        )
+        parser.feed(self.payload(), 11.0)
+        result = parser.finalize(12.0)
+        self.assertNotIn(self.secret, json.dumps(result, sort_keys=True))
+        self.assertNotIn(self.secret, repr(vars(parser)))
+        self.assertNotIn("summary", json.dumps(result, sort_keys=True))
+        self.assertNotIn("private_detail", json.dumps(result, sort_keys=True))
+
+    def test_finalize_purges_truncated_raw_event_content(self):
+        parser = router_metrics.OpenAIChatSSEParser(
+            requested_model="openai/gpt-4o-mini", started_at=10.0
+        )
+        parser.feed(("data: " + json.dumps(self.token)).encode(), 11.0)
+        result = parser.finalize(12.0)
+        self.assertEqual(result["stream"]["malformed_events"], 1)
+        self.assertNotIn(self.secret, repr(vars(parser)))
+        self.assertFalse(result["route_evidence"]["pass"])
+
+    def test_rejects_non_monotonic_timestamps_and_feed_after_finalize(self):
+        parser = router_metrics.OpenAIChatSSEParser(requested_model="model", started_at=5.0)
+        parser.feed(b"data: ", 6.0)
+        parser.feed(b"", 6.5)
+        with self.assertRaises(ValueError):
+            parser.feed(b"{}\n\n", 6.25)
+        parser.finalize(7.0)
+        with self.assertRaises(RuntimeError):
+            parser.feed(b"", 7.0)
+
+    def test_rejects_mixed_bytes_and_text_chunks(self):
+        parser = router_metrics.OpenAIChatSSEParser(requested_model="model", started_at=5.0)
+        parser.feed(b"data: ", 6.0)
+        with self.assertRaises(TypeError):
+            parser.feed("{}\n\n", 6.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_router_metrics.py
+++ b/obench/tests/test_router_metrics.py
@@ -227,6 +227,33 @@ class RouterMetricsTests(unittest.TestCase):
         result = self.parse([(11.0, sse(self.token, final, "[DONE]"))])
         self.assertFalse(result["route_evidence"]["pass"])
         self.assertIn("fallback_attempt", result["route_evidence"]["reasons"])
+        self.assertIn("unsuccessful_attempt", result["route_evidence"]["reasons"])
+
+    def test_gateway_same_route_unsuccessful_attempt_fails(self):
+        final = dict(self.final)
+        final["openrouter_metadata"] = dict(self.final["openrouter_metadata"])
+        final["openrouter_metadata"]["attempts"] = [
+            {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "status": 503},
+            {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "status": 200},
+        ]
+        result = self.parse([(11.0, sse(self.token, final, "[DONE]"))])
+        self.assertFalse(result["route_evidence"]["pass"])
+        self.assertIn("unsuccessful_attempt", result["route_evidence"]["reasons"])
+
+    def test_gateway_explicit_empty_attempts_is_optional(self):
+        final = dict(self.final)
+        final["openrouter_metadata"] = dict(self.final["openrouter_metadata"])
+        final["openrouter_metadata"]["attempts"] = []
+        result = self.parse([(11.0, sse(self.token, final, "[DONE]"))])
+        self.assertTrue(result["route_evidence"]["pass"])
+
+    def test_gateway_malformed_attempts_fail(self):
+        final = dict(self.final)
+        final["openrouter_metadata"] = dict(self.final["openrouter_metadata"])
+        final["openrouter_metadata"]["attempts"] = ["malformed"]
+        result = self.parse([(11.0, sse(self.token, final, "[DONE]"))])
+        self.assertFalse(result["route_evidence"]["pass"])
+        self.assertIn("malformed_attempts", result["route_evidence"]["reasons"])
 
     def test_direct_exact_served_model_and_done_pass_without_gateway_evidence(self):
         result = router_metrics.parse_chat_sse(

--- a/obench/tests/test_router_metrics.py
+++ b/obench/tests/test_router_metrics.py
@@ -40,9 +40,8 @@ class RouterMetricsTests(unittest.TestCase):
                     {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "selected": True},
                 ]},
                 "attempts": [
-                    {"provider": "Other", "model": "openai/gpt-4o-mini", "status": 503,
+                    {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "status": 200,
                      "private_detail": self.secret},
-                    {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "status": 200},
                 ],
                 "summary": self.secret,
             },
@@ -59,6 +58,10 @@ class RouterMetricsTests(unittest.TestCase):
             requested_model="openai/gpt-4o-mini",
             started_at=10.0,
             completed_at=completed_at,
+            route_kind="gateway",
+            requested_provider="OpenAI",
+            allowed_models=("openai/gpt-4o-mini",),
+            allowed_providers=("OpenAI",),
         )
 
     def test_fragmented_and_coalesced_frames_have_identical_evidence(self):
@@ -170,7 +173,6 @@ class RouterMetricsTests(unittest.TestCase):
             "served_model": "openai/gpt-4o-mini",
             "provider": "OpenAI",
             "attempts": [
-                {"provider": "Other", "model": "openai/gpt-4o-mini", "status": 503},
                 {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "status": 200},
             ],
         })
@@ -188,18 +190,58 @@ class RouterMetricsTests(unittest.TestCase):
         self.assertEqual(result["route_evidence"]["verdict"], "fail")
         self.assertIn("missing_openrouter_metadata", result["route_evidence"]["reasons"])
         self.assertIn("missing_metadata_requested_model", result["route_evidence"]["reasons"])
-        self.assertIn("missing_attempts", result["route_evidence"]["reasons"])
 
-    def test_route_evidence_fails_closed_on_conflicting_attempt(self):
+    def test_gateway_missing_optional_attempts_passes(self):
+        final = dict(self.final)
+        final["openrouter_metadata"] = dict(self.final["openrouter_metadata"])
+        final["openrouter_metadata"].pop("attempts")
+        result = self.parse([(11.0, sse(self.token, final, "[DONE]"))])
+        self.assertTrue(result["route_evidence"]["pass"])
+        self.assertEqual(result["route"]["attempts"], [])
+
+    def test_gateway_wrong_selected_provider_fails(self):
+        final = dict(self.final)
+        final["openrouter_metadata"] = dict(self.final["openrouter_metadata"])
+        final["openrouter_metadata"]["endpoints"] = {
+            "available": [{
+                "provider": "Different",
+                "model": "openai/gpt-4o-mini",
+                "selected": True,
+            }],
+        }
+        final["openrouter_metadata"].pop("attempts")
+        token = dict(self.token)
+        token.pop("provider")
+        result = self.parse([(11.0, sse(token, final, "[DONE]"))])
+        self.assertFalse(result["route_evidence"]["pass"])
+        self.assertIn("provider_conflict", result["route_evidence"]["reasons"])
+        self.assertIn("provider_not_allowed", result["route_evidence"]["reasons"])
+
+    def test_gateway_fallback_attempt_fails(self):
         final = dict(self.final)
         final["openrouter_metadata"] = dict(self.final["openrouter_metadata"])
         final["openrouter_metadata"]["attempts"] = [
-            {"provider": "Different", "model": "other/model", "status": 200}
+            {"provider": "Different", "model": "openai/gpt-4o-mini", "status": 503},
+            {"provider": "OpenAI", "model": "openai/gpt-4o-mini", "status": 200},
         ]
         result = self.parse([(11.0, sse(self.token, final, "[DONE]"))])
         self.assertFalse(result["route_evidence"]["pass"])
-        self.assertIn("provider_conflict", result["route_evidence"]["reasons"])
-        self.assertIn("served_model_conflict", result["route_evidence"]["reasons"])
+        self.assertIn("fallback_attempt", result["route_evidence"]["reasons"])
+
+    def test_direct_exact_served_model_and_done_pass_without_gateway_evidence(self):
+        result = router_metrics.parse_chat_sse(
+            [(11.0, sse(self.token, "[DONE]"))],
+            requested_model="openai/gpt-4o-mini",
+            started_at=10.0,
+            completed_at=12.0,
+            route_kind="direct",
+            requested_provider="OpenAI",
+            allowed_models=("openai/gpt-4o-mini",),
+            allowed_providers=("OpenAI",),
+        )
+        self.assertTrue(result["route_evidence"]["pass"])
+        self.assertFalse(result["coverage"]["openrouter_metadata"])
+        self.assertFalse(result["coverage"]["attempts"])
 
     def test_malformed_event_does_not_poison_later_events(self):
         payload = b"data: {not-json}\n\n" + self.payload()

--- a/obench/tests/test_router_proxy.py
+++ b/obench/tests/test_router_proxy.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Lifecycle, durability, and compatibility tests for router proxy ledgers."""
+
+import hashlib
+import http.client
+import json
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest import mock
+
+from obench import proxy
+
+
+SECRET = "ROUTER_LEDGER_SECRET"
+
+
+class BlockingUpstream(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+class BlockingHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("content-length") or 0)
+        self.rfile.read(length)
+        self.server.started.set()
+        self.server.release.wait(5)
+        payload = b'{"usage":{"prompt_tokens":3,"completion_tokens":2}}'
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class RouterProxyLedgerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="router_proxy_test_")
+        self.upstream = BlockingUpstream(("127.0.0.1", 0), BlockingHandler)
+        self.upstream.started = threading.Event()
+        self.upstream.release = threading.Event()
+        self.upstream_thread = threading.Thread(target=self.upstream.serve_forever, daemon=True)
+        self.upstream_thread.start()
+        upstream_url = f"http://127.0.0.1:{self.upstream.server_address[1]}"
+        self.server = proxy.make_server(
+            "127.0.0.1",
+            0,
+            self.tmp.name,
+            chat_upstreams={"router": upstream_url},
+        )
+        self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.server_thread.start()
+        self.host, self.port = self.server.server_address[:2]
+
+    def tearDown(self):
+        self.upstream.release.set()
+        self.server.shutdown()
+        self.server.server_close()
+        self.upstream.shutdown()
+        self.upstream.server_close()
+        self.tmp.cleanup()
+
+    def _post(self, token):
+        body = json.dumps({"model": "router-model", "api_key": SECRET}).encode()
+        conn = http.client.HTTPConnection(self.host, self.port, timeout=5)
+        conn.request(
+            "POST",
+            f"/cell/{token}/chat/router/v1/chat/completions",
+            body=body,
+            headers={"content-type": "application/json", "content-length": str(len(body))},
+        )
+        response = conn.getresponse()
+        response.read()
+        conn.close()
+        return response.status
+
+    def _rows(self, token):
+        path = self.server.ledger_dir / f"{token}.jsonl"
+        deadline = time.monotonic() + 2
+        while (not path.exists() or not path.stat().st_size) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        with path.open(encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh]
+
+    def test_registered_cell_drains_seals_and_rejects_new_or_late_writes(self):
+        token = "router-cell"
+        self.server.register_cell(token)
+        statuses = []
+        request = threading.Thread(target=lambda: statuses.append(self._post(token)))
+        request.start()
+        self.assertTrue(self.upstream.started.wait(2))
+
+        self.server.revoke_cell(token)
+        self.assertEqual(self._post(token), 502)
+        with self.assertRaises(TimeoutError):
+            self.server.seal_cell(token, timeout_s=0.01)
+
+        self.upstream.release.set()
+        request.join(2)
+        self.assertEqual(statuses, [200])
+        seal = self.server.seal_cell(token, timeout_s=1)
+        self.assertIsInstance(seal, proxy.LedgerSeal)
+        self.assertEqual(seal.record_count, 1)
+        self.assertEqual(seal.last_sequence, 1)
+
+        rows = self._rows(token)
+        self.assertEqual([row["record_type"] for row in rows], ["request", "ledger_seal"])
+        request_row, terminal = rows
+        self.assertEqual(request_row["previous_hash"], proxy.EMPTY_LEDGER_HASH)
+        unhashed = {key: value for key, value in request_row.items() if key != "record_hash"}
+        expected_hash = hashlib.sha256(
+            json.dumps(unhashed, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        self.assertEqual(request_row["record_hash"], expected_hash)
+        self.assertEqual(seal.root_hash, expected_hash)
+        self.assertEqual(terminal["root_hash"], expected_hash)
+        self.assertEqual(terminal["record_count"], 1)
+        self.assertEqual(terminal["last_sequence"], 1)
+        self.assertNotIn(SECRET, seal.path.read_text(encoding="utf-8"))
+
+        self.assertEqual(self._post(token), 502)
+        with self.assertRaisesRegex(RuntimeError, "sealed"):
+            self.server.complete_cell_request(token, {"status": 200})
+        self.assertEqual(self.server.seal_cell(token), seal)
+        self.assertEqual(len(self._rows(token)), 2)
+
+    def test_concurrent_completions_are_sequenced_and_hash_chained(self):
+        token = "concurrent-cell"
+        self.server.register_cell(token)
+        self.upstream.release.set()
+        threads = [threading.Thread(target=self._post, args=(token,)) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(3)
+            self.assertFalse(thread.is_alive())
+
+        seal = self.server.seal_cell(token, timeout_s=1)
+        rows = self._rows(token)
+        requests = rows[:-1]
+        self.assertEqual([row["sequence"] for row in requests], list(range(1, 9)))
+        previous = proxy.EMPTY_LEDGER_HASH
+        for row in requests:
+            self.assertEqual(row["previous_hash"], previous)
+            previous = row["record_hash"]
+        self.assertEqual(seal.record_count, 8)
+        self.assertEqual(seal.root_hash, previous)
+
+    def test_unregistered_legacy_cell_keeps_plain_append_behavior(self):
+        self.upstream.release.set()
+        self.assertEqual(self._post("legacy-cell"), 200)
+        row = self._rows("legacy-cell")[0]
+        self.assertNotIn("record_type", row)
+        self.assertNotIn("sequence", row)
+        self.assertNotIn("record_hash", row)
+        with self.assertRaisesRegex(RuntimeError, "not registered"):
+            self.server.seal_cell("legacy-cell", timeout_s=0)
+
+    def test_registration_rejects_request_already_admitted_as_legacy(self):
+        token = "registration-race"
+        self.assertFalse(self.server.admit_cell_request(token))
+        with self.assertRaisesRegex(RuntimeError, "active legacy"):
+            self.server.register_cell(token)
+        self.server.complete_legacy_request(token, {"status": 200, "api_key": SECRET})
+        row = self._rows(token)[0]
+        self.assertEqual(row["status"], 200)
+        self.assertNotIn(SECRET, self.server._ledger_path(token).read_text(encoding="utf-8"))
+        with self.assertRaises(FileExistsError):
+            self.server.register_cell(token)
+
+    def test_seal_retry_does_not_append_duplicate_terminal_record(self):
+        token = "seal-retry"
+        self.server.register_cell(token)
+        original_fsync_directory = self.server._fsync_directory
+        calls = 0
+
+        def fail_once(path):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise OSError("injected directory fsync failure")
+            return original_fsync_directory(path)
+
+        with mock.patch.object(self.server, "_fsync_directory", side_effect=fail_once):
+            with self.assertRaisesRegex(OSError, "injected"):
+                self.server.seal_cell(token)
+            seal = self.server.seal_cell(token)
+
+        rows = self._rows(token)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["record_type"], "ledger_seal")
+        self.assertEqual(seal.record_count, 0)
+
+    def test_legacy_header_token_is_sanitized_before_path_use(self):
+        self.upstream.release.set()
+        token = "../../outside"
+        body = b'{"model":"router-model"}'
+        conn = http.client.HTTPConnection(self.host, self.port, timeout=5)
+        conn.request(
+            "POST",
+            "/chat/router/v1/chat/completions",
+            body=body,
+            headers={
+                "x-openbench-cell-token": token,
+                "content-type": "application/json",
+                "content-length": str(len(body)),
+            },
+        )
+        response = conn.getresponse()
+        response.read()
+        conn.close()
+        self.assertEqual(response.status, 200)
+        safe_path = self.server.ledger_dir / ".._.._outside.jsonl"
+        deadline = time.monotonic() + 2
+        while not safe_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(safe_path.exists())
+        self.assertFalse((self.server.ledger_dir.parent.parent / "outside.jsonl").exists())
+
+    def test_pre_admission_error_cannot_write_after_registration(self):
+        token = "managed-error"
+        self.server.register_cell(token)
+        wrote = self.server.write_legacy_record_if_unregistered(token, {"error": "late"})
+        self.assertFalse(wrote)
+        seal = self.server.seal_cell(token)
+        rows = self._rows(token)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["record_type"], "ledger_seal")
+        self.assertEqual(seal.record_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_router_publish.py
+++ b/obench/tests/test_router_publish.py
@@ -1,0 +1,401 @@
+"""Tests for sanitized Router Bench publishing and verification."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from obench import results
+from obench import router_publish
+from obench import router_spec
+
+
+def digest(label):
+    return results.canonical_digest({"fixture": label})
+
+
+def canonical_line(value):
+    return results.canonical_json(value) + "\n"
+
+
+def experiment():
+    return router_spec.parse_experiment({
+        "schema_version": 1,
+        "experiment_id": "gateway-tax-publish",
+        "track": "gateway_tax",
+        "harness": "pi",
+        "tasks": ["make-it-run"],
+        "repetitions_per_window": 1,
+        "schedule_seed": 17,
+        "execution_lane": "docker",
+        "private_router": False,
+        "windows": [{
+            "window_id": "morning",
+            "start": "2026-07-22T08:00:00Z",
+            "end": "2026-07-22T09:00:00Z",
+        }],
+        "budget": {
+            "timeout_s": 300,
+            "max_calls": 8,
+            "max_output_tokens": 16000,
+            "usd_cap": "2.5",
+        },
+        "arms": [
+            {
+                "arm_id": "direct",
+                "route_kind": "direct",
+                "endpoint": "https://direct.example.test/v1/chat/completions",
+                "protocol": "openai_chat",
+                "baseline": True,
+                "requested_model": "openai/gpt-test",
+                "requested_provider": "OpenAI",
+                "allowed_models": ["openai/gpt-test"],
+                "allowed_providers": ["OpenAI"],
+                "fallback_enabled": False,
+                "retry_count": 0,
+                "cache_enabled": False,
+                "auth_env": "VERY_PRIVATE_DIRECT_KEY",
+                "sampling": {"temperature": 0.0, "top_p": 1.0, "seed": 17},
+            },
+            {
+                "arm_id": "gateway",
+                "route_kind": "gateway",
+                "endpoint": "https://router.example.test/private/v1/chat/completions",
+                "protocol": "openai_chat",
+                "baseline": False,
+                "requested_model": "openai/gpt-test",
+                "requested_provider": "OpenAI",
+                "allowed_models": ["openai/gpt-test"],
+                "allowed_providers": ["OpenAI"],
+                "fallback_enabled": False,
+                "retry_count": 0,
+                "cache_enabled": False,
+                "auth_env": "VERY_PRIVATE_ROUTER_KEY",
+                "sampling": {"temperature": 0.0, "top_p": 1.0, "seed": 17},
+                "direct_control_arm_id": "direct",
+            },
+        ],
+    })
+
+
+class RouterPublishTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="router_publish_test_")
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.results_path = self.root / "source-results.jsonl"
+        self.source_ledger = self.root / "private-ledger.jsonl"
+        self.bundle = self.root / "bundle"
+        self.experiment = experiment()
+        self.policy = {
+            "schema_version": 1,
+            "policy_id": "strict",
+            "allowed_models": ["openai/gpt-test"],
+            "allowed_providers": ["OpenAI"],
+            "fallback_enabled": False,
+            "retry_count": 0,
+            "raw_headers": {"Authorization": "Bearer should-never-publish"},
+        }
+        self.catalog = {
+            "schema_version": 1,
+            "catalog_id": "catalog-1",
+            "models": [{
+                "model": "openai/gpt-test",
+                "provider": "OpenAI",
+                "context_window": 128000,
+                "endpoint": "https://router.example.test/private/model",
+            }],
+        }
+        self.prices = {
+            "schema_version": 1,
+            "price_id": "prices-1",
+            "currency": "USD",
+            "prices": [{
+                "model": "openai/gpt-test",
+                "provider": "OpenAI",
+                "input_per_million": "1.25",
+                "output_per_million": "5.00",
+                "account_id": "123456789012",
+            }],
+        }
+        self.identity = results.CellIdentity.for_router(
+            track="gateway_tax",
+            experiment_id=self.experiment.experiment_id,
+            experiment_digest=self.experiment.digest,
+            arm_id="gateway",
+            arm_digest=self.experiment.arms[1].digest,
+            policy_digest=results.canonical_digest(self.policy),
+            catalog_digest=results.canonical_digest(self.catalog),
+            price_digest=results.canonical_digest(self.prices),
+            sampling_digest=digest("sampling"),
+            schedule_digest=digest("schedule"),
+            task="make-it-run",
+            task_digest=digest("task"),
+            checker_digest=digest("checker"),
+            workspace_source_sha="a" * 40,
+            harness="pi",
+            candidate=None,
+            harness_version="0.80.10",
+            execution_lane="docker",
+            image_digest=digest("image"),
+            budget_timeout_s=300,
+            budget_max_calls=8,
+            budget_max_output_tokens=16000,
+            budget_usd_cap="2.5",
+            adapter_timeout_s=240,
+            checker_timeout_s=60,
+            window_id="morning",
+            repetition=1,
+            block_id="block-001",
+            block_attempt=0,
+        )
+        self.cell_id = results.make_router_cell_id(self.identity)
+        self.row = {
+            "schema_version": 2,
+            "benchmark": "router",
+            "identity": self.identity.as_dict(),
+            "run_id": results.make_router_run_id(self.identity),
+            "cell_id": self.cell_id,
+            "completed": True,
+            "success": True,
+            "score": 1.0,
+            "usage": {"input_tokens": 11, "output_tokens": 4, "total_tokens": 15},
+            "raw_headers": {"authorization": "Bearer source-result-secret"},
+            "query": "api_key=source-result-secret",
+            "request_body": "private prompt",
+            "response_body": "private answer",
+            "transcript_path": "/Users/private/transcript.txt",
+        }
+        self._write_results(self.row)
+        self._write_ledger()
+
+    def _write_results(self, *rows):
+        self.results_path.write_text(
+            "".join(canonical_line(row) for row in rows),
+            encoding="utf-8",
+        )
+
+    def _write_ledger(self, *, allowed_secret=None):
+        request = {
+            "record_type": "request",
+            "sequence": 1,
+            "previous_hash": hashlib.sha256(b"").hexdigest(),
+            "ts": "2026-07-22T08:01:00Z",
+            "method": "POST",
+            "path": "/cell/private-token/chat/router/private/v1/chat/completions",
+            "upstream": "https://router.example.test/private/v1",
+            "status": 200,
+            "model": allowed_secret or "openai/gpt-test",
+            "usage": {"input_tokens": 11, "output_tokens": 4, "total_tokens": 15},
+            "router_arm": {
+                "arm_id": "gateway",
+                "arm_digest": self.identity.arm_digest,
+                "route_kind": "gateway",
+            },
+            "error": "request body and credentials must never publish",
+        }
+        request["record_hash"] = hashlib.sha256(
+            results.canonical_json_bytes({
+                key: value for key, value in request.items() if key != "record_hash"
+            })
+        ).hexdigest()
+        seal = {
+            "record_type": "ledger_seal",
+            "state": "SEALED",
+            "record_count": 1,
+            "last_sequence": 1,
+            "root_hash": request["record_hash"],
+        }
+        self.source_ledger.write_text(
+            canonical_line(request) + canonical_line(seal),
+            encoding="utf-8",
+        )
+
+    def publish(self):
+        return router_publish.publish_bundle(
+            self.results_path,
+            self.bundle,
+            experiment=self.experiment,
+            policy=self.policy,
+            catalog=self.catalog,
+            prices=self.prices,
+            ledgers={self.cell_id: self.source_ledger},
+        )
+
+    def test_round_trip_uses_allowlisted_dtos_and_binds_all_artifacts(self):
+        provenance = self.publish()
+        self.assertEqual(router_publish.verify_bundle(self.bundle), provenance)
+
+        files = {
+            path.relative_to(self.bundle).as_posix()
+            for path in self.bundle.rglob("*")
+            if path.is_file()
+        }
+        self.assertEqual(files, set(provenance["artifacts"]) | {"provenance.json"})
+        for relative, expected in provenance["artifacts"].items():
+            self.assertEqual(
+                hashlib.sha256((self.bundle / relative).read_bytes()).hexdigest(),
+                expected,
+            )
+
+        bundle_text = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in self.bundle.rglob("*")
+            if path.is_file()
+        )
+        for forbidden in (
+            "raw_headers", "source-result-secret", "private prompt",
+            "private answer", "transcript_path", "/Users/private",
+            "VERY_PRIVATE_ROUTER_KEY", "/private/v1", "account_id",
+            "123456789012", "credentials must never publish",
+        ):
+            self.assertNotIn(forbidden, bundle_text)
+
+        public_row = json.loads((self.bundle / "results.jsonl").read_text())
+        binding = public_row["ledger"]
+        self.assertEqual(binding, provenance["ledgers"][self.cell_id])
+        seal = json.loads(
+            (self.bundle / binding["artifact"]).read_text().splitlines()[-1]
+        )
+        self.assertEqual(seal["cell_id"], self.cell_id)
+        self.assertEqual(seal["root_hash"], binding["root_hash"])
+        self.assertEqual(seal["seal_sha256"], binding["seal_sha256"])
+
+    def test_publish_rejects_corrupt_jsonl_and_cell_ledger_mismatch(self):
+        self.results_path.write_bytes(self.results_path.read_bytes()[:-1])
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "newline"):
+            self.publish()
+
+        self._write_results(self.row)
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "bindings mismatch"):
+            router_publish.publish_bundle(
+                self.results_path,
+                self.bundle,
+                experiment=self.experiment,
+                policy=self.policy,
+                catalog=self.catalog,
+                prices=self.prices,
+                ledgers={"router-cell-v2-wrong": self.source_ledger},
+            )
+
+    def test_publish_rejects_unsealed_or_tampered_source_ledger(self):
+        lines = self.source_ledger.read_text().splitlines()
+        self.source_ledger.write_text(lines[0] + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "terminal seal"):
+            self.publish()
+
+        self._write_ledger()
+        request, seal = [
+            json.loads(line) for line in self.source_ledger.read_text().splitlines()
+        ]
+        request["status"] = 500
+        self.source_ledger.write_text(
+            canonical_line(request) + canonical_line(seal),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "tampered"):
+            self.publish()
+
+    def test_verify_rejects_tamper_extra_artifact_and_binding_mismatch(self):
+        self.publish()
+        results_path = self.bundle / "results.jsonl"
+        results_path.write_bytes(results_path.read_bytes().replace(b'"score":1.0', b'"score":0.0'))
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "digest mismatch"):
+            router_publish.verify_bundle(self.bundle)
+
+        results_path.write_text(canonical_line(
+            router_publish._decode_json(  # noqa: SLF001 - restore test fixture
+                self.results_path.read_bytes().splitlines()[0], "fixture"
+            )
+        ), encoding="utf-8")
+        # Re-publish is simpler than reconstructing the public row and digest.
+        for child in self.bundle.rglob("*"):
+            if child.is_file():
+                child.unlink()
+        for child in sorted(self.bundle.rglob("*"), reverse=True):
+            if child.is_dir():
+                child.rmdir()
+        self.bundle.rmdir()
+        self.publish()
+        (self.bundle / "unexpected.txt").write_text("extra", encoding="utf-8")
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "artifact set mismatch"):
+            router_publish.verify_bundle(self.bundle)
+
+        (self.bundle / "unexpected.txt").unlink()
+        price_path = self.bundle / "prices.json"
+        price_raw = price_path.read_bytes()
+        price_path.unlink()
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "artifact set mismatch"):
+            router_publish.verify_bundle(self.bundle)
+        price_path.write_bytes(price_raw)
+
+        public_rows = [
+            json.loads(line)
+            for line in (self.bundle / "results.jsonl").read_text().splitlines()
+        ]
+        public_rows[0]["ledger"]["root_hash"] = "0" * 64
+        raw = "".join(canonical_line(row) for row in public_rows).encode()
+        (self.bundle / "results.jsonl").write_bytes(raw)
+        provenance_path = self.bundle / "provenance.json"
+        provenance = json.loads(provenance_path.read_text())
+        provenance["artifacts"]["results.jsonl"] = hashlib.sha256(raw).hexdigest()
+        provenance_path.write_text(canonical_line(provenance), encoding="utf-8")
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "ledger binding mismatch"):
+            router_publish.verify_bundle(self.bundle)
+
+    def test_verify_rejects_corrupt_jsonl_even_when_artifact_hash_is_updated(self):
+        self.publish()
+        path = self.bundle / "results.jsonl"
+        raw = path.read_bytes()[:-1]
+        path.write_bytes(raw)
+        provenance_path = self.bundle / "provenance.json"
+        provenance = json.loads(provenance_path.read_text())
+        provenance["artifacts"]["results.jsonl"] = hashlib.sha256(raw).hexdigest()
+        provenance_path.write_text(canonical_line(provenance), encoding="utf-8")
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "newline"):
+            router_publish.verify_bundle(self.bundle)
+
+    def test_secret_in_allowlisted_value_is_rejected_on_publish_and_verify(self):
+        self._write_ledger(allowed_secret="sk-abcdefghijklmnopqrstuvwxyz")
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "credential pattern"):
+            self.publish()
+
+        self._write_ledger()
+        self.publish()
+        catalog_path = self.bundle / "catalog.json"
+        catalog = json.loads(catalog_path.read_text())
+        catalog["data"]["name"] = "leak@example.com"
+        raw = canonical_line(catalog).encode()
+        catalog_path.write_bytes(raw)
+        provenance_path = self.bundle / "provenance.json"
+        provenance = json.loads(provenance_path.read_text())
+        provenance["artifacts"]["catalog.json"] = hashlib.sha256(raw).hexdigest()
+        provenance_path.write_text(canonical_line(provenance), encoding="utf-8")
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "email"):
+            router_publish.verify_bundle(self.bundle)
+
+    def test_snapshot_digest_mismatch_fails_closed(self):
+        wrong = dataclasses.replace(self.identity, policy_digest=digest("wrong-policy"))
+        row = dict(self.row)
+        row["identity"] = wrong.as_dict()
+        row["run_id"] = results.make_router_run_id(wrong)
+        row["cell_id"] = results.make_router_cell_id(wrong)
+        self._write_results(row)
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "snapshot digests"):
+            router_publish.publish_bundle(
+                self.results_path,
+                self.bundle,
+                experiment=self.experiment,
+                policy=self.policy,
+                catalog=self.catalog,
+                prices=self.prices,
+                ledgers={row["cell_id"]: self.source_ledger},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_router_publish.py
+++ b/obench/tests/test_router_publish.py
@@ -202,7 +202,6 @@ class RouterPublishTests(unittest.TestCase):
             "response_body": "private answer",
             "transcript_path": "/Users/private/transcript.txt",
         }
-        self._write_results(self.row)
         self._write_ledger()
 
     def _write_results(self, *rows):
@@ -252,6 +251,13 @@ class RouterPublishTests(unittest.TestCase):
             canonical_line(request) + canonical_line(seal),
             encoding="utf-8",
         )
+        self.row["ledger_seal"] = {
+            "record_count": seal["record_count"],
+            "last_sequence": seal["last_sequence"],
+            "root_hash": seal["root_hash"],
+            "ledger_file": self.source_ledger.name,
+        }
+        self._write_results(self.row)
 
     def publish(self):
         return router_publish.publish_bundle(
@@ -319,6 +325,34 @@ class RouterPublishTests(unittest.TestCase):
         direct["proxy_metrics"]["calls"][0]["timing"]["ttfb_s"] = 0.5
         direct["proxy_metrics"]["calls"][0]["timing"]["semantic_ttft_s"] = 1.0
         direct["proxy_metrics"]["calls"][0]["route"]["provider"] = "Direct"
+        direct_ledger = self.root / "direct-ledger.jsonl"
+        request = json.loads(self.source_ledger.read_text().splitlines()[0])
+        request["router_arm"] = {
+            "arm_id": "direct",
+            "arm_digest": direct_identity.arm_digest,
+            "route_kind": "direct",
+        }
+        request["record_hash"] = hashlib.sha256(
+            results.canonical_json_bytes({
+                key: value for key, value in request.items() if key != "record_hash"
+            })
+        ).hexdigest()
+        seal = {
+            "record_type": "ledger_seal",
+            "state": "SEALED",
+            "record_count": 1,
+            "last_sequence": 1,
+            "root_hash": request["record_hash"],
+        }
+        direct_ledger.write_text(
+            canonical_line(request) + canonical_line(seal), encoding="utf-8"
+        )
+        direct["ledger_seal"] = {
+            "record_count": 1,
+            "last_sequence": 1,
+            "root_hash": request["record_hash"],
+            "ledger_file": direct_ledger.name,
+        }
 
         source_rows = [direct, self.row]
         self._write_results(*source_rows)
@@ -330,7 +364,7 @@ class RouterPublishTests(unittest.TestCase):
             catalog=self.catalog,
             prices=self.prices,
             ledgers={
-                direct["cell_id"]: self.source_ledger,
+                direct["cell_id"]: direct_ledger,
                 self.cell_id: self.source_ledger,
             },
         )
@@ -419,6 +453,12 @@ class RouterPublishTests(unittest.TestCase):
             encoding="utf-8",
         )
         with self.assertRaisesRegex(router_publish.RouterPublishError, "tampered"):
+            self.publish()
+
+    def test_publish_rejects_source_ledger_not_bound_to_result(self):
+        self.row["ledger_seal"]["root_hash"] = "0" * 64
+        self._write_results(self.row)
+        with self.assertRaisesRegex(router_publish.RouterPublishError, "does not match"):
             self.publish()
 
     def test_verify_rejects_tamper_extra_artifact_and_binding_mismatch(self):

--- a/obench/tests/test_router_publish.py
+++ b/obench/tests/test_router_publish.py
@@ -53,6 +53,7 @@ def experiment():
                 "endpoint": "https://direct.example.test/v1/chat/completions",
                 "protocol": "openai_chat",
                 "baseline": True,
+                "canonical_model": "openai/gpt-test",
                 "requested_model": "openai/gpt-test",
                 "requested_provider": "OpenAI",
                 "allowed_models": ["openai/gpt-test"],
@@ -69,6 +70,7 @@ def experiment():
                 "endpoint": "https://router.example.test/private/v1/chat/completions",
                 "protocol": "openai_chat",
                 "baseline": False,
+                "canonical_model": "openai/gpt-test",
                 "requested_model": "openai/gpt-test",
                 "requested_provider": "OpenAI",
                 "allowed_models": ["openai/gpt-test"],
@@ -174,6 +176,11 @@ class RouterPublishTests(unittest.TestCase):
                 "infrastructure_invalid_reason": None,
             },
             "route_integrity": {"pass": True, "reasons": []},
+            "route_isolation": {
+                "classification": "exploratory",
+                "lane": "router-local-v1",
+                "egress_enforced": False,
+            },
             "proxy_metrics": {"calls": [{
                 "timing": {"ttfb_s": 1.0, "semantic_ttft_s": 2.0},
                 "generation": {"output_tokens": 4, "duration_s": 1.0},

--- a/obench/tests/test_router_publish.py
+++ b/obench/tests/test_router_publish.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import hashlib
 import json
@@ -11,6 +12,7 @@ import unittest
 
 from obench import results
 from obench import router_publish
+from obench import router_report
 from obench import router_spec
 
 
@@ -160,10 +162,33 @@ class RouterPublishTests(unittest.TestCase):
             "identity": self.identity.as_dict(),
             "run_id": results.make_router_run_id(self.identity),
             "cell_id": self.cell_id,
-            "completed": True,
-            "success": True,
-            "score": 1.0,
-            "usage": {"input_tokens": 11, "output_tokens": 4, "total_tokens": 15},
+            "expected_arm_ids": ["direct", "gateway"],
+            "arm_role": "gateway",
+            "baseline": False,
+            "result": {
+                "solved": True,
+                "checker_score": 1.0,
+                "available": True,
+                "duration_s": 12.0,
+                "timed_out": False,
+                "infrastructure_invalid_reason": None,
+            },
+            "route_integrity": {"pass": True, "reasons": []},
+            "proxy_metrics": {"calls": [{
+                "timing": {"ttfb_s": 1.0, "semantic_ttft_s": 2.0},
+                "generation": {"output_tokens": 4, "duration_s": 1.0},
+                "route": {
+                    "provider": "OpenAI",
+                    "served_model": "openai/gpt-test",
+                },
+                "costs": {
+                    "frozen_list_estimate": {
+                        "amount_usd": 0.001,
+                        "currency": "USD",
+                        "effective_at": "2026-07-01T00:00:00Z",
+                    },
+                },
+            }]},
             "raw_headers": {"authorization": "Bearer source-result-secret"},
             "query": "api_key=source-result-secret",
             "request_body": "private prompt",
@@ -179,7 +204,7 @@ class RouterPublishTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-    def _write_ledger(self, *, allowed_secret=None):
+    def _write_ledger(self, *, allowed_secret=None, partial=False):
         request = {
             "record_type": "request",
             "sequence": 1,
@@ -190,7 +215,11 @@ class RouterPublishTests(unittest.TestCase):
             "upstream": "https://router.example.test/private/v1",
             "status": 200,
             "model": allowed_secret or "openai/gpt-test",
-            "usage": {"input_tokens": 11, "output_tokens": 4, "total_tokens": 15},
+            "usage": (
+                None
+                if partial
+                else {"input_tokens": 11, "output_tokens": 4, "total_tokens": 15}
+            ),
             "router_arm": {
                 "arm_id": "gateway",
                 "arm_digest": self.identity.arm_digest,
@@ -198,6 +227,8 @@ class RouterPublishTests(unittest.TestCase):
             },
             "error": "request body and credentials must never publish",
         }
+        if partial:
+            request["router_metrics"] = None
         request["record_hash"] = hashlib.sha256(
             results.canonical_json_bytes({
                 key: value for key, value in request.items() if key != "record_hash"
@@ -265,6 +296,89 @@ class RouterPublishTests(unittest.TestCase):
         self.assertEqual(seal["root_hash"], binding["root_hash"])
         self.assertEqual(seal["seal_sha256"], binding["seal_sha256"])
 
+    def test_published_results_round_trip_through_router_report(self):
+        direct_identity = dataclasses.replace(
+            self.identity,
+            arm_id="direct",
+            arm_digest=self.experiment.arms[0].digest,
+        )
+        direct = copy.deepcopy(self.row)
+        direct["identity"] = direct_identity.as_dict()
+        direct["run_id"] = results.make_router_run_id(direct_identity)
+        direct["cell_id"] = results.make_router_cell_id(direct_identity)
+        direct["arm_role"] = "direct"
+        direct["baseline"] = True
+        direct["result"]["duration_s"] = 10.0
+        direct["proxy_metrics"]["calls"][0]["timing"]["ttfb_s"] = 0.5
+        direct["proxy_metrics"]["calls"][0]["timing"]["semantic_ttft_s"] = 1.0
+        direct["proxy_metrics"]["calls"][0]["route"]["provider"] = "Direct"
+
+        source_rows = [direct, self.row]
+        self._write_results(*source_rows)
+        router_publish.publish_bundle(
+            self.results_path,
+            self.bundle,
+            experiment=self.experiment,
+            policy=self.policy,
+            catalog=self.catalog,
+            prices=self.prices,
+            ledgers={
+                direct["cell_id"]: self.source_ledger,
+                self.cell_id: self.source_ledger,
+            },
+        )
+        public_rows = [
+            json.loads(line)
+            for line in (self.bundle / "results.jsonl").read_text().splitlines()
+        ]
+
+        expected = router_report.aggregate(
+            source_rows, bootstrap_replicates=20, bootstrap_seed=7
+        )
+        actual = router_report.aggregate(
+            public_rows, bootstrap_replicates=20, bootstrap_seed=7
+        )
+        self.assertEqual(actual, expected)
+
+    def test_partial_failed_call_with_nullable_evidence_is_published(self):
+        call = self.row["proxy_metrics"]["calls"][0]
+        call["timing"] = None
+        call["generation"] = None
+        call["route"] = None
+        call["costs"] = None
+        self.row["result"].update(
+            solved=False,
+            checker_score=0.0,
+            available=False,
+            duration_s=None,
+            timed_out=True,
+        )
+        self._write_results(self.row)
+        self._write_ledger(partial=True)
+
+        provenance = self.publish()
+        self.assertEqual(router_publish.verify_bundle(self.bundle), provenance)
+        public_row = json.loads((self.bundle / "results.jsonl").read_text())
+        public_call = public_row["proxy_metrics"]["calls"][0]
+        self.assertNotIn("timing", public_call)
+        self.assertIsNone(public_call["generation"])
+        self.assertNotIn("route", public_call)
+        self.assertIsNone(public_call["costs"])
+        public_ledger = self.bundle / public_row["ledger"]["artifact"]
+        request = json.loads(public_ledger.read_text().splitlines()[0])
+        self.assertIsNone(request["usage"])
+        self.assertIsNone(request["router_metrics"])
+
+    def test_partial_call_shape_validation_remains_fail_closed(self):
+        self.row["proxy_metrics"]["calls"][0]["generation"] = "unknown"
+        self._write_results(self.row)
+
+        with self.assertRaisesRegex(
+            router_publish.RouterPublishError,
+            "generation must be an object",
+        ):
+            self.publish()
+
     def test_publish_rejects_corrupt_jsonl_and_cell_ledger_mismatch(self):
         self.results_path.write_bytes(self.results_path.read_bytes()[:-1])
         with self.assertRaisesRegex(router_publish.RouterPublishError, "newline"):
@@ -303,7 +417,12 @@ class RouterPublishTests(unittest.TestCase):
     def test_verify_rejects_tamper_extra_artifact_and_binding_mismatch(self):
         self.publish()
         results_path = self.bundle / "results.jsonl"
-        results_path.write_bytes(results_path.read_bytes().replace(b'"score":1.0', b'"score":0.0'))
+        results_path.write_bytes(
+            results_path.read_bytes().replace(
+                b'"checker_score":1.0',
+                b'"checker_score":0.0',
+            )
+        )
         with self.assertRaisesRegex(router_publish.RouterPublishError, "digest mismatch"):
             router_publish.verify_bundle(self.bundle)
 

--- a/obench/tests/test_router_report.py
+++ b/obench/tests/test_router_report.py
@@ -282,6 +282,12 @@ class RouterReportTests(unittest.TestCase):
             distribution["Fallback/gpt-fixed"]["share"], 1 / 6
         )
 
+    def test_route_label_does_not_duplicate_provider_prefix(self):
+        self.assertEqual(
+            router_report._route_label("OpenAI", "openai/gpt-fixed"),
+            "openai/gpt-fixed",
+        )
+
     def test_timeout_caps_end_to_end_latency(self):
         rows = self.complete_rows()
         rows[1]["result"]["duration_s"] = 300

--- a/obench/tests/test_router_report.py
+++ b/obench/tests/test_router_report.py
@@ -1,0 +1,392 @@
+"""Contract tests for the schema-v2 Gateway Tax report."""
+
+import copy
+import json
+import unittest
+
+from obench import results, router_report
+
+
+DIGESTS = {
+    name: format(index, "064x")
+    for index, name in enumerate(
+        (
+            "experiment",
+            "direct_arm",
+            "gateway_arm",
+            "policy",
+            "catalog",
+            "price",
+            "sampling",
+            "schedule",
+            "task_a",
+            "task_b",
+            "checker",
+        ),
+        1,
+    )
+}
+
+
+def make_row(
+    *,
+    task,
+    arm_id,
+    role,
+    baseline,
+    repetition=1,
+    window="w1",
+    block_attempt=0,
+    solved=True,
+    score=1.0,
+    available=True,
+    duration=10.0,
+    calls=None,
+    infrastructure_reason=None,
+    route_pass=True,
+    route_reasons=None,
+):
+    block_id = f"{task}-{window}-{repetition}-a{block_attempt}"
+    identity = results.CellIdentity.for_router(
+        track="gateway_tax",
+        experiment_id="gateway-tax-fixture",
+        experiment_digest=DIGESTS["experiment"],
+        arm_id=arm_id,
+        arm_digest=DIGESTS[f"{arm_id}_arm"],
+        policy_digest=DIGESTS["policy"],
+        catalog_digest=DIGESTS["catalog"],
+        price_digest=DIGESTS["price"],
+        sampling_digest=DIGESTS["sampling"],
+        schedule_digest=DIGESTS["schedule"],
+        task=task,
+        task_digest=DIGESTS[task],
+        checker_digest=DIGESTS["checker"],
+        workspace_source_sha="a" * 40,
+        harness="pi",
+        candidate=None,
+        harness_version="1.0",
+        execution_lane="docker",
+        image_digest="b" * 64,
+        budget_timeout_s=30,
+        budget_max_calls=4,
+        budget_max_output_tokens=1000,
+        budget_usd_cap="1.00",
+        adapter_timeout_s=30,
+        checker_timeout_s=10,
+        window_id=window,
+        repetition=repetition,
+        block_id=block_id,
+        block_attempt=block_attempt,
+    )
+    result = {
+        "solved": solved,
+        "checker_score": score,
+        "available": available,
+        "duration_s": duration,
+        "infrastructure_invalid_reason": infrastructure_reason,
+    }
+    row = {
+        "schema_version": 2,
+        "benchmark": "router",
+        "run_id": results.make_router_run_id(identity),
+        "cell_id": results.make_router_cell_id(identity),
+        "identity": identity.as_dict(),
+        "arm_role": role,
+        "baseline": baseline,
+        "result": result,
+        "route_integrity": {
+            "pass": route_pass,
+            "reasons": route_reasons or [],
+        },
+        "proxy_metrics": {"calls": [] if calls is None else calls},
+    }
+    return row
+
+
+def call(
+    *,
+    provider="OpenAI",
+    model="gpt-fixed",
+    ttfb=1.0,
+    ttft=2.0,
+    tokens=10,
+    generation_s=2.0,
+    costs=True,
+):
+    bases = {}
+    if costs:
+        bases = {
+            "router_reported": {
+                "amount_usd": 0.10,
+                "currency": "USD",
+                "effective_at": "2026-07-01T00:00:00Z",
+            },
+            "frozen_list_estimate": {
+                "amount_usd": 0.12,
+                "currency": "USD",
+                "effective_at": "2026-07-01T00:00:00Z",
+            },
+        }
+    return {
+        "timing": {"ttfb_s": ttfb, "semantic_ttft_s": ttft},
+        "generation": {"output_tokens": tokens, "duration_s": generation_s},
+        "route": {"provider": provider, "served_model": model},
+        "costs": bases,
+    }
+
+
+class RouterReportTests(unittest.TestCase):
+    def complete_rows(self):
+        rows = []
+        for task in ("task_a", "task_b"):
+            for repetition in (1, 2):
+                rows.append(
+                    make_row(
+                        task=task,
+                        arm_id="direct",
+                        role="direct",
+                        baseline=True,
+                        repetition=repetition,
+                        duration=10 if task == "task_a" else 20,
+                        calls=[call(ttfb=1, ttft=2)],
+                    )
+                )
+                rows.append(
+                    make_row(
+                        task=task,
+                        arm_id="gateway",
+                        role="gateway",
+                        baseline=False,
+                        repetition=repetition,
+                        solved=task == "task_a",
+                        score=1.0 if task == "task_a" else 0.0,
+                        available=not (task == "task_b" and repetition == 2),
+                        duration=15 if task == "task_a" else 40,
+                        calls=[
+                            call(
+                                provider="OpenRouter",
+                                ttfb=2,
+                                ttft=4,
+                                tokens=20,
+                                generation_s=2,
+                            )
+                        ],
+                    )
+                )
+        return rows
+
+    def test_aggregates_cells_to_tasks_then_weights_tasks_equally(self):
+        report = router_report.aggregate(
+            self.complete_rows(), bootstrap_replicates=200, bootstrap_seed=7
+        )
+        direct = report["arms"]["direct"]
+        gateway = report["arms"]["gateway"]
+
+        self.assertEqual(report["blocks"], {
+            "observed": 4,
+            "included": 4,
+            "excluded": 0,
+            "excluded_by_reason": {},
+        })
+        self.assertEqual(report["tasks"]["included"], 2)
+        self.assertEqual(direct["metrics"]["solve_rate"]["estimate"], 1.0)
+        self.assertEqual(gateway["metrics"]["solve_rate"]["estimate"], 0.5)
+        self.assertEqual(gateway["metrics"]["availability"]["estimate"], 0.75)
+        self.assertEqual(gateway["metrics"]["latency_s"]["estimate"], 22.5)
+        self.assertEqual(
+            gateway["metrics"]["throughput_tokens_per_s"]["estimate"], 10.0
+        )
+        self.assertEqual(
+            report["paired_contrasts"]["gateway"]["metrics"]["latency_s"]["estimate"],
+            7.5,
+        )
+        self.assertEqual(
+            report["paired_contrasts"]["gateway"]["metrics"]["solve_rate"]["estimate"],
+            -0.5,
+        )
+        self.assertFalse(report["analysis"]["wilson_intervals"])
+        self.assertFalse(report["analysis"]["composite_score"])
+
+    def test_router_provider_failure_stays_in_attempted_denominator(self):
+        rows = self.complete_rows()
+        failed = rows[-1]
+        failed["result"].update(
+            solved=False,
+            checker_score=0.0,
+            available=False,
+            duration_s=30.0,
+            failure_origin="router",
+        )
+        failed["proxy_metrics"]["calls"] = []
+
+        report = router_report.aggregate(rows, bootstrap_replicates=20)
+
+        gateway = report["arms"]["gateway"]
+        self.assertEqual(report["blocks"]["included"], 4)
+        self.assertEqual(gateway["attempted_cells"], 4)
+        self.assertEqual(gateway["metrics"]["availability"]["estimate"], 0.75)
+        self.assertEqual(gateway["metrics"]["latency_s"]["estimate"], 22.5)
+
+    def test_invalid_and_incomplete_blocks_are_excluded_and_counted(self):
+        rows = self.complete_rows()
+        rows[0]["result"]["infrastructure_invalid_reason"] = "host"
+        rows[2]["route_integrity"] = {
+            "pass": False,
+            "reasons": ["served_model_mismatch"],
+        }
+        rows.pop()
+
+        report = router_report.aggregate(
+            rows,
+            expected_arm_ids=("direct", "gateway"),
+            bootstrap_replicates=20,
+        )
+
+        self.assertEqual(report["blocks"]["observed"], 4)
+        self.assertEqual(report["blocks"]["included"], 1)
+        self.assertEqual(report["blocks"]["excluded_by_reason"], {
+            "incomplete_all_arm_block": 1,
+            "infrastructure:host": 1,
+            "route_integrity:served_model_mismatch": 1,
+        })
+        self.assertEqual(report["arms"]["direct"]["attempted_cells"], 1)
+        self.assertEqual(report["arms"]["gateway"]["attempted_cells"], 1)
+
+    def test_cost_per_solve_requires_complete_call_coverage(self):
+        rows = self.complete_rows()
+        rows[-1]["proxy_metrics"]["calls"][0]["costs"].pop("router_reported")
+
+        report = router_report.aggregate(rows, bootstrap_replicates=20)
+        cost = report["arms"]["gateway"]["costs"]["router_reported"]
+
+        self.assertEqual(cost["basis_coverage"]["covered_calls"], 3)
+        self.assertEqual(cost["basis_coverage"]["total_calls"], 4)
+        self.assertFalse(cost["basis_coverage"]["complete"])
+        self.assertIsNotNone(cost["attempted_cost_usd"]["estimate"])
+        self.assertIsNone(cost["cost_per_solve_usd"])
+        estimate = report["arms"]["gateway"]["costs"]["frozen_list_estimate"]
+        self.assertEqual(estimate["cost_per_solve_usd"], 0.24)
+
+    def test_route_distribution_is_task_weighted(self):
+        rows = self.complete_rows()
+        rows[1]["proxy_metrics"]["calls"].append(
+            call(provider="Fallback", costs=False)
+        )
+        report = router_report.aggregate(rows, bootstrap_replicates=20)
+        distribution = report["arms"]["gateway"]["route_distribution"]
+
+        self.assertAlmostEqual(
+            distribution["OpenRouter/gpt-fixed"]["share"], 5 / 6
+        )
+        self.assertAlmostEqual(
+            distribution["Fallback/gpt-fixed"]["share"], 1 / 6
+        )
+
+    def test_timeout_caps_end_to_end_latency(self):
+        rows = self.complete_rows()
+        rows[1]["result"]["duration_s"] = 300
+        report = router_report.aggregate(rows, bootstrap_replicates=20)
+
+        self.assertEqual(
+            report["arms"]["gateway"]["metrics"]["latency_s"]["estimate"], 26.25
+        )
+
+    def test_timeout_without_observed_duration_uses_timeout_cap(self):
+        rows = self.complete_rows()
+        rows[1]["result"]["duration_s"] = None
+        rows[1]["result"]["timed_out"] = True
+        report = router_report.aggregate(rows, bootstrap_replicates=20)
+
+        self.assertEqual(
+            report["arms"]["gateway"]["metrics"]["latency_s"]["estimate"], 26.25
+        )
+
+    def test_conditional_contrasts_pair_within_blocks_before_tasks(self):
+        rows = self.complete_rows()
+        rows[0]["proxy_metrics"]["calls"][0]["timing"]["ttfb_s"] = 1
+        rows[1]["proxy_metrics"]["calls"][0]["timing"]["ttfb_s"] = None
+        rows[2]["proxy_metrics"]["calls"][0]["timing"]["ttfb_s"] = 3
+        rows[3]["proxy_metrics"]["calls"][0]["timing"]["ttfb_s"] = 5
+
+        report = router_report.aggregate(rows, bootstrap_replicates=20)
+
+        # task_a contributes the paired block delta 5 - 3 = 2. task_b
+        # contributes 2 - 1 = 1, so tasks equally produce 1.5.
+        contrast = report["paired_contrasts"]["gateway"]["metrics"]["ttfb_s"]
+        self.assertEqual(contrast["estimate"], 1.5)
+        self.assertEqual(contrast["paired_task_coverage"]["covered"], 2)
+        self.assertEqual(contrast["paired_block_coverage"]["covered"], 3)
+        coverage = report["arms"]["gateway"]["metrics"]["ttfb_s"]["call_coverage"]
+        self.assertEqual(coverage, {"covered": 3, "total": 4, "ratio": 0.75})
+
+    def test_bootstrap_and_json_are_deterministic_and_safe(self):
+        first = router_report.aggregate(
+            self.complete_rows(), bootstrap_replicates=100, bootstrap_seed=99
+        )
+        second = router_report.aggregate(
+            reversed(self.complete_rows()), bootstrap_replicates=100, bootstrap_seed=99
+        )
+
+        self.assertEqual(first, second)
+        encoded = json.dumps(first, allow_nan=False, sort_keys=True)
+        self.assertIn('"task_cluster_bootstrap_percentile"', encoded)
+
+    def test_text_renderer_is_concise_and_names_exclusions(self):
+        rows = self.complete_rows()
+        rows[0]["route_integrity"] = {"pass": False, "reasons": ["ledger_gap"]}
+        report = router_report.aggregate(rows, bootstrap_replicates=20)
+        text = router_report.render_text(report)
+
+        self.assertIn("Router Bench: gateway_tax", text)
+        self.assertIn("route_integrity:ledger_gap=1", text)
+        self.assertIn("gateway - direct", text)
+        self.assertLessEqual(len(text.splitlines()), 12)
+
+    def test_rejects_mixed_experiment_track_or_stratum(self):
+        mutators = (
+            lambda row: row["identity"]["experiment"].update(digest="f" * 64),
+            lambda row: row["identity"]["benchmark"].update(track="provider_router"),
+            lambda row: row["identity"]["comparison"].update(policy_digest="f" * 64),
+        )
+        for mutate in mutators:
+            rows = self.complete_rows()
+            mutate(rows[-1])
+            identity = results.validate_router_identity(rows[-1]["identity"])
+            rows[-1]["run_id"] = results.make_router_run_id(identity)
+            rows[-1]["cell_id"] = results.make_router_cell_id(identity)
+            with self.subTest(mutate=mutate), self.assertRaises(
+                router_report.RouterReportError
+            ):
+                router_report.aggregate(rows, bootstrap_replicates=10)
+
+    def test_rejects_duplicate_cells_and_inconsistent_arm_metadata(self):
+        rows = self.complete_rows()
+        with self.assertRaisesRegex(router_report.RouterReportError, "duplicate cell_id"):
+            router_report.aggregate(rows + [copy.deepcopy(rows[0])], bootstrap_replicates=10)
+
+        rows = self.complete_rows()
+        rows[-1]["baseline"] = True
+        with self.assertRaisesRegex(router_report.RouterReportError, "metadata"):
+            router_report.aggregate(rows, bootstrap_replicates=10)
+
+    def test_rejects_malformed_metric_and_route_evidence(self):
+        rows = self.complete_rows()
+        rows[0]["proxy_metrics"]["calls"][0]["generation"].pop("duration_s")
+        with self.assertRaisesRegex(router_report.RouterReportError, "must pair"):
+            router_report.aggregate(rows, bootstrap_replicates=10)
+
+        rows = self.complete_rows()
+        rows[0]["route_integrity"] = {"pass": True, "reasons": ["contradiction"]}
+        with self.assertRaisesRegex(router_report.RouterReportError, "passes"):
+            router_report.aggregate(rows, bootstrap_replicates=10)
+
+        rows = self.complete_rows()
+        rows[0]["proxy_metrics"]["calls"][0]["costs"]["router_reported"][
+            "currency"
+        ] = "EUR"
+        with self.assertRaisesRegex(router_report.RouterReportError, "must be USD"):
+            router_report.aggregate(rows, bootstrap_replicates=10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_router_report.py
+++ b/obench/tests/test_router_report.py
@@ -227,6 +227,28 @@ class RouterReportTests(unittest.TestCase):
         self.assertEqual(gateway["metrics"]["availability"]["estimate"], 0.75)
         self.assertEqual(gateway["metrics"]["latency_s"]["estimate"], 22.5)
 
+    def test_only_latest_block_attempt_is_reported(self):
+        rows = [
+            make_row(
+                task="task_a", arm_id=arm, role=role, baseline=baseline,
+                block_attempt=attempt, solved=attempt == 0,
+                score=1.0 if attempt == 0 else 0.0,
+                calls=[call(),],
+            )
+            for attempt in (0, 1)
+            for arm, role, baseline in (
+                ("direct", "direct", True),
+                ("gateway", "gateway", False),
+            )
+        ]
+        report = router_report.aggregate(rows, bootstrap_replicates=20)
+        self.assertEqual(report["blocks"]["observed"], 1)
+        self.assertEqual(report["arms"]["direct"]["attempted_cells"], 1)
+        self.assertEqual(
+            report["arms"]["direct"]["metrics"]["solve_rate"]["estimate"],
+            0.0,
+        )
+
     def test_invalid_and_incomplete_blocks_are_excluded_and_counted(self):
         rows = self.complete_rows()
         rows[0]["result"]["infrastructure_invalid_reason"] = "host"

--- a/obench/tests/test_router_route.py
+++ b/obench/tests/test_router_route.py
@@ -49,21 +49,44 @@ class RouteFixtureHandler(BaseHTTPRequestHandler):
             self.send_header("content-type", "text/event-stream")
             self.send_header("connection", "close")
             self.end_headers()
-            event = json.dumps({
+            event_body = {
                 "model": "gpt-route-test",
-                "openrouter_metadata": {
-                    "requested": "gpt-route-test",
-                    "attempts": [{
+                "choices": [{"delta": {"content": PRIVATE_CONTENT}}],
+            }
+            metadata = {
+                "requested": "gpt-route-test",
+                "attempts": [{
+                    "provider": "openai",
+                    "model": "gpt-route-test",
+                    "status": 200,
+                }],
+                "endpoints": {
+                    "available": [{"provider": "openai", "selected": True}],
+                },
+            }
+            if self.path.startswith("/sse-wrong-provider"):
+                metadata["attempts"] = []
+                metadata["endpoints"] = {
+                    "available": [{"provider": "different", "selected": True}],
+                }
+            elif self.path.startswith("/sse-no-attempts"):
+                metadata.pop("attempts")
+            elif self.path.startswith("/sse-fallback"):
+                metadata["attempts"] = [
+                    {
+                        "provider": "different",
+                        "model": "gpt-route-test",
+                        "status": 503,
+                    },
+                    {
                         "provider": "openai",
                         "model": "gpt-route-test",
                         "status": 200,
-                    }],
-                    "endpoints": {
-                        "available": [{"provider": "openai", "selected": True}],
                     },
-                },
-                "choices": [{"delta": {"content": PRIVATE_CONTENT}}],
-            }, separators=(",", ":"))
+                ]
+            if not self.path.startswith("/sse-direct"):
+                event_body["openrouter_metadata"] = metadata
+            event = json.dumps(event_body, separators=(",", ":"))
             stream = (
                 f"data: {event}\n\n"
                 'data: {"usage":{"prompt_tokens":5,"completion_tokens":3,'
@@ -211,6 +234,9 @@ class RouterRouteTests(unittest.TestCase):
                 "cookie": f"session={CLIENT_SECRET}",
                 "x-auth-token": CLIENT_SECRET,
                 "x-openrouter-metadata": "false",
+                "x-openrouter-cache": "true",
+                "x-openrouter-cache-key": "client-cache",
+                "x-openrouter-cache-control": "max-age=3600",
             },
         )
         self.assertEqual(status, 200)
@@ -218,6 +244,9 @@ class RouterRouteTests(unittest.TestCase):
         self.assertEqual(request["path"], "/gateway")
         self.assertEqual(request["headers"]["authorization"], f"Bearer {HOST_SECRET}")
         self.assertEqual(request["headers"]["x-openrouter-metadata"], "enabled")
+        self.assertEqual(request["headers"]["x-openrouter-cache"], "false")
+        self.assertNotIn("x-openrouter-cache-key", request["headers"])
+        self.assertNotIn("x-openrouter-cache-control", request["headers"])
         self.assertNotIn("x-api-key", request["headers"])
         self.assertNotIn("x-openrouter-api-key", request["headers"])
         self.assertNotIn("cookie", request["headers"])
@@ -306,6 +335,23 @@ class RouterRouteTests(unittest.TestCase):
         ledger = self.server._ledger_path(token).read_text(encoding="utf-8")
         for secret in (HOST_SECRET, CLIENT_SECRET, PRIVATE_CONTENT, PRIVATE_PROMPT):
             self.assertNotIn(secret, ledger)
+
+    def test_route_plan_constraints_drive_route_kind_aware_evidence(self):
+        cases = (
+            ("direct-pass", "direct", "/sse-direct", True, None),
+            ("wrong-provider", "gateway", "/sse-wrong-provider", False, "provider_conflict"),
+            ("no-attempts", "gateway", "/sse-no-attempts", True, None),
+            ("fallback", "gateway", "/sse-fallback", False, "fallback_attempt"),
+        )
+        for token, route_kind, path, expected_pass, reason in cases:
+            with self.subTest(token=token):
+                plan = self._register(token, route_kind=route_kind, path=path)
+                status, _ = self._post(token, plan.arm_digest)
+                self.assertEqual(status, 200)
+                evidence = self._seal_rows(token)[0]["router_metrics"]["route_evidence"]
+                self.assertEqual(evidence["pass"], expected_pass)
+                if reason is not None:
+                    self.assertIn(reason, evidence["reasons"])
 
 
 if __name__ == "__main__":

--- a/obench/tests/test_router_route.py
+++ b/obench/tests/test_router_route.py
@@ -238,6 +238,7 @@ class RouterRouteTests(unittest.TestCase):
                 "x-openrouter-cache": "true",
                 "x-openrouter-cache-key": "client-cache",
                 "x-openrouter-cache-control": "max-age=3600",
+                "accept-encoding": "gzip",
             },
         )
         self.assertEqual(status, 200)
@@ -252,6 +253,7 @@ class RouterRouteTests(unittest.TestCase):
         self.assertNotIn("x-openrouter-api-key", request["headers"])
         self.assertNotIn("cookie", request["headers"])
         self.assertNotIn("x-auth-token", request["headers"])
+        self.assertEqual(request["headers"].get("accept-encoding"), "identity")
         self.assertEqual(request["body"]["model"], plan.requested_model)
         self.assertEqual(request["body"]["temperature"], 0.0)
         self.assertEqual(request["body"]["top_p"], 1.0)

--- a/obench/tests/test_router_route.py
+++ b/obench/tests/test_router_route.py
@@ -119,6 +119,7 @@ def route_plan(*, endpoint, route_kind, arm_id, arm_digest):
         route_kind=route_kind,
         endpoint=endpoint,
         protocol="openai_chat",
+        canonical_model="openai/gpt-route-test",
         requested_model="gpt-route-test",
         requested_provider="openai",
         allowed_models=("gpt-route-test",),

--- a/obench/tests/test_router_route.py
+++ b/obench/tests/test_router_route.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""End-to-end tests for managed Router Bench proxy routes."""
+
+import http.client
+import json
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from obench import proxy
+from obench import router_spec
+
+
+HOST_SECRET = "HOST_ROUTER_SECRET_MUST_NOT_PERSIST"
+CLIENT_SECRET = "CLIENT_CREDENTIAL_MUST_NOT_FORWARD"
+PRIVATE_CONTENT = "PRIVATE_STREAM_CONTENT_MUST_NOT_PERSIST"
+PRIVATE_PROMPT = "PRIVATE_PROMPT_MUST_NOT_PERSIST"
+
+
+class RouteFixtureServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+class RouteFixtureHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("content-length") or 0)
+        body = self.rfile.read(length)
+        self.server.requests.append({
+            "path": self.path,
+            "headers": {key.lower(): value for key, value in self.headers.items()},
+            "body": json.loads(body),
+        })
+        if self.path.startswith("/redirect"):
+            self.send_response(302)
+            self.send_header("location", "http://example.invalid/escaped")
+            self.send_header("content-length", "0")
+            self.end_headers()
+            return
+        if self.path.startswith("/sse"):
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("connection", "close")
+            self.end_headers()
+            event = json.dumps({
+                "model": "gpt-route-test",
+                "openrouter_metadata": {
+                    "requested": "gpt-route-test",
+                    "attempts": [{
+                        "provider": "openai",
+                        "model": "gpt-route-test",
+                        "status": 200,
+                    }],
+                    "endpoints": {
+                        "available": [{"provider": "openai", "selected": True}],
+                    },
+                },
+                "choices": [{"delta": {"content": PRIVATE_CONTENT}}],
+            }, separators=(",", ":"))
+            stream = (
+                f"data: {event}\n\n"
+                'data: {"usage":{"prompt_tokens":5,"completion_tokens":3,'
+                '"total_tokens":8}}\n\n'
+                "data: [DONE]\n\n"
+            ).encode()
+            cuts = (7, 19, 43, 71, 113, len(stream))
+            start = 0
+            for end in cuts:
+                self.wfile.write(stream[start:end])
+                self.wfile.flush()
+                start = end
+                time.sleep(0.005)
+            self.close_connection = True
+            return
+        payload = b'{"usage":{"prompt_tokens":4,"completion_tokens":2}}'
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def route_plan(*, endpoint, route_kind, arm_id, arm_digest):
+    return router_spec.RoutePlan(
+        schema_version=1,
+        experiment_digest="e" * 64,
+        arm_digest=arm_digest,
+        arm_id=arm_id,
+        route_kind=route_kind,
+        endpoint=endpoint,
+        protocol="openai_chat",
+        requested_model="gpt-route-test",
+        requested_provider="openai",
+        allowed_models=("gpt-route-test",),
+        allowed_providers=("openai",),
+        fallback_enabled=False,
+        retry_count=0,
+        cache_enabled=False,
+        auth_env="ROUTER_TEST_KEY",
+        sampling=router_spec.Sampling(temperature=0.0, top_p=1.0, seed=1234),
+        private_router=True,
+        private_host_allowlist=("127.0.0.1",),
+        private_cidr_allowlist=(),
+    )
+
+
+def secret_plan(arm_id):
+    return router_spec.SecretPlan((
+        router_spec._ArmSecret(arm_id, "ROUTER_TEST_KEY", HOST_SECRET),
+    ))
+
+
+class RouterRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="router_route_test_")
+        self.upstream = RouteFixtureServer(("127.0.0.1", 0), RouteFixtureHandler)
+        self.upstream.requests = []
+        self.upstream_thread = threading.Thread(target=self.upstream.serve_forever, daemon=True)
+        self.upstream_thread.start()
+        self.upstream_base = f"http://127.0.0.1:{self.upstream.server_address[1]}"
+        self.server = proxy.make_server("127.0.0.1", 0, self.tmp.name)
+        self.server_thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.server_thread.start()
+        self.host, self.port = self.server.server_address[:2]
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.upstream.shutdown()
+        self.upstream.server_close()
+        self.tmp.cleanup()
+
+    def _register(self, token, *, route_kind="gateway", path="/gateway"):
+        digest = ("a" if route_kind == "gateway" else "b") * 64
+        plan = route_plan(
+            endpoint=self.upstream_base + path,
+            route_kind=route_kind,
+            arm_id=f"{route_kind}-{token}",
+            arm_digest=digest,
+        )
+        self.server.register_cell(token)
+        self.server.register_route(token, plan, secret_plan(plan.arm_id))
+        return plan
+
+    def _post(self, token, digest, body=None, headers=None, suffix="/client/controlled"):
+        payload = json.dumps(body or {
+            "model": "client-model",
+            "messages": [{"role": "user", "content": PRIVATE_PROMPT}],
+            "temperature": 0.9,
+            "top_p": 0.2,
+            "seed": 9,
+        }).encode()
+        request_headers = {
+            "content-type": "application/json",
+            "content-length": str(len(payload)),
+        }
+        request_headers.update(headers or {})
+        conn = http.client.HTTPConnection(self.host, self.port, timeout=5)
+        conn.request(
+            "POST",
+            f"/cell/{token}/route/{digest}{suffix}?client=query",
+            body=payload,
+            headers=request_headers,
+        )
+        response = conn.getresponse()
+        response_body = response.read()
+        conn.close()
+        return response.status, response_body
+
+    def _seal_rows(self, token):
+        seal = self.server.seal_cell(token, timeout_s=2)
+        with seal.path.open(encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh]
+
+    def test_gateway_authorizes_exact_arm_and_rewrites_credentials_and_body(self):
+        token = "gateway-cell"
+        plan = self._register(token)
+        status, _ = self._post(token, "f" * 64)
+        self.assertEqual(status, 502)
+        self.assertEqual(self.upstream.requests, [])
+
+        status, _ = self._post(
+            token,
+            plan.arm_digest,
+            body={
+                "model": "attacker-model",
+                "messages": [{
+                    "role": "user",
+                    "content": PRIVATE_PROMPT,
+                    "cache_control": {"type": "ephemeral"},
+                }],
+                "provider": {"only": ["attacker"], "allow_fallbacks": True},
+                "cache": True,
+                "prompt_cache_key": "client-cache",
+                "temperature": 0.8,
+                "top_p": 0.1,
+                "seed": 99,
+                "reasoning_effort": "high",
+            },
+            headers={
+                "authorization": f"Bearer {CLIENT_SECRET}",
+                "x-api-key": CLIENT_SECRET,
+                "x-openrouter-api-key": CLIENT_SECRET,
+                "cookie": f"session={CLIENT_SECRET}",
+                "x-auth-token": CLIENT_SECRET,
+                "x-openrouter-metadata": "false",
+            },
+        )
+        self.assertEqual(status, 200)
+        request = self.upstream.requests[-1]
+        self.assertEqual(request["path"], "/gateway")
+        self.assertEqual(request["headers"]["authorization"], f"Bearer {HOST_SECRET}")
+        self.assertEqual(request["headers"]["x-openrouter-metadata"], "enabled")
+        self.assertNotIn("x-api-key", request["headers"])
+        self.assertNotIn("x-openrouter-api-key", request["headers"])
+        self.assertNotIn("cookie", request["headers"])
+        self.assertNotIn("x-auth-token", request["headers"])
+        self.assertEqual(request["body"]["model"], plan.requested_model)
+        self.assertEqual(request["body"]["temperature"], 0.0)
+        self.assertEqual(request["body"]["top_p"], 1.0)
+        self.assertEqual(request["body"]["seed"], 1234)
+        self.assertNotIn("reasoning_effort", request["body"])
+        self.assertNotIn("cache", request["body"])
+        self.assertNotIn("prompt_cache_key", request["body"])
+        self.assertNotIn("cache_control", request["body"]["messages"][0])
+        self.assertEqual(request["body"]["provider"], {
+            "only": ["openai"],
+            "allow_fallbacks": False,
+        })
+
+        rows = self._seal_rows(token)
+        ledger = self.server._ledger_path(token).read_text(encoding="utf-8")
+        self.assertEqual(rows[0]["router_arm"]["arm_digest"], plan.arm_digest)
+        for secret in (HOST_SECRET, CLIENT_SECRET, PRIVATE_PROMPT):
+            self.assertNotIn(secret, ledger)
+
+    def test_direct_openai_forces_model_and_sampling_without_gateway_metadata(self):
+        token = "direct-cell"
+        plan = self._register(token, route_kind="direct", path="/direct")
+        status, _ = self._post(
+            token,
+            plan.arm_digest,
+            body={
+                "model": "wrong",
+                "messages": [],
+                "provider": {"only": ["wrong"]},
+                "temperature": 1.0,
+                "top_p": 0.0,
+                "seed": 1,
+            },
+        )
+        self.assertEqual(status, 200)
+        request = self.upstream.requests[-1]
+        self.assertEqual(request["path"], "/direct")
+        self.assertNotIn("x-openrouter-metadata", request["headers"])
+        self.assertNotIn("provider", request["body"])
+        self.assertEqual(request["body"]["model"], plan.requested_model)
+        self.assertEqual(
+            {key: request["body"][key] for key in ("temperature", "top_p", "seed")},
+            {"temperature": 0.0, "top_p": 1.0, "seed": 1234},
+        )
+
+    def test_redirect_is_rejected_and_recorded_without_following(self):
+        token = "redirect-cell"
+        plan = self._register(token, path="/redirect")
+        status, _ = self._post(token, plan.arm_digest)
+        self.assertEqual(status, 502)
+        self.assertEqual(len(self.upstream.requests), 1)
+        rows = self._seal_rows(token)
+        self.assertEqual(rows[0]["status"], 502)
+        self.assertIn("redirect rejected", rows[0]["error"])
+
+    def test_fragmented_sse_adds_privacy_safe_metrics_to_sealed_ledger(self):
+        token = "stream-cell"
+        plan = self._register(token, path="/sse")
+        status, response = self._post(token, plan.arm_digest)
+        self.assertEqual(status, 200)
+        self.assertIn(PRIVATE_CONTENT.encode(), response)
+
+        rows = self._seal_rows(token)
+        request = rows[0]
+        metrics = request["router_metrics"]
+        self.assertEqual(metrics["usage"], {
+            "input_tokens": 5,
+            "output_tokens": 3,
+            "total_tokens": 8,
+        })
+        self.assertEqual(metrics["route"]["requested_model"], "gpt-route-test")
+        self.assertEqual(metrics["route"]["served_model"], "gpt-route-test")
+        self.assertEqual(metrics["route"]["provider"], "openai")
+        self.assertTrue(metrics["route_evidence"]["pass"])
+        self.assertTrue(metrics["stream"]["done"])
+        self.assertTrue(metrics["stream"]["finalized"])
+        self.assertGreaterEqual(metrics["timing"]["ttfb_s"], 0)
+        self.assertGreaterEqual(metrics["timing"]["semantic_ttft_s"], 0)
+        self.assertGreaterEqual(metrics["timing"]["total_s"], 0)
+        self.assertEqual(request["router_arm"]["arm_digest"], plan.arm_digest)
+
+        ledger = self.server._ledger_path(token).read_text(encoding="utf-8")
+        for secret in (HOST_SECRET, CLIENT_SECRET, PRIVATE_CONTENT, PRIVATE_PROMPT):
+            self.assertNotIn(secret, ledger)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_router_run.py
+++ b/obench/tests/test_router_run.py
@@ -426,6 +426,64 @@ direct_control_arm_id = "direct"
         }
         self.assertIn("malformed_sse_event", router_run._route_reasons(metrics, plan))
 
+    def test_price_coverage_and_auth_failures_fail_closed(self):
+        experiment = router_run.router_spec.load_experiment(self.experiment)
+        with mock.patch.object(router_run.pi, "version", return_value="fake-pi 1.0"):
+            report = router_run.doctor_experiment(
+                self.experiment,
+                tasks_dir=self.tasks,
+                environ={
+                    **self.env,
+                    router_run.FROZEN_PRICES_ENV: json.dumps({
+                        "other/model": {
+                            "input_per_million": "1",
+                            "output_per_million": "1",
+                            "effective_at": "2026-07-22",
+                        }
+                    }),
+                },
+            )
+        self.assertFalse(report["usd_cap_enforceable"])
+        self.assertEqual(report["missing_price_models"], ["openai/fake-model"])
+        incomplete_env = {
+            **self.env,
+            router_run.FROZEN_PRICES_ENV: json.dumps({
+                "other/model": {
+                    "input_per_million": "1",
+                    "output_per_million": "1",
+                    "effective_at": "2026-07-22",
+                }
+            }),
+        }
+        with mock.patch.object(router_run.pi, "version", return_value="fake-pi 1.0"):
+            with self.assertRaisesRegex(router_run.RouterRunError, "missing"):
+                router_run.run_experiment(
+                    self.experiment,
+                    results_path=self.results,
+                    tasks_dir=self.tasks,
+                    exec_mode="local",
+                    environ=incomplete_env,
+                    adapters_dir=self.adapters,
+                )
+        self.assertFalse(self.results.exists())
+
+        plans, _secrets = router_run.router_spec.compile_route_plans(
+            experiment,
+            environ=self.env,
+            admitted_auth_envs={"DIRECT_KEY", "GATEWAY_KEY"},
+        )
+        plan = plans[0]
+        _calls, integrity, reason = router_run._proxy_evidence(
+            [{"status": 401}],
+            {plan.canonical_model: router_run.Price(
+                router_run.Decimal("1"), router_run.Decimal("1"), "2026-07-22"
+            )},
+            experiment.budget,
+            plan,
+        )
+        self.assertTrue(integrity["pass"])
+        self.assertEqual(reason, "upstream_auth_failure")
+
     def test_docker_fails_closed_in_local_mvp(self):
         with self._runtime():
             with self.assertRaisesRegex(router_run.RouterRunError, "unsupported"):

--- a/obench/tests/test_router_run.py
+++ b/obench/tests/test_router_run.py
@@ -402,6 +402,30 @@ direct_control_arm_id = "direct"
             {0},
         )
 
+    def test_proxy_evidence_honors_parser_integrity_verdict(self):
+        experiment = router_run.router_spec.load_experiment(self.experiment)
+        plans, _secrets = router_run.router_spec.compile_route_plans(
+            experiment,
+            environ=self.env,
+            admitted_auth_envs={"DIRECT_KEY", "GATEWAY_KEY"},
+        )
+        plan = next(item for item in plans if item.route_kind == "gateway")
+        metrics = {
+            "route": {
+                "requested_model": plan.requested_model,
+                "metadata_requested_model": plan.requested_model,
+                "served_model": plan.requested_model,
+                "provider": plan.requested_provider,
+                "attempts": [],
+            },
+            "stream": {"done": True},
+            "route_evidence": {
+                "pass": False,
+                "reasons": ["malformed_sse_event"],
+            },
+        }
+        self.assertIn("malformed_sse_event", router_run._route_reasons(metrics, plan))
+
     def test_docker_fails_closed_in_local_mvp(self):
         with self._runtime():
             with self.assertRaisesRegex(router_run.RouterRunError, "unsupported"):

--- a/obench/tests/test_router_run.py
+++ b/obench/tests/test_router_run.py
@@ -353,10 +353,10 @@ direct_control_arm_id = "direct"
             self.assertEqual((code, err), (0, ""))
             report = json.loads(out)
             self.assertEqual(report["blocks"], {
-                "excluded": 1,
-                "excluded_by_reason": {"incomplete_all_arm_block": 1},
+                "excluded": 0,
+                "excluded_by_reason": {},
                 "included": 1,
-                "observed": 2,
+                "observed": 1,
             })
             self.assertEqual(report["arms"]["gateway"]["attempted_cells"], 1)
 

--- a/obench/tests/test_router_run.py
+++ b/obench/tests/test_router_run.py
@@ -1,0 +1,419 @@
+"""Focused local Gateway Tax runner and CLI integration tests."""
+
+from __future__ import annotations
+
+import contextlib
+import http.client
+import io
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+from obench import cli, proxy, results, router_report, router_run
+
+
+SECRET = "gateway-tax-secret-that-must-not-persist"
+PRICE_JSON = json.dumps({
+    "openai/fake-model": {
+        "input_per_million": "1.00",
+        "output_per_million": "2.00",
+        "effective_at": "2026-07-22T00:00:00Z",
+    }
+})
+
+
+class _UpstreamHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, _format, *_args):
+        return
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("content-length", "0"))
+        body = json.loads(self.rfile.read(length))
+        self.server.requests.append({  # type: ignore[attr-defined]
+            "path": self.path,
+            "body": body,
+            "authorization": self.headers.get("authorization"),
+        })
+        gateway = "/gateway/" in self.path
+        status = 503 if gateway else 200
+        event = {
+            "model": "fake-model",
+            "provider": "openai",
+            "openrouter_metadata": {
+                "requested": "fake-model",
+                "attempts": [{
+                    "provider": "openai",
+                    "model": "fake-model",
+                    "status": status,
+                }],
+                "endpoints": {
+                    "available": [{"provider": "openai", "selected": True}]
+                },
+            },
+            "choices": [{"delta": {"content": "fake completion"}}],
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 3,
+                "total_tokens": 8,
+            },
+        }
+        payload = (
+            f"data: {json.dumps(event, separators=(',', ':'))}\n\n"
+            "data: [DONE]\n\n"
+        ).encode()
+        self.send_response(status)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(payload)))
+        self.send_header("connection", "close")
+        self.end_headers()
+        self.wfile.write(payload)
+        self.close_connection = True
+
+
+FAKE_ADAPTER = '''\
+import http.client
+import json
+import os
+from pathlib import Path
+from urllib.parse import urlsplit
+
+ADAPTER_API_VERSION = 2
+ROUTED_CAPABILITIES = {
+    "protocols": ["openai_chat"],
+    "execution_lanes": ["local", "docker"],
+    "streaming": True,
+    "dynamic_model_ids": True,
+    "route_plan_transport": "sanitized_file",
+}
+
+def run(*_args):
+    raise AssertionError("ordinary run() must not be used")
+
+def run_routed(_instruction, workdir, route_plan_path, _timeout_s):
+    plan = json.loads(Path(route_plan_path).read_text())
+    base = os.environ["OPENBENCH_PROXY_BASE_URL"]
+    token = os.environ["OPENBENCH_PROXY_CELL_TOKEN"]
+    url = urlsplit(base)
+    body = json.dumps({
+        "model": "client-controlled",
+        "messages": [{"role": "user", "content": "private prompt"}],
+        "stream": True,
+        "temperature": 1.5,
+        "top_p": 0.1,
+        "seed": 999,
+    })
+    conn = http.client.HTTPConnection(url.hostname, url.port, timeout=5)
+    conn.request(
+        "POST",
+        f"/cell/{token}/route/{plan['arm_digest']}",
+        body=body,
+        headers={
+            "content-type": "application/json",
+            "authorization": "Bearer client-secret",
+        },
+    )
+    response = conn.getresponse()
+    response.read()
+    conn.close()
+    if plan["route_kind"] == "direct":
+        Path(workdir, "solved.txt").write_text("checker owns the verdict\\n")
+        return {"completed": False, "error": "adapter self-report says failure"}
+    return {"completed": True, "error": None}
+'''
+
+
+class RouterRunE2ETests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="router_run_test_")
+        self.root = Path(self.temp.name)
+        self.tasks = self.root / "tasks"
+        self.task = self.tasks / "fake-task"
+        (self.task / "workspace").mkdir(parents=True)
+        (self.task / "workspace" / "README.txt").write_text("fresh\n")
+        (self.task / "instruction.md").write_text("Create solved.txt.\n")
+        checker = self.task / "checker.sh"
+        checker.write_text(
+            '#!/usr/bin/env bash\n'
+            'test -z "${DIRECT_KEY:-}"\n'
+            'test -z "${GATEWAY_KEY:-}"\n'
+            'test "$(cat solved.txt 2>/dev/null)" = "checker owns the verdict"\n'
+        )
+        checker.chmod(0o755)
+
+        self.adapters = self.root / "adapters"
+        self.adapters.mkdir()
+        (self.adapters / "pi.py").write_text(FAKE_ADAPTER)
+
+        self.upstream = ThreadingHTTPServer(("127.0.0.1", 0), _UpstreamHandler)
+        self.upstream.requests = []
+        self.upstream_thread = threading.Thread(
+            target=self.upstream.serve_forever, daemon=True
+        )
+        self.upstream_thread.start()
+        port = self.upstream.server_address[1]
+        self.experiment = self.root / "experiment.toml"
+        self.experiment.write_text(self._experiment_toml(port))
+        self.results = self.root / "router-results.jsonl"
+        self.env = {
+            "DIRECT_KEY": SECRET,
+            "GATEWAY_KEY": SECRET,
+            router_run.FROZEN_PRICES_ENV: PRICE_JSON,
+            router_run.ADAPTERS_DIR_ENV: str(self.adapters),
+        }
+
+    def tearDown(self):
+        self.upstream.shutdown()
+        self.upstream.server_close()
+        self.upstream_thread.join(timeout=2)
+        self.temp.cleanup()
+
+    @staticmethod
+    def _experiment_toml(port):
+        common = '''\
+protocol = "openai_chat"
+canonical_model = "openai/fake-model"
+requested_model = "fake-model"
+requested_provider = "openai"
+allowed_models = ["fake-model"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 7
+'''
+        return f'''\
+schema_version = 1
+experiment_id = "fake-gateway-tax"
+track = "gateway_tax"
+harness = "pi"
+tasks = ["fake-task"]
+repetitions_per_window = 1
+schedule_seed = 11
+execution_lane = "local"
+private_router = true
+private_cidr_allowlist = ["127.0.0.1/32"]
+
+[[windows]]
+window_id = "w1"
+start = "2026-07-01T00:00:00Z"
+end = "2026-08-01T00:00:00Z"
+
+[budget]
+timeout_s = 10
+max_calls = 1
+max_output_tokens = 10
+usd_cap = "1.0"
+
+[[arms]]
+arm_id = "direct"
+route_kind = "direct"
+endpoint = "https://127.0.0.1:{port}/direct/v1/chat/completions"
+baseline = true
+auth_env = "DIRECT_KEY"
+{common}
+
+[[arms]]
+arm_id = "gateway"
+route_kind = "gateway"
+endpoint = "https://127.0.0.1:{port}/gateway/v1/chat/completions"
+baseline = false
+auth_env = "GATEWAY_KEY"
+direct_control_arm_id = "direct"
+{common}
+'''
+
+    @contextlib.contextmanager
+    def _runtime(self):
+        # The schema correctly requires HTTPS. The in-process fake transport
+        # speaks plain HTTP; replace only the proxy client's connection class.
+        class PlainHTTPSConnection(http.client.HTTPConnection):
+            pass
+
+        with (
+            mock.patch.object(proxy.http.client, "HTTPSConnection", PlainHTTPSConnection),
+            mock.patch.object(router_run.pi, "version", return_value="fake-pi 1.0"),
+            mock.patch.dict(os.environ, self.env, clear=False),
+        ):
+            yield
+
+    def _cli(self, argv):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            code = cli.main(argv)
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_local_cli_vertical_slice_resume_seal_and_treatment_denominator(self):
+        with self._runtime():
+            code, out, err = self._cli([
+                "router", "validate", str(self.experiment),
+                "--tasks-dir", str(self.tasks),
+            ])
+            self.assertEqual((code, err), (0, ""))
+            self.assertIn("valid experiment=fake-gateway-tax", out)
+
+            code, out, err = self._cli([
+                "router", "doctor", str(self.experiment),
+                "--tasks-dir", str(self.tasks),
+            ])
+            self.assertEqual((code, err), (0, ""))
+            self.assertTrue(json.loads(out)["usd_cap_enforceable"])
+
+            code, out, err = self._cli([
+                "router", "run", str(self.experiment),
+                "--results", str(self.results),
+                "--tasks-dir", str(self.tasks),
+                "--exec", "local",
+            ])
+            self.assertEqual((code, err), (0, ""))
+            self.assertIn("rows_appended=2", out)
+            first_rows = results.read_jsonl_for_resume(self.results).rows
+            self.assertEqual({row["arm_role"] for row in first_rows}, {"direct", "gateway"})
+            self.assertEqual({tuple(row["schedule_order"]) for row in first_rows},
+                             {tuple(first_rows[0]["schedule_order"])})
+            self.assertTrue(all(row["ledger_seal"]["record_count"] == 1
+                                for row in first_rows))
+            self.assertTrue(all(row["route_integrity"]["pass"] for row in first_rows))
+            self.assertTrue(all(
+                row["result"]["infrastructure_invalid_reason"] is None
+                for row in first_rows
+            ))
+            direct = next(row for row in first_rows if row["arm_role"] == "direct")
+            gateway = next(row for row in first_rows if row["arm_role"] == "gateway")
+            self.assertTrue(direct["result"]["solved"])
+            self.assertFalse(direct["result"]["adapter_completed"])
+            self.assertFalse(gateway["result"]["solved"])
+            self.assertTrue(gateway["result"]["adapter_completed"])
+            self.assertFalse(gateway["result"]["available"])
+            self.assertEqual(
+                router_report.aggregate(first_rows)["arms"]["gateway"]["attempted_cells"],
+                1,
+            )
+
+            bundle = self.root / "bundle"
+            self.assertTrue(
+                (self.root / ".router-results.router-prices.json").is_file()
+            )
+            with mock.patch.dict(os.environ, {}, clear=True):
+                code, out, err = self._cli([
+                    "router", "publish", str(self.results), str(self.experiment), str(bundle),
+                ])
+            self.assertEqual((code, err), (0, ""))
+            self.assertEqual(json.loads(out)["result_count"], 2)
+            code, out, err = self._cli(["router", "verify", str(bundle)])
+            self.assertEqual((code, err), (0, ""))
+            self.assertEqual(json.loads(out)["result_count"], 2)
+            published = results.read_jsonl_for_resume(bundle / "results.jsonl").rows
+            self.assertEqual(
+                {row["route_isolation"]["classification"] for row in published},
+                {"exploratory"},
+            )
+
+            # A fully valid block is skipped on resume.
+            resumed = router_run.run_experiment(
+                self.experiment,
+                results_path=self.results,
+                tasks_dir=self.tasks,
+                exec_mode="local",
+                environ={**os.environ, **self.env},
+                adapters_dir=self.adapters,
+            )
+            self.assertEqual((resumed.rows_appended, resumed.blocks_skipped), (0, 1))
+
+            # A partial attempt is preserved; resume starts a fresh all-arm attempt.
+            partial = self.root / "partial.jsonl"
+            partial.write_text(json.dumps(first_rows[0], sort_keys=True) + "\n")
+            replacement = router_run.run_experiment(
+                self.experiment,
+                results_path=partial,
+                tasks_dir=self.tasks,
+                exec_mode="local",
+                environ={**os.environ, **self.env},
+                adapters_dir=self.adapters,
+            )
+            self.assertEqual(replacement.rows_appended, 2)
+            replacement_rows = results.read_jsonl_for_resume(partial).rows
+            self.assertEqual(
+                [row["identity"]["schedule"]["block_attempt"] for row in replacement_rows],
+                [0, 1, 1],
+            )
+
+            code, out, err = self._cli(["router", "report", str(partial), "--json"])
+            self.assertEqual((code, err), (0, ""))
+            report = json.loads(out)
+            self.assertEqual(report["blocks"], {
+                "excluded": 1,
+                "excluded_by_reason": {"incomplete_all_arm_block": 1},
+                "included": 1,
+                "observed": 2,
+            })
+            self.assertEqual(report["arms"]["gateway"]["attempted_cells"], 1)
+
+        persisted = self.results.read_text()
+        ledgers = "".join(
+            path.read_text()
+            for path in (self.root / ".router-results.router-ledgers").glob("*.jsonl")
+        )
+        self.assertNotIn(SECRET, persisted + ledgers)
+        self.assertEqual(
+            {request["authorization"] for request in self.upstream.requests},
+            {f"Bearer {SECRET}"},
+        )
+
+    def test_active_schedule_respects_declared_window(self):
+        experiment = router_run.router_spec.load_experiment(self.experiment)
+        schedule = router_run.build_schedule(experiment)
+        inside = router_run.datetime.fromisoformat("2026-07-15T00:00:00+00:00")
+        outside = router_run.datetime.fromisoformat("2026-08-02T00:00:00+00:00")
+        self.assertEqual(len(router_run._active_schedule(experiment, schedule, inside)), 1)
+        self.assertEqual(router_run._active_schedule(experiment, schedule, outside), ())
+
+    def test_budget_violation_never_retries_paid_block_automatically(self):
+        limited = self.root / "limited.toml"
+        limited.write_text(
+            self.experiment.read_text().replace("max_output_tokens = 10", "max_output_tokens = 1")
+        )
+        limited_results = self.root / "limited.jsonl"
+        with self._runtime():
+            with self.assertRaisesRegex(router_run.RouterRunError, "explicit rerun"):
+                router_run.run_experiment(
+                    limited,
+                    results_path=limited_results,
+                    tasks_dir=self.tasks,
+                    exec_mode="local",
+                    environ={**os.environ, **self.env},
+                    adapters_dir=self.adapters,
+                )
+        rows = results.read_jsonl_for_resume(limited_results).rows
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(
+            {row["identity"]["schedule"]["block_attempt"] for row in rows},
+            {0},
+        )
+
+    def test_docker_fails_closed_in_local_mvp(self):
+        with self._runtime():
+            with self.assertRaisesRegex(router_run.RouterRunError, "unsupported"):
+                router_run.run_experiment(
+                    self.experiment,
+                    results_path=self.results,
+                    tasks_dir=self.tasks,
+                    exec_mode="docker",
+                    environ={**os.environ, **self.env},
+                    adapters_dir=self.adapters,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_router_spec.py
+++ b/obench/tests/test_router_spec.py
@@ -266,6 +266,9 @@ class RouterExperimentTests(unittest.TestCase):
             (manifest().replace(
                 'canonical_model = "openai/gpt-test-2026-07-01"',
                 'canonical_model = "openai/other-model"', 1), "canonical_model"),
+            (manifest().replace(
+                'allowed_providers = ["openai"]',
+                'allowed_providers = ["openai", "other"]', 1), "only requested_provider"),
         )
         for text, message in cases:
             with self.subTest(message=message):

--- a/obench/tests/test_router_spec.py
+++ b/obench/tests/test_router_spec.py
@@ -1,0 +1,360 @@
+import dataclasses
+import hashlib
+import math
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from obench.router_spec import (
+    RouterSpecError,
+    canonical_digest,
+    canonical_json,
+    compile_route_plans,
+    load_experiment,
+    parse_experiment_toml,
+)
+
+
+def manifest(**replacements):
+    values = {
+        "track": "gateway_tax",
+        "harness": "pi",
+        "tasks": '["task-a", "task-b"]',
+        "repetitions": "2",
+        "windows": textwrap.dedent(
+            """
+            [[windows]]
+            window_id = "morning"
+            start = "2026-07-22T08:00:00Z"
+            end = "2026-07-22T09:00:00Z"
+
+            [[windows]]
+            window_id = "evening"
+            start = "2026-07-22T18:00:00-07:00"
+            end = "2026-07-22T19:00:00-07:00"
+            """
+        ).strip(),
+        "budget": textwrap.dedent(
+            """
+            [budget]
+            timeout_s = 300
+            max_calls = 8
+            max_output_tokens = 16000
+            usd_cap = 2.5
+            """
+        ).strip(),
+        "direct_extra": "",
+        "gateway_extra": 'direct_control_arm_id = "direct-openai"',
+        "direct_auth": 'auth_env = "OPENAI_API_KEY"',
+        "gateway_auth": 'auth_env = "OPENROUTER_API_KEY"',
+        "direct_controls": textwrap.dedent(
+            """
+            fallback_enabled = false
+            retry_count = 0
+            cache_enabled = false
+            """
+        ).strip(),
+        "gateway_controls": textwrap.dedent(
+            """
+            fallback_enabled = false
+            retry_count = 0
+            cache_enabled = false
+            """
+        ).strip(),
+    }
+    values.update(replacements)
+    return textwrap.dedent(
+        f"""
+        schema_version = 1
+        experiment_id = "gateway-tax-smoke"
+        track = "{values['track']}"
+        harness = "{values['harness']}"
+        tasks = {values['tasks']}
+        repetitions_per_window = {values['repetitions']}
+        schedule_seed = 17
+        execution_lane = "docker"
+        private_router = false
+
+        {values['windows']}
+
+        {values['budget']}
+
+        [[arms]]
+        arm_id = "direct-openai"
+        route_kind = "direct"
+        endpoint = "https://api.openai.com/v1/chat/completions"
+        protocol = "openai_chat"
+        baseline = true
+        requested_model = "gpt-test-2026-07-01"
+        requested_provider = "openai"
+        allowed_models = ["gpt-test-2026-07-01"]
+        allowed_providers = ["openai"]
+        {values['direct_controls']}
+        {values['direct_auth']}
+        {values['direct_extra']}
+
+        [arms.sampling]
+        temperature = 0.0
+        top_p = 1.0
+        seed = 1234
+
+        [[arms]]
+        arm_id = "via-openrouter"
+        route_kind = "gateway"
+        endpoint = "https://openrouter.ai/api/v1/chat/completions"
+        protocol = "openai_chat"
+        baseline = false
+        requested_model = "gpt-test-2026-07-01"
+        requested_provider = "openai"
+        allowed_models = ["gpt-test-2026-07-01"]
+        allowed_providers = ["openai"]
+        {values['gateway_controls']}
+        {values['gateway_auth']}
+        {values['gateway_extra']}
+
+        [arms.sampling]
+        temperature = 0.0
+        top_p = 1.0
+        seed = 1234
+        """
+    )
+
+
+class RouterExperimentTests(unittest.TestCase):
+    def test_loads_frozen_normalized_experiment(self):
+        spec = parse_experiment_toml(manifest())
+
+        self.assertEqual(spec.track, "gateway_tax")
+        self.assertEqual(spec.tasks, ("task-a", "task-b"))
+        self.assertEqual(spec.arms[1].direct_control_arm_id, "direct-openai")
+        self.assertEqual(spec.budget.usd_cap, "2.5")
+        self.assertTrue(spec.windows[0].start.endswith("Z"))
+        self.assertTrue(spec.windows[1].start.endswith("Z"))
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            spec.track = "model_router"
+
+    def test_load_file_matches_text_and_digest_ignores_toml_formatting(self):
+        text = manifest()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "experiment.toml")
+            path.write_text(text, encoding="utf-8")
+            from_file = load_experiment(path)
+
+        from_text = parse_experiment_toml("\n# comment\n" + text)
+        self.assertEqual(from_file, from_text)
+        self.assertEqual(from_file.digest, from_text.digest)
+        self.assertEqual(
+            from_file.digest,
+            hashlib.sha256(from_file.canonical_json.encode("utf-8")).hexdigest(),
+        )
+
+    def test_canonical_json_is_sorted_compact_and_rejects_non_finite_values(self):
+        self.assertEqual(canonical_json({"z": 1, "a": [True, None]}),
+                         '{"a":[true,null],"z":1}')
+        self.assertEqual(canonical_digest({"b": 2, "a": 1}),
+                         canonical_digest({"a": 1, "b": 2}))
+        with self.assertRaises(RouterSpecError):
+            canonical_json({"bad": math.inf})
+
+    def test_route_plan_is_sanitized_and_secret_plan_is_memory_only(self):
+        spec = parse_experiment_toml(manifest())
+        plans, secrets = compile_route_plans(
+            spec,
+            environ={
+                "OPENAI_API_KEY": "direct-secret-value",
+                "OPENROUTER_API_KEY": "gateway-secret-value",
+            },
+            admitted_auth_envs={"OPENAI_API_KEY", "OPENROUTER_API_KEY"},
+        )
+
+        persisted = canonical_json([plan.to_dict() for plan in plans])
+        self.assertIn("OPENAI_API_KEY", persisted)
+        self.assertNotIn("direct-secret-value", persisted)
+        self.assertNotIn("gateway-secret-value", persisted)
+        self.assertEqual(secrets.value_for("direct-openai"), "direct-secret-value")
+        self.assertNotIn("direct-secret-value", repr(secrets))
+        with self.assertRaises(TypeError):
+            canonical_json(secrets)
+
+    def test_secret_use_requires_explicit_admission_and_present_value(self):
+        spec = parse_experiment_toml(manifest())
+        with self.assertRaisesRegex(RouterSpecError, "not explicitly admitted"):
+            compile_route_plans(
+                spec,
+                environ={"OPENAI_API_KEY": "x", "OPENROUTER_API_KEY": "y"},
+                admitted_auth_envs={"OPENAI_API_KEY"},
+            )
+        with self.assertRaisesRegex(RouterSpecError, "missing or empty"):
+            compile_route_plans(
+                spec,
+                environ={"OPENAI_API_KEY": "x"},
+                admitted_auth_envs={"OPENAI_API_KEY", "OPENROUTER_API_KEY"},
+            )
+
+    def test_auth_accepts_environment_variable_names_never_values(self):
+        with self.assertRaisesRegex(RouterSpecError, "auth_env"):
+            parse_experiment_toml(
+                manifest(gateway_auth='auth_env = "sk-live-secret"')
+            )
+        with self.assertRaisesRegex(RouterSpecError, "unknown field"):
+            parse_experiment_toml(
+                manifest(gateway_extra='direct_control_arm_id = "direct-openai"\nauth_value = "secret"')
+            )
+
+    def test_rejects_unknown_keys_at_every_level(self):
+        cases = (
+            manifest().replace(
+                "schema_version = 1", "schema_version = 1\nunexpected = true", 1),
+            manifest(budget=manifest_budget() + "\nextra = 1"),
+            manifest(gateway_extra='direct_control_arm_id = "direct-openai"\nextra = 1'),
+            manifest(windows=manifest_windows().replace(
+                'window_id = "morning"', 'window_id = "morning"\nextra = 1', 1)),
+            manifest().replace("temperature = 0.0", "temperature = 0.0\nextra = 1", 1),
+        )
+        for text in cases:
+            with self.subTest(text=text[-80:]):
+                with self.assertRaisesRegex(RouterSpecError, "unknown field"):
+                    parse_experiment_toml(text)
+
+    def test_rejects_invalid_track_harness_tasks_windows_and_budget(self):
+        cases = (
+            (manifest(track="provider_router"), "track"),
+            (manifest(harness="codex"), "harness"),
+            (manifest(tasks='["task-a", "task-a"]'), "tasks"),
+            (manifest(repetitions="0"), "repetitions_per_window"),
+            (manifest(windows=overlapping_windows()), "overlap"),
+            (manifest(budget=manifest_budget().replace("max_calls = 8", "max_calls = 0")),
+             "max_calls"),
+            (manifest(budget=manifest_budget().replace("usd_cap = 2.5", "usd_cap = -1")),
+             "usd_cap"),
+        )
+        for text, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(RouterSpecError, message):
+                    parse_experiment_toml(text)
+
+    def test_gateway_tax_requires_direct_control_and_equal_fixed_conditions(self):
+        cases = (
+            (manifest(gateway_extra=""), "direct_control_arm_id"),
+            (manifest(direct_extra='direct_control_arm_id = "via-openrouter"'),
+             "direct arm"),
+            (manifest(gateway_extra='direct_control_arm_id = "missing"'),
+             "unknown direct control"),
+            (manifest(gateway_controls=manifest_controls().replace(
+                "fallback_enabled = false", "fallback_enabled = true")), "fallback"),
+            (manifest(gateway_controls=manifest_controls().replace(
+                "retry_count = 0", "retry_count = 1")), "retry_count"),
+            (manifest(gateway_controls=manifest_controls().replace(
+                "cache_enabled = false", "cache_enabled = true")), "cache"),
+            (manifest().replace(
+                'requested_model = "gpt-test-2026-07-01"',
+                'requested_model = "other-model"', 1), "requested_model"),
+        )
+        for text, message in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(RouterSpecError, message):
+                    parse_experiment_toml(text)
+
+    def test_rejects_non_https_and_private_endpoint_without_private_admission(self):
+        with self.assertRaisesRegex(RouterSpecError, "HTTPS"):
+            parse_experiment_toml(manifest().replace("https://api.openai.com", "http://api.openai.com"))
+        with self.assertRaisesRegex(RouterSpecError, "private_router"):
+            parse_experiment_toml(manifest().replace("api.openai.com", "127.0.0.1"))
+
+    def test_private_literal_endpoint_must_match_declared_allowlist(self):
+        private = manifest().replace(
+            "private_router = false",
+            'private_router = true\nprivate_cidr_allowlist = ["10.0.0.0/8"]',
+        ).replace("api.openai.com", "127.0.0.1")
+        with self.assertRaisesRegex(RouterSpecError, "not covered"):
+            parse_experiment_toml(private)
+
+        admitted = private.replace("10.0.0.0/8", "127.0.0.0/8")
+        self.assertEqual(
+            parse_experiment_toml(admitted).arms[0].endpoint,
+            "https://127.0.0.1/v1/chat/completions",
+        )
+
+    def test_private_host_allowlist_is_validated_and_normalized(self):
+        valid = manifest().replace(
+            "private_router = false",
+            'private_router = true\nprivate_host_allowlist = ["Router.Internal."]',
+        )
+        self.assertEqual(
+            parse_experiment_toml(valid).private_host_allowlist,
+            ("router.internal",),
+        )
+        with self.assertRaisesRegex(RouterSpecError, "bare DNS hostname"):
+            parse_experiment_toml(valid.replace("Router.Internal.", "bad host:443"))
+
+    def test_window_timestamps_require_rfc3339_not_broader_iso8601(self):
+        invalid = manifest().replace(
+            "2026-07-22T08:00:00Z", "2026-07-22 08:00:00+00:00"
+        )
+        with self.assertRaisesRegex(RouterSpecError, "RFC3339"):
+            parse_experiment_toml(invalid)
+
+    def test_compile_revalidates_manually_constructed_experiment(self):
+        spec = parse_experiment_toml(manifest())
+        invalid_arm = dataclasses.replace(spec.arms[0], endpoint="http://127.0.0.1")
+        invalid_spec = dataclasses.replace(spec, arms=(invalid_arm, spec.arms[1]))
+
+        with self.assertRaisesRegex(RouterSpecError, "HTTPS"):
+            compile_route_plans(
+                invalid_spec,
+                environ={"OPENAI_API_KEY": "x", "OPENROUTER_API_KEY": "y"},
+                admitted_auth_envs={"OPENAI_API_KEY", "OPENROUTER_API_KEY"},
+            )
+
+
+def manifest_budget():
+    return textwrap.dedent(
+        """
+        [budget]
+        timeout_s = 300
+        max_calls = 8
+        max_output_tokens = 16000
+        usd_cap = 2.5
+        """
+    ).strip()
+
+
+def manifest_controls():
+    return textwrap.dedent(
+        """
+        fallback_enabled = false
+        retry_count = 0
+        cache_enabled = false
+        """
+    ).strip()
+
+
+def manifest_windows():
+    return textwrap.dedent(
+        """
+        [[windows]]
+        window_id = "morning"
+        start = "2026-07-22T08:00:00Z"
+        end = "2026-07-22T09:00:00Z"
+
+        [[windows]]
+        window_id = "evening"
+        start = "2026-07-22T18:00:00-07:00"
+        end = "2026-07-22T19:00:00-07:00"
+        """
+    ).strip()
+
+
+def overlapping_windows():
+    return manifest_windows().replace(
+        'start = "2026-07-22T18:00:00-07:00"',
+        'start = "2026-07-22T08:30:00Z"',
+    ).replace(
+        'end = "2026-07-22T19:00:00-07:00"',
+        'end = "2026-07-22T09:30:00Z"',
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_router_spec.py
+++ b/obench/tests/test_router_spec.py
@@ -86,6 +86,7 @@ def manifest(**replacements):
         endpoint = "https://api.openai.com/v1/chat/completions"
         protocol = "openai_chat"
         baseline = true
+        canonical_model = "openai/gpt-test-2026-07-01"
         requested_model = "gpt-test-2026-07-01"
         requested_provider = "openai"
         allowed_models = ["gpt-test-2026-07-01"]
@@ -105,6 +106,7 @@ def manifest(**replacements):
         endpoint = "https://openrouter.ai/api/v1/chat/completions"
         protocol = "openai_chat"
         baseline = false
+        canonical_model = "openai/gpt-test-2026-07-01"
         requested_model = "gpt-test-2026-07-01"
         requested_provider = "openai"
         allowed_models = ["gpt-test-2026-07-01"]
@@ -234,6 +236,20 @@ class RouterExperimentTests(unittest.TestCase):
                 with self.assertRaisesRegex(RouterSpecError, message):
                     parse_experiment_toml(text)
 
+    def test_gateway_may_use_endpoint_specific_wire_model_id(self):
+        text = manifest().replace(
+            'requested_model = "gpt-test-2026-07-01"',
+            'requested_model = "openai/gpt-test-2026-07-01"',
+            1,
+        ).replace(
+            'allowed_models = ["gpt-test-2026-07-01"]',
+            'allowed_models = ["openai/gpt-test-2026-07-01"]',
+            1,
+        )
+        spec = parse_experiment_toml(text)
+        self.assertEqual(spec.arms[0].canonical_model, spec.arms[1].canonical_model)
+        self.assertNotEqual(spec.arms[0].requested_model, spec.arms[1].requested_model)
+
     def test_gateway_tax_requires_direct_control_and_equal_fixed_conditions(self):
         cases = (
             (manifest(gateway_extra=""), "direct_control_arm_id"),
@@ -248,8 +264,8 @@ class RouterExperimentTests(unittest.TestCase):
             (manifest(gateway_controls=manifest_controls().replace(
                 "cache_enabled = false", "cache_enabled = true")), "cache"),
             (manifest().replace(
-                'requested_model = "gpt-test-2026-07-01"',
-                'requested_model = "other-model"', 1), "requested_model"),
+                'canonical_model = "openai/gpt-test-2026-07-01"',
+                'canonical_model = "openai/other-model"', 1), "canonical_model"),
         )
         for text, message in cases:
             with self.subTest(message=message):


### PR DESCRIPTION
## Summary

- add a separate Router Bench Gateway Tax track for Pi coding tasks
- compare one direct control against one or more gateways with matched all-arm blocks
- support strict OpenRouter and Vercel gateway profiles with endpoint-specific request controls and route evidence
- add managed proxy routing, sealed privacy-safe evidence, matched reporting, and tamper-evident publish/verify bundles
- enforce active windows, provider/model routing, frozen-price coverage, explicit paid retries, and checker/adapter credential isolation
- admission-block Concentrate and Cloudflare until their current APIs can satisfy the strict measurement contract

## Gateway profiles

- **OpenRouter:** provider allowlist, fallbacks/cache disabled, served route and attempts verified
- **Vercel:** provider filter, client routing controls removed, live streaming metadata parsed, one-attempt evidence verified, gateway-reported cost captured
- **Concentrate:** blocked because Chat Completions cannot currently disable or prove fallback, retries, and caching
- **Cloudflare:** blocked because its REST endpoint requires a metadata-only Logs API lookup to prove provider/model route details; dynamic-route-only headers are not accepted as evidence

## Verification

- `python3 -m unittest discover -s obench/tests -v` (773 tests passed)
- `python3 -m obench.cli validate` (40 task polarity checks passed)
- fake local Gateway Tax E2E including resume, failure denominator, publish, and verify
- live OpenRouter smoke: direct OpenAI vs OpenRouter pinned to OpenAI; both solved
- live Vercel smoke: direct OpenAI vs Vercel restricted to OpenAI; both solved, one matched block, one successful provider attempt per call
- Vercel live evidence bundle published locally and verified without API keys in the verification environment
- one branch-wide autoreview completed; accepted Cloudflare evidence finding fixed

## Live Vercel smoke

One `make-it-run` task and one repetition, so these numbers prove the measurement path rather than general performance:

| Metric | Direct OpenAI | Vercel/OpenAI |
|---|---:|---:|
| Solve rate | 100% | 100% |
| Task latency | 7.292s | 6.308s |
| Mean semantic TTFT | 1.200s | 1.108s |
| Throughput | 96.9 tok/s | 153.5 tok/s |
| Frozen-price estimate | $0.0008277 | $0.00082965 |
| Vercel-reported cost | unavailable | $0.00082965 |

Vercel accepted the dated requested ID but reported the canonical served route as `openai/gpt-4o-mini`. The result retains both identifiers; immutable revision parity is therefore not independently proven for this model.

## Scope

Current results are explicitly exploratory because local execution does not enforce outbound egress isolation. Provider Router, Model Router, verified-route Docker execution, Cloudflare Logs API evidence, and Concentrate admission remain deferred.
