### PR TITLE
Gateway Bench: bind provider prompt cache modes

### DIFF
--- a/docs/gateway-bench.md
+++ b/docs/gateway-bench.md
@@ -53,6 +53,23 @@ Client retries are zero. Request cache controls are stripped. A returned
 cached-input count is retained as measured provider behavior, not treated as a
 client-requested cache hit.
 
+Provider prompt-prefix caching is a required, experiment-wide condition:
+
+- `provider_prompt_mode = "provider_default"` leaves the provider-visible
+  prompt intact and measures normal production behavior, including
+  provider-reported cached input tokens.
+- `provider_prompt_mode = "isolated_per_call_v1"` prepends a unique neutral
+  identifier to Responses `instructions` on every model call. It is currently
+  admitted only for direct OpenAI, OpenRouter, Vercel, and Concentrate
+  Responses routes. A cell fails route integrity if transformation evidence is
+  missing or the provider reports any cached input tokens.
+
+The provider prompt mode is bound into experiment, policy, run, and cell
+identity, retained in public bundles, and reports refuse to mix modes. Use
+`provider_default` for headline gateway comparisons and
+`isolated_per_call_v1` as a sensitivity control for whether provider prompt
+caching changes the ranking. Both modes disable gateway response caching.
+
 Route integrity fails closed when required evidence is absent or contradictory:
 served model, provider, requested-model metadata, terminal stream state, or
 single-attempt evidence where the gateway exposes it.
@@ -66,7 +83,8 @@ Reports retain per-metric coverage and use equal task weighting.
 - time to first byte and semantic time to first token;
 - output throughput;
 - input, output, and total token usage;
-- cached-input and cache-write token counts when reported;
+- cached-input and cache-write token counts, cache-hit call rate, and cached
+  input fraction when reported;
 - cost using separately labeled evidence bases;
 - served-model/provider distribution;
 - route-integrity and infrastructure exclusion reasons;
@@ -165,7 +183,9 @@ obench gateway report results/gateway-five-way.jsonl --json \
 Publication creates a new sanitized, tamper-evident `gateway_bench` bundle. It
 contains canonical Gateway identities (`benchmark="gateway"`), `gateway-run-*`
 and `gateway-cell-*` IDs, public snapshots, minimized ledgers, and provenance
-digests.
+digests. Publishing and verification reject a result set that does not contain
+the latest complete all-arm block for every declared task, window, and
+repetition.
 
 ```bash
 obench gateway publish \

--- a/obench/examples/gateway-bench-five-way-responses.toml
+++ b/obench/examples/gateway-bench-five-way-responses.toml
@@ -1,7 +1,8 @@
-schema_version = 1
+schema_version = 2
 experiment_id = "gpt-4o-mini-five-way-responses-gateway-bench"
 track = "fixed_model_provider"
 model_match = "rolling_alias"
+provider_prompt_mode = "provider_default"
 harness = "pi"
 tasks = ["make-it-run"]
 repetitions_per_window = 10

--- a/obench/examples/gateway-bench-four-way.toml
+++ b/obench/examples/gateway-bench-four-way.toml
@@ -1,7 +1,8 @@
-schema_version = 1
+schema_version = 2
 experiment_id = "gpt-4o-mini-four-way-gateway-bench"
 track = "fixed_model_provider"
 model_match = "rolling_alias"
+provider_prompt_mode = "provider_default"
 harness = "pi"
 tasks = ["make-ci-green", "add-feature", "misleading-error"]
 repetitions_per_window = 1

--- a/obench/examples/gateway-bench-responses.toml
+++ b/obench/examples/gateway-bench-responses.toml
@@ -1,7 +1,8 @@
-schema_version = 1
+schema_version = 2
 experiment_id = "gpt-4o-mini-responses-gateway-bench"
 track = "fixed_model_provider"
 model_match = "rolling_alias"
+provider_prompt_mode = "provider_default"
 harness = "pi"
 tasks = ["make-it-run"]
 repetitions_per_window = 5

--- a/obench/examples/gateway-bench-three-way.toml
+++ b/obench/examples/gateway-bench-three-way.toml
@@ -1,7 +1,8 @@
-schema_version = 1
+schema_version = 2
 experiment_id = "gpt-4o-mini-three-way-gateway-bench"
 track = "fixed_model_provider"
 model_match = "rolling_alias"
+provider_prompt_mode = "provider_default"
 harness = "pi"
 tasks = ["make-ci-green", "add-feature", "misleading-error"]
 repetitions_per_window = 1

--- a/obench/examples/gateway-bench.toml
+++ b/obench/examples/gateway-bench.toml
@@ -1,7 +1,8 @@
-schema_version = 1
+schema_version = 2
 experiment_id = "gpt-4o-mini-openrouter-gateway-bench"
 track = "fixed_model_provider"
 model_match = "rolling_alias"
+provider_prompt_mode = "provider_default"
 harness = "pi"
 tasks = ["make-ci-green", "add-feature", "misleading-error"]
 repetitions_per_window = 1

--- a/obench/gateway_publish.py
+++ b/obench/gateway_publish.py
@@ -8,7 +8,7 @@ the private source ledger.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 import hashlib
 import json
 import math
@@ -23,7 +23,7 @@ from . import results
 from . import gateway_spec
 
 
-BUNDLE_SCHEMA_VERSION = 1
+BUNDLE_SCHEMA_VERSION = 2
 PROVENANCE_FILE = "provenance.json"
 RESULTS_FILE = "results.jsonl"
 SNAPSHOT_FILES = {
@@ -163,6 +163,11 @@ _REPORT_CACHE_SCHEMA = {
     "cached_input_tokens": _SCALAR,
     "cache_write_input_tokens": _SCALAR,
 }
+_REPORT_TOKENS_SCHEMA = {
+    "input_tokens": _SCALAR,
+    "output_tokens": _SCALAR,
+    "total_tokens": _SCALAR,
+}
 _REPORT_ROUTE_SCHEMA = {
     "served_model": _SCALAR,
     "provider": _SCALAR,
@@ -170,9 +175,11 @@ _REPORT_ROUTE_SCHEMA = {
     "attempts_present": _SCALAR,
 }
 _PROXY_CALL_SCHEMA = {
+    "request_ordinal": _SCALAR,
     "timing": _NullableSchema(_REPORT_TIMING_SCHEMA),
     "generation": _NullableSchema(_REPORT_GENERATION_SCHEMA),
     "route": _NullableSchema(_REPORT_ROUTE_SCHEMA),
+    "tokens": _NullableSchema(_REPORT_TOKENS_SCHEMA),
     "cache": _NullableSchema(_REPORT_CACHE_SCHEMA),
     "costs": _NullableSchema(_COSTS_SCHEMA),
 }
@@ -190,6 +197,7 @@ _RESULT_SCHEMA = {
     "arm_role": _SCALAR,
     "baseline": _SCALAR,
     "model_match": _SCALAR,
+    "provider_prompt_mode": _SCALAR,
     "result": _CANONICAL_RESULT_SCHEMA,
     "route_integrity": _ROUTE_EVIDENCE_SCHEMA,
     "proxy_metrics": {"calls": [_PROXY_CALL_SCHEMA]},
@@ -216,6 +224,13 @@ _SERVING_ARM_SCHEMA = {
     "arm_digest": _SCALAR,
     "route_kind": _SCALAR,
 }
+_PROVIDER_CACHE_SCHEMA = {
+    "mode": _SCALAR,
+    "transform_id": _SCALAR,
+    "prefix_injected": _SCALAR,
+    "scope": _SCALAR,
+    "nonce_commitment": _SCALAR,
+}
 _LEDGER_REQUEST_SCHEMA = {
     "ts": _SCALAR,
     "status": _SCALAR,
@@ -225,6 +240,7 @@ _LEDGER_REQUEST_SCHEMA = {
     "sampling_source": _SCALAR,
     "duration_ms": _SCALAR,
     "serving_arm": _SERVING_ARM_SCHEMA,
+    "provider_cache": _PROVIDER_CACHE_SCHEMA,
     "gateway_metrics": _NullableSchema(_METRICS_SCHEMA),
     "session_hash": _SCALAR,
     "previous_response_hash": _SCALAR,
@@ -239,6 +255,7 @@ _POLICY_SCHEMA = {
     "version": _SCALAR,
     "track": _SCALAR,
     "model_match": _SCALAR,
+    "provider_prompt_mode": _SCALAR,
     "route_kind": _SCALAR,
     "allowed_models": [_SCALAR],
     "allowed_providers": [_SCALAR],
@@ -334,6 +351,7 @@ _EXPERIMENT_PUBLIC_SCHEMA = {
     "experiment_id": _SCALAR,
     "track": _SCALAR,
     "model_match": _SCALAR,
+    "provider_prompt_mode": _SCALAR,
     "harness": _SCALAR,
     "tasks": [_SCALAR],
     "repetitions_per_window": _SCALAR,
@@ -547,6 +565,7 @@ def _experiment_dto(source: Mapping[str, Any], source_digest: str) -> dict[str, 
         "experiment_id": source["experiment_id"],
         "track": source["track"],
         "model_match": source["model_match"],
+        "provider_prompt_mode": source["provider_prompt_mode"],
         "harness": source["harness"],
         "tasks": list(source["tasks"]),
         "repetitions_per_window": source["repetitions_per_window"],
@@ -587,6 +606,76 @@ def _load_jsonl(path: Path, label: str) -> list[dict[str, Any]]:
             raise GatewayPublishError(f"{label} line {line_no} is not an object")
         rows.append(row)
     return rows
+
+
+def _require_complete_schedule(
+    experiment: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+) -> None:
+    tasks = experiment.get("tasks")
+    windows = experiment.get("windows")
+    repetitions = experiment.get("repetitions_per_window")
+    arms = experiment.get("arms")
+    if (
+        not isinstance(tasks, list)
+        or not isinstance(windows, list)
+        or not isinstance(repetitions, int)
+        or isinstance(repetitions, bool)
+        or repetitions < 1
+        or not isinstance(arms, list)
+    ):
+        raise GatewayPublishError("experiment has invalid schedule dimensions")
+    window_ids = {
+        window.get("window_id")
+        for window in windows
+        if isinstance(window, Mapping)
+    }
+    arm_ids = {
+        arm.get("arm_id")
+        for arm in arms
+        if isinstance(arm, Mapping)
+    }
+    if (
+        len(window_ids) != len(windows)
+        or None in window_ids
+        or len(arm_ids) != len(arms)
+        or None in arm_ids
+    ):
+        raise GatewayPublishError("experiment has invalid schedule identifiers")
+    expected = {
+        (task, window_id, repetition)
+        for task in tasks
+        for window_id in window_ids
+        for repetition in range(1, repetitions + 1)
+    }
+    observed: dict[tuple[str, str, int], dict[int, list[str]]] = {}
+    for row in rows:
+        identity = results.gateway_identity_from_row(row)
+        coordinate = (
+            identity.task,
+            identity.window_id,
+            identity.repetition,
+        )
+        observed.setdefault(coordinate, {}).setdefault(
+            identity.block_attempt, []
+        ).append(identity.arm_id)
+    if set(observed) != expected:
+        missing = sorted(expected - set(observed))
+        extra = sorted(set(observed) - expected)
+        raise GatewayPublishError(
+            f"result schedule is incomplete; missing={missing!r} extra={extra!r}"
+        )
+    for coordinate, attempts in observed.items():
+        attempt_numbers = sorted(attempts)
+        if attempt_numbers != list(range(attempt_numbers[-1] + 1)):
+            raise GatewayPublishError(
+                f"result schedule has non-contiguous attempts for {coordinate!r}"
+            )
+        latest = attempts[attempt_numbers[-1]]
+        if len(latest) != len(arm_ids) or set(latest) != arm_ids:
+            raise GatewayPublishError(
+                f"latest matched block is incomplete for {coordinate!r}"
+            )
 
 
 def _validate_source_ledger(path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -853,6 +942,7 @@ def publish_bundle(
             bindings[cell_id] = binding
             ledger_provenance[cell_id] = dict(binding)
 
+        _require_complete_schedule(experiment_source, resume.rows)
         public_rows = [
             _result_dto(row, bindings[results.result_cell_id(row)])
             for row in resume.rows
@@ -998,6 +1088,7 @@ def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
     snapshot_digests = provenance["snapshot_digests"]
     if not isinstance(snapshot_digests, dict) or set(snapshot_digests) != set(SNAPSHOT_FILES):
         raise GatewayPublishError("invalid snapshot digest provenance")
+    experiment_snapshot = None
     for kind, relative in SNAPSHOT_FILES.items():
         expected = _require_digest(snapshot_digests[kind], f"{kind} source digest")
         snapshot = _read_json(root / relative)
@@ -1005,6 +1096,7 @@ def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
             raise GatewayPublishError(f"{kind} snapshot digest binding mismatch")
         if kind == "experiment":
             _require_projected(snapshot, _EXPERIMENT_PUBLIC_SCHEMA, kind)
+            experiment_snapshot = snapshot
         else:
             expected_keys = {"kind", "source_digest", "data"}
             if set(snapshot) != expected_keys or snapshot.get("kind") != kind:
@@ -1020,6 +1112,9 @@ def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
     result_rows = _load_jsonl(root / RESULTS_FILE, RESULTS_FILE)
     if provenance["result_count"] != len(result_rows):
         raise GatewayPublishError("result count does not match provenance")
+    if experiment_snapshot is None:
+        raise GatewayPublishError("experiment snapshot is missing")
+    _require_complete_schedule(experiment_snapshot, result_rows)
     ledger_meta = provenance["ledgers"]
     if not isinstance(ledger_meta, dict):
         raise GatewayPublishError("ledger provenance must be an object")

--- a/obench/gateway_publish.py
+++ b/obench/gateway_publish.py
@@ -71,6 +71,11 @@ class _NullableSchema:
         self.schema = schema
 
 
+_INPUT_TOKEN_DETAILS_SCHEMA = {
+    "cached_tokens": _SCALAR,
+    "cache_write_tokens": _SCALAR,
+    "cached_tokens_created": _SCALAR,
+}
 _USAGE_SCHEMA = {
     "input_tokens": _SCALAR,
     "output_tokens": _SCALAR,
@@ -82,6 +87,7 @@ _USAGE_SCHEMA = {
     "cache_creation_input_tokens": _SCALAR,
     "reasoning_output_tokens": _SCALAR,
     "cost_usd": _SCALAR,
+    "input_tokens_details": _NullableSchema(_INPUT_TOKEN_DETAILS_SCHEMA),
 }
 _TIMING_SCHEMA = {
     "ttfb_s": _SCALAR,
@@ -240,7 +246,8 @@ _LEDGER_REQUEST_SCHEMA = {
     "sampling_source": _SCALAR,
     "duration_ms": _SCALAR,
     "serving_arm": _SERVING_ARM_SCHEMA,
-    "provider_cache": _PROVIDER_CACHE_SCHEMA,
+    "provider_cache": _NullableSchema(_PROVIDER_CACHE_SCHEMA),
+    "forwarded_upstream": _SCALAR,
     "gateway_metrics": _NullableSchema(_METRICS_SCHEMA),
     "session_hash": _SCALAR,
     "previous_response_hash": _SCALAR,
@@ -630,16 +637,20 @@ def _require_complete_schedule(
         for window in windows
         if isinstance(window, Mapping)
     }
-    arm_ids = {
-        arm.get("arm_id")
-        for arm in arms
-        if isinstance(arm, Mapping)
-    }
+    arm_digests = {}
+    for arm in arms:
+        if not isinstance(arm, Mapping):
+            continue
+        arm_id = arm.get("arm_id")
+        arm_digest = arm.get("arm_digest")
+        if arm_digest is None:
+            arm_digest = gateway_spec.canonical_digest(arm)
+        if isinstance(arm_id, str) and isinstance(arm_digest, str):
+            arm_digests[arm_id] = arm_digest
     if (
         len(window_ids) != len(windows)
         or None in window_ids
-        or len(arm_ids) != len(arms)
-        or None in arm_ids
+        or len(arm_digests) != len(arms)
     ):
         raise GatewayPublishError("experiment has invalid schedule identifiers")
     expected = {
@@ -648,9 +659,17 @@ def _require_complete_schedule(
         for window_id in window_ids
         for repetition in range(1, repetitions + 1)
     }
-    observed: dict[tuple[str, str, int], dict[int, list[str]]] = {}
+    observed: dict[
+        tuple[str, str, int],
+        dict[int, list[results.CellIdentity]],
+    ] = {}
     for row in rows:
         identity = results.gateway_identity_from_row(row)
+        if arm_digests.get(identity.arm_id) != identity.arm_digest:
+            raise GatewayPublishError(
+                f"result {results.make_gateway_cell_id(identity)} "
+                "arm digest does not match experiment"
+            )
         coordinate = (
             identity.task,
             identity.window_id,
@@ -658,7 +677,7 @@ def _require_complete_schedule(
         )
         observed.setdefault(coordinate, {}).setdefault(
             identity.block_attempt, []
-        ).append(identity.arm_id)
+        ).append(identity)
     if set(observed) != expected:
         missing = sorted(expected - set(observed))
         extra = sorted(set(observed) - expected)
@@ -671,11 +690,125 @@ def _require_complete_schedule(
             raise GatewayPublishError(
                 f"result schedule has non-contiguous attempts for {coordinate!r}"
             )
+        for attempt, identities in attempts.items():
+            block_ids = {identity.block_id for identity in identities}
+            arm_ids = [identity.arm_id for identity in identities]
+            if len(block_ids) != 1:
+                raise GatewayPublishError(
+                    f"matched block has conflicting block IDs for "
+                    f"{coordinate!r} attempt {attempt}"
+                )
+            if len(arm_ids) != len(set(arm_ids)):
+                raise GatewayPublishError(
+                    f"matched block has duplicate arms for "
+                    f"{coordinate!r} attempt {attempt}"
+                )
         latest = attempts[attempt_numbers[-1]]
-        if len(latest) != len(arm_ids) or set(latest) != arm_ids:
+        latest_arm_ids = {identity.arm_id for identity in latest}
+        if len(latest) != len(arm_digests) or latest_arm_ids != set(arm_digests):
             raise GatewayPublishError(
                 f"latest matched block is incomplete for {coordinate!r}"
             )
+
+
+def _require_provider_prompt_mode_binding(
+    experiment: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+) -> None:
+    mode = experiment.get("provider_prompt_mode")
+    if mode not in gateway_spec.PROVIDER_PROMPT_MODES:
+        raise GatewayPublishError("experiment has invalid provider_prompt_mode")
+    if policy.get("provider_prompt_mode") != mode:
+        raise GatewayPublishError(
+            "policy provider_prompt_mode does not match experiment"
+        )
+    for row in rows:
+        try:
+            identity = results.gateway_identity_from_row(row)
+        except results.ResultError as exc:
+            raise GatewayPublishError(
+                f"result has invalid provider_prompt_mode binding: {exc}"
+            ) from exc
+        if (
+            identity.provider_prompt_mode != mode
+            or row.get("provider_prompt_mode") != mode
+        ):
+            raise GatewayPublishError(
+                f"result {results.make_gateway_cell_id(identity)} "
+                "provider_prompt_mode does not match experiment"
+            )
+
+
+def _provider_prompt_commitments(
+    requests: Sequence[Mapping[str, Any]],
+    mode: str,
+    label: str,
+) -> set[str]:
+    commitments = set()
+    for sequence, request in enumerate(requests, 1):
+        forwarded = request.get("forwarded_upstream")
+        if not isinstance(forwarded, bool):
+            raise GatewayPublishError(
+                f"{label} request {sequence} lacks forwarding evidence"
+            )
+        if not forwarded:
+            continue
+        evidence = request.get("provider_cache")
+        if mode == "provider_default":
+            if (
+                not isinstance(evidence, Mapping)
+                or evidence.get("mode") != "provider_default"
+                or evidence.get("prefix_injected") is not False
+                or evidence.get("transform_id") is not None
+                or evidence.get("scope") is not None
+                or evidence.get("nonce_commitment") is not None
+            ):
+                raise GatewayPublishError(
+                    f"{label} request {sequence} lacks provider-default evidence"
+                )
+            continue
+        if (
+            not isinstance(evidence, Mapping)
+            or evidence.get("mode") != "isolated_per_call_v1"
+            or evidence.get("transform_id") != gateway_spec.COLD_PREFIX_TRANSFORM_ID
+            or evidence.get("prefix_injected") is not True
+            or evidence.get("scope") != "forwarded_request"
+        ):
+            raise GatewayPublishError(
+                f"{label} request {sequence} lacks cold-prefix evidence"
+            )
+        commitment = evidence.get("nonce_commitment")
+        if not isinstance(commitment, str) or not _DIGEST_RE.fullmatch(commitment):
+            raise GatewayPublishError(
+                f"{label} request {sequence} has an invalid nonce commitment"
+            )
+        if commitment in commitments:
+            raise GatewayPublishError(f"{label} reuses a cold-prefix commitment")
+        commitments.add(commitment)
+        status = request.get("status")
+        if isinstance(status, int) and not isinstance(status, bool) and 200 <= status < 300:
+            metrics = request.get("gateway_metrics")
+            usage = metrics.get("usage") if isinstance(metrics, Mapping) else None
+            details = (
+                usage.get("input_tokens_details")
+                if isinstance(usage, Mapping)
+                else None
+            )
+            cached_tokens = (
+                details.get("cached_tokens")
+                if isinstance(details, Mapping)
+                else None
+            )
+            if (
+                not isinstance(cached_tokens, int)
+                or isinstance(cached_tokens, bool)
+                or cached_tokens != 0
+            ):
+                raise GatewayPublishError(
+                    f"{label} request {sequence} lacks zero cached-token evidence"
+                )
+    return commitments
 
 
 def _validate_source_ledger(path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -903,6 +1036,7 @@ def publish_bundle(
         rows_by_cell = {
             results.result_cell_id(row): row for row in resume.rows
         }
+        provider_prompt_commitments: set[str] = set()
         for cell_id in sorted(cell_ids):
             source_path = ledger_sources[cell_id]
             requests, source_seal = _validate_source_ledger(source_path)
@@ -930,6 +1064,16 @@ def publish_bundle(
                     raise GatewayPublishError(
                         f"result {cell_id} arm identity does not match source ledger"
                     )
+            cell_commitments = _provider_prompt_commitments(
+                requests,
+                identity.provider_prompt_mode,
+                f"result {cell_id}",
+            )
+            if provider_prompt_commitments & cell_commitments:
+                raise GatewayPublishError(
+                    "bundle reuses a cold-prefix commitment across cells"
+                )
+            provider_prompt_commitments.update(cell_commitments)
             raw, seal = _public_ledger(cell_id, requests)
             relative = f"ledgers/{cell_id}.jsonl"
             artifacts[relative] = _write_file(temporary, relative, raw)
@@ -943,6 +1087,11 @@ def publish_bundle(
             ledger_provenance[cell_id] = dict(binding)
 
         _require_complete_schedule(experiment_source, resume.rows)
+        _require_provider_prompt_mode_binding(
+            experiment_source,
+            policy_source,
+            resume.rows,
+        )
         public_rows = [
             _result_dto(row, bindings[results.result_cell_id(row)])
             for row in resume.rows
@@ -989,7 +1138,7 @@ def _verify_public_ledger(
     raw: bytes,
     artifact: str,
     expected_cell_id: str,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     with tempfile.TemporaryDirectory(prefix="gateway_bundle_verify_") as tmp:
         path = Path(tmp) / "ledger.jsonl"
         path.write_bytes(raw)
@@ -1035,7 +1184,7 @@ def _verify_public_ledger(
     if seal != expected_seal:
         raise GatewayPublishError(f"{artifact} has an invalid seal or cell binding")
     _assert_safe(rows, artifact)
-    return seal
+    return seal, requests
 
 
 def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
@@ -1089,6 +1238,7 @@ def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
     if not isinstance(snapshot_digests, dict) or set(snapshot_digests) != set(SNAPSHOT_FILES):
         raise GatewayPublishError("invalid snapshot digest provenance")
     experiment_snapshot = None
+    policy_snapshot = None
     for kind, relative in SNAPSHOT_FILES.items():
         expected = _require_digest(snapshot_digests[kind], f"{kind} source digest")
         snapshot = _read_json(root / relative)
@@ -1107,14 +1257,21 @@ def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
                 "price": _PRICE_SCHEMA,
             }
             _require_projected(snapshot["data"], schemas[kind], f"{kind}.data")
+            if kind == "policy":
+                policy_snapshot = snapshot["data"]
         _assert_safe(snapshot, f"{kind} snapshot")
 
     result_rows = _load_jsonl(root / RESULTS_FILE, RESULTS_FILE)
     if provenance["result_count"] != len(result_rows):
         raise GatewayPublishError("result count does not match provenance")
-    if experiment_snapshot is None:
-        raise GatewayPublishError("experiment snapshot is missing")
+    if experiment_snapshot is None or policy_snapshot is None:
+        raise GatewayPublishError("experiment or policy snapshot is missing")
     _require_complete_schedule(experiment_snapshot, result_rows)
+    _require_provider_prompt_mode_binding(
+        experiment_snapshot,
+        policy_snapshot,
+        result_rows,
+    )
     ledger_meta = provenance["ledgers"]
     if not isinstance(ledger_meta, dict):
         raise GatewayPublishError("ledger provenance must be an object")
@@ -1154,6 +1311,8 @@ def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
     if seen_cells != set(ledger_meta):
         raise GatewayPublishError("result and ledger cell sets do not match")
 
+    provider_prompt_commitments: set[str] = set()
+    rows_by_cell = {row["cell_id"]: row for row in result_rows}
     for cell_id, binding in ledger_meta.items():
         if not isinstance(binding, dict) or set(binding) != {
             "artifact", "root_hash", "seal_sha256", "record_count",
@@ -1162,11 +1321,22 @@ def verify_bundle(bundle_dir: str | os.PathLike[str]) -> dict[str, Any]:
         artifact = binding["artifact"]
         if not isinstance(artifact, str) or artifact not in artifacts:
             raise GatewayPublishError(f"missing ledger artifact for {cell_id}")
-        seal = _verify_public_ledger(
+        seal, requests = _verify_public_ledger(
             (root / artifact).read_bytes(),
             artifact,
             cell_id,
         )
+        identity = results.gateway_identity_from_row(rows_by_cell[cell_id])
+        cell_commitments = _provider_prompt_commitments(
+            requests,
+            identity.provider_prompt_mode,
+            f"ledger {cell_id}",
+        )
+        if provider_prompt_commitments & cell_commitments:
+            raise GatewayPublishError(
+                "bundle reuses a cold-prefix commitment across cells"
+            )
+        provider_prompt_commitments.update(cell_commitments)
         expected_binding = {
             "artifact": artifact,
             "root_hash": seal["root_hash"],

--- a/obench/gateway_report.py
+++ b/obench/gateway_report.py
@@ -9,7 +9,7 @@ these result fields:
 * ``route_integrity`` with boolean ``pass`` and a list of reason strings;
 * ``proxy_metrics.calls``, where each call may contain ``timing`` (``ttfb_s``
   and ``semantic_ttft_s``), ``generation`` (paired ``output_tokens`` and
-  ``duration_s``), ``cache`` (``cached_input_tokens`` and
+  ``duration_s``), ``tokens`` (input, output, and total), ``cache`` (``cached_input_tokens`` and
   ``cache_write_input_tokens``), ``route`` (``provider`` and ``served_model``),
   and ``costs``.
 
@@ -42,6 +42,9 @@ _COST_BASES = (
 _CALL_COVERAGE_FIELDS = {
     "ttfb_s": "ttfb",
     "semantic_ttft_s": "ttft",
+    "mean_input_tokens_per_call": "input_tokens",
+    "mean_output_tokens_per_call": "token_output_tokens",
+    "mean_total_tokens_per_call": "total_tokens",
     "mean_cached_input_tokens_per_call": "cached_input_tokens",
     "mean_cache_write_input_tokens_per_call": "cache_write_input_tokens",
 }
@@ -356,6 +359,11 @@ def _cell(row: Mapping[str, Any], row_number: int) -> dict[str, Any]:
             {} if cache_value is None else cache_value,
             f"row {row_number} call {call_number} cache",
         )
+        tokens_value = call.get("tokens")
+        tokens = _object(
+            {} if tokens_value is None else tokens_value,
+            f"row {row_number} call {call_number} tokens",
+        )
         route = _object(
             call.get("route", {}),
             f"row {row_number} call {call_number} route",
@@ -427,6 +435,18 @@ def _cell(row: Mapping[str, Any], row_number: int) -> dict[str, Any]:
                     f"row {row_number} call {call_number} timing.semantic_ttft_s",
                 ),
                 "output_tokens": output_tokens,
+                "input_tokens": _optional_number(
+                    tokens.get("input_tokens"),
+                    f"row {row_number} call {call_number} tokens.input_tokens",
+                ),
+                "token_output_tokens": _optional_number(
+                    tokens.get("output_tokens"),
+                    f"row {row_number} call {call_number} tokens.output_tokens",
+                ),
+                "total_tokens": _optional_number(
+                    tokens.get("total_tokens"),
+                    f"row {row_number} call {call_number} tokens.total_tokens",
+                ),
                 "generation_duration": generation_duration,
                 "cached_input_tokens": _optional_number(
                     cache.get("cached_input_tokens"),
@@ -478,6 +498,32 @@ def _cell_throughput(cell: Mapping[str, Any]) -> float | None:
     if duration <= 0:
         return None
     return sum(item[0] for item in paired) / duration
+
+
+def _cell_cache_hit_rate(cell: Mapping[str, Any]) -> float | None:
+    values = [
+        call["cached_input_tokens"]
+        for call in cell["calls"]
+        if call["cached_input_tokens"] is not None
+    ]
+    if not values:
+        return None
+    return sum(value > 0 for value in values) / len(values)
+
+
+def _cell_cached_input_fraction(cell: Mapping[str, Any]) -> float | None:
+    paired = [
+        (call["cached_input_tokens"], call["input_tokens"])
+        for call in cell["calls"]
+        if call["cached_input_tokens"] is not None
+        and call["input_tokens"] is not None
+    ]
+    if not paired:
+        return None
+    total_input = sum(item[1] for item in paired)
+    if total_input <= 0:
+        return None
+    return sum(item[0] for item in paired) / total_input
 
 
 def _cell_cost(cell: Mapping[str, Any], basis: str) -> float | None:
@@ -539,6 +585,7 @@ def aggregate(
     logical_cells = {}
     arm_metadata: dict[str, tuple[str, bool, str]] = {}
     model_matches = set()
+    provider_prompt_modes = set()
     task_metadata: dict[str, tuple[str, str, str]] = {}
     block_coordinates: dict[str, tuple[Any, ...]] = {}
     coordinate_block_ids: dict[tuple[Any, ...], str] = {}
@@ -557,6 +604,16 @@ def aggregate(
                 f"row {row_number} has invalid model_match"
             )
         model_matches.add(model_match)
+        provider_prompt_mode = row.get("provider_prompt_mode")
+        if provider_prompt_mode not in gateway_spec.PROVIDER_PROMPT_MODES:
+            raise GatewayReportError(
+                f"row {row_number} has invalid provider_prompt_mode"
+            )
+        if provider_prompt_mode != identity.provider_prompt_mode:
+            raise GatewayReportError(
+                f"row {row_number} provider_prompt_mode conflicts with identity"
+            )
+        provider_prompt_modes.add(provider_prompt_mode)
         experiment_ids.add(identity.experiment_id)
         experiment_digests.add(identity.experiment_digest)
         strata.add(_stratum(identity))
@@ -626,6 +683,9 @@ def aggregate(
     if len(model_matches) != 1:
         raise GatewayReportError("rows mix model_match policies")
     model_match = next(iter(model_matches))
+    if len(provider_prompt_modes) != 1:
+        raise GatewayReportError("rows mix provider cache modes")
+    provider_prompt_mode = next(iter(provider_prompt_modes))
     if len(strata) != 1:
         raise GatewayReportError("rows mix comparison strata")
 
@@ -742,6 +802,17 @@ def aggregate(
             "ttfb_s": lambda cell: _cell_call_metric(cell, "ttfb"),
             "semantic_ttft_s": lambda cell: _cell_call_metric(cell, "ttft"),
             "throughput_tokens_per_s": _cell_throughput,
+            "mean_input_tokens_per_call": lambda cell: _cell_call_metric(
+                cell, "input_tokens"
+            ),
+            "mean_output_tokens_per_call": lambda cell: _cell_call_metric(
+                cell, "token_output_tokens"
+            ),
+            "mean_total_tokens_per_call": lambda cell: _cell_call_metric(
+                cell, "total_tokens"
+            ),
+            "cache_hit_call_rate": _cell_cache_hit_rate,
+            "cached_input_fraction": _cell_cached_input_fraction,
             "mean_cached_input_tokens_per_call": lambda cell: _cell_call_metric(
                 cell, "cached_input_tokens"
             ),
@@ -925,6 +996,17 @@ def aggregate(
         "ttfb_s": lambda cell: _cell_call_metric(cell, "ttfb"),
         "semantic_ttft_s": lambda cell: _cell_call_metric(cell, "ttft"),
         "throughput_tokens_per_s": _cell_throughput,
+        "mean_input_tokens_per_call": lambda cell: _cell_call_metric(
+            cell, "input_tokens"
+        ),
+        "mean_output_tokens_per_call": lambda cell: _cell_call_metric(
+            cell, "token_output_tokens"
+        ),
+        "mean_total_tokens_per_call": lambda cell: _cell_call_metric(
+            cell, "total_tokens"
+        ),
+        "cache_hit_call_rate": _cell_cache_hit_rate,
+        "cached_input_fraction": _cell_cached_input_fraction,
         "mean_cached_input_tokens_per_call": lambda cell: _cell_call_metric(
             cell, "cached_input_tokens"
         ),
@@ -987,6 +1069,7 @@ def aggregate(
         "benchmark": results.GATEWAY_BENCHMARK,
         "track": track,
         "model_match": model_match,
+        "provider_prompt_mode": provider_prompt_mode,
         "experiment_id": next(iter(experiment_ids)),
         "experiment_digest": next(iter(experiment_digests)),
         "analysis": {
@@ -1017,6 +1100,7 @@ def render_text(report: Mapping[str, Any]) -> str:
     blocks = report["blocks"]
     lines = [
         f"Gateway Bench: {report['track']} ({report['experiment_digest'][:12]})",
+        f"Provider prompt mode: {report['provider_prompt_mode']}",
         (
             f"Blocks: {blocks['included']}/{blocks['observed']} included; "
             f"tasks: {report['tasks']['included']}"

--- a/obench/gateway_report.py
+++ b/obench/gateway_report.py
@@ -9,9 +9,9 @@ these result fields:
 * ``route_integrity`` with boolean ``pass`` and a list of reason strings;
 * ``proxy_metrics.calls``, where each call may contain ``timing`` (``ttfb_s``
   and ``semantic_ttft_s``), ``generation`` (paired ``output_tokens`` and
-  ``duration_s``), ``tokens`` (input, output, and total), ``cache`` (``cached_input_tokens`` and
-  ``cache_write_input_tokens``), ``route`` (``provider`` and ``served_model``),
-  and ``costs``.
+  ``duration_s``), ``tokens`` (input, output, and total), ``cache``
+  (``cached_input_tokens`` and ``cache_write_input_tokens``), ``route``
+  (``provider`` and ``served_model``), and ``costs``.
 
 ``costs`` maps a basis name to an object containing ``amount_usd``, ``currency``
 and ``effective_at``. Missing conditional timing or cost evidence affects only

--- a/obench/gateway_run.py
+++ b/obench/gateway_run.py
@@ -310,6 +310,7 @@ def policy_snapshot(
         policy.update({
             "track": experiment.track,
             "model_match": experiment.model_match,
+            "provider_prompt_mode": experiment.provider_prompt_mode,
             "fallback": False,
         })
     return policy
@@ -401,6 +402,7 @@ def _identity(
         repetition=block.repetition,
         block_id=block_id,
         block_attempt=attempt,
+        provider_prompt_mode=experiment.provider_prompt_mode,
         **digests,
     )
 
@@ -740,6 +742,28 @@ def _cache_accounting(metrics: Mapping[str, Any]) -> dict[str, int | None]:
     }
 
 
+def _token_accounting(metrics: Mapping[str, Any]) -> dict[str, int | None]:
+    usage = metrics.get("usage")
+    usage = usage if isinstance(usage, Mapping) else {}
+
+    def count(key: str) -> int | None:
+        value = usage.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+        return None
+
+    input_tokens = count("input_tokens")
+    output_tokens = count("output_tokens")
+    total_tokens = count("total_tokens")
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
 def _route_reasons(metrics: Mapping[str, Any], plan: gateway_spec.RoutePlan) -> list[str]:
     route = metrics.get("route")
     stream = metrics.get("stream")
@@ -821,6 +845,49 @@ def _route_reasons(metrics: Mapping[str, Any], plan: gateway_spec.RoutePlan) -> 
     return sorted(set(reasons))
 
 
+def _provider_cache_reasons(
+    row: Mapping[str, Any],
+    metrics: Mapping[str, Any],
+    plan: gateway_spec.RoutePlan,
+) -> list[str]:
+    evidence = row.get("provider_cache")
+    if plan.provider_prompt_mode == "provider_default":
+        if evidence is None:
+            return []
+        if (
+            not isinstance(evidence, Mapping)
+            or evidence.get("mode") != "provider_default"
+        ):
+            return ["provider_prompt_mode_unverified"]
+        if evidence.get("prefix_injected") is not False:
+            return ["unexpected_cache_prefix"]
+        return []
+    if (
+        not isinstance(evidence, Mapping)
+        or evidence.get("mode") != plan.provider_prompt_mode
+    ):
+        return ["provider_prompt_mode_unverified"]
+    if (
+        evidence.get("prefix_injected") is not True
+        or evidence.get("scope") != "forwarded_request"
+        or evidence.get("transform_id") != gateway_spec.COLD_PREFIX_TRANSFORM_ID
+    ):
+        return ["cold_cache_prefix_unverified"]
+    commitment = evidence.get("nonce_commitment")
+    if (
+        not isinstance(commitment, str)
+        or len(commitment) != 64
+        or any(character not in "0123456789abcdef" for character in commitment)
+    ):
+        return ["cold_cache_nonce_unverified"]
+    cached_tokens = _cache_accounting(metrics)["cached_input_tokens"]
+    if cached_tokens is None:
+        return ["cold_cache_usage_missing"]
+    if cached_tokens != 0:
+        return ["cold_cache_hit"]
+    return []
+
+
 def _proxy_evidence(
     ledger_rows: Sequence[Mapping[str, Any]],
     prices: Mapping[str, Price],
@@ -840,12 +907,14 @@ def _proxy_evidence(
             continue
         if isinstance(status, int) and 200 <= status < 300 and row.get("error"):
             calls.append({
+                "request_ordinal": row.get("sequence"),
                 "timing": None,
                 "generation": None,
                 "route": {
                     "provider": plan.requested_provider,
                     "served_model": plan.requested_model,
                 },
+                "tokens": None,
                 "cache": None,
                 "costs": None,
             })
@@ -854,12 +923,14 @@ def _proxy_evidence(
             if status in {401, 403, 407}:
                 auth_failure = True
             calls.append({
+                "request_ordinal": row.get("sequence"),
                 "timing": None,
                 "generation": None,
                 "route": {
                     "provider": plan.requested_provider,
                     "served_model": plan.requested_model,
                 },
+                "tokens": None,
                 "cache": None,
                 "costs": None,
             })
@@ -868,18 +939,21 @@ def _proxy_evidence(
         if not isinstance(metrics, dict):
             reasons.append("missing_gateway_metrics")
             calls.append({
+                "request_ordinal": row.get("sequence"),
                 "timing": None,
                 "generation": None,
                 "route": {
                     "provider": plan.requested_provider,
                     "served_model": plan.requested_model,
                 },
+                "tokens": None,
                 "cache": None,
                 "costs": None,
             })
             continue
         successful_calls += 1
         reasons.extend(_route_reasons(metrics, plan))
+        reasons.extend(_provider_cache_reasons(row, metrics, plan))
         usage = metrics.get("usage") if isinstance(metrics.get("usage"), dict) else {}
         output_tokens = usage.get("output_tokens")
         if isinstance(output_tokens, int) and not isinstance(output_tokens, bool):
@@ -895,9 +969,11 @@ def _proxy_evidence(
                 normalized_route["provider"] = plan.requested_provider
         calls.append(
             {
+                "request_ordinal": row.get("sequence"),
                 "timing": metrics.get("timing"),
                 "generation": metrics.get("generation"),
                 "route": normalized_route,
+                "tokens": _token_accounting(metrics),
                 "cache": _cache_accounting(metrics),
                 "costs": costs,
             }
@@ -1105,6 +1181,7 @@ def _run_cell(
         "arm_role": arm.route_kind,
         "baseline": arm.baseline,
         "model_match": experiment.model_match,
+        "provider_prompt_mode": experiment.provider_prompt_mode,
         "result": {
             "solved": solved,
             "checker_score": checker_score,

--- a/obench/gateway_run.py
+++ b/obench/gateway_run.py
@@ -852,14 +852,17 @@ def _provider_cache_reasons(
 ) -> list[str]:
     evidence = row.get("provider_cache")
     if plan.provider_prompt_mode == "provider_default":
-        if evidence is None:
-            return []
         if (
             not isinstance(evidence, Mapping)
             or evidence.get("mode") != "provider_default"
         ):
             return ["provider_prompt_mode_unverified"]
-        if evidence.get("prefix_injected") is not False:
+        if (
+            evidence.get("prefix_injected") is not False
+            or evidence.get("transform_id") is not None
+            or evidence.get("scope") is not None
+            or evidence.get("nonce_commitment") is not None
+        ):
             return ["unexpected_cache_prefix"]
         return []
     if (

--- a/obench/gateway_spec.py
+++ b/obench/gateway_spec.py
@@ -21,9 +21,12 @@ from typing import Any
 from . import gateway_profiles
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 TRACK = "fixed_model_provider"
 MODEL_MATCHES = frozenset({"exact_revision", "model_family", "rolling_alias"})
+PROVIDER_PROMPT_MODES = frozenset({"provider_default", "isolated_per_call_v1"})
+COLD_PREFIX_GATEWAYS = frozenset({"openrouter", "vercel", "concentrate"})
+COLD_PREFIX_TRANSFORM_ID = "openbench.responses-prefix.v1"
 HARNESS = "pi"
 PROTOCOLS = frozenset({"openai_chat", "openai_responses"})
 PROTOCOL_ENDPOINT_SUFFIXES = {
@@ -166,6 +169,7 @@ class GatewayExperiment:
     experiment_id: str
     track: str
     model_match: str
+    provider_prompt_mode: str
     harness: str
     tasks: tuple[str, ...]
     repetitions_per_window: int
@@ -179,11 +183,12 @@ class GatewayExperiment:
     arms: tuple[Arm, ...]
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        result = {
             "schema_version": self.schema_version,
             "experiment_id": self.experiment_id,
             "track": self.track,
             "model_match": self.model_match,
+            "provider_prompt_mode": self.provider_prompt_mode,
             "harness": self.harness,
             "tasks": list(self.tasks),
             "repetitions_per_window": self.repetitions_per_window,
@@ -196,6 +201,7 @@ class GatewayExperiment:
             "budget": self.budget.to_dict(),
             "arms": [arm.to_dict() for arm in self.arms],
         }
+        return result
 
     @property
     def canonical_json(self) -> str:
@@ -230,11 +236,12 @@ class RoutePlan:
     allow_private_endpoint: bool
     private_host_allowlist: tuple[str, ...]
     private_cidr_allowlist: tuple[str, ...]
-    # Proxy-only controls. They are bound by arm_digest but intentionally
-    # omitted from the adapter-facing route-plan JSON.
+    # Proxy-only controls. They are bound by the experiment or arm digest but
+    # intentionally omitted from the adapter-facing route-plan JSON.
     gateway: str | None = None
     track: str = TRACK
     model_match: str = "exact_revision"
+    provider_prompt_mode: str = "provider_default"
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -300,7 +307,8 @@ class SecretPlan:
 
 
 _ROOT_FIELDS = {
-    "schema_version", "experiment_id", "track", "model_match", "harness", "tasks",
+    "schema_version", "experiment_id", "track", "model_match",
+    "provider_prompt_mode", "harness", "tasks",
     "repetitions_per_window", "schedule_seed", "execution_lane",
     "allow_private_endpoint", "private_host_allowlist", "private_cidr_allowlist",
     "windows", "budget", "arms",
@@ -713,6 +721,15 @@ def parse_experiment(data: Mapping[str, Any]) -> GatewayExperiment:
         raise GatewaySpecError(
             f"model_match must be one of: {', '.join(sorted(MODEL_MATCHES))}"
         )
+    provider_prompt_mode = _string(
+        _required(table, "provider_prompt_mode", "experiment"),
+        "provider_prompt_mode",
+    )
+    if provider_prompt_mode not in PROVIDER_PROMPT_MODES:
+        raise GatewaySpecError(
+            "provider_prompt_mode must be one of: "
+            + ", ".join(sorted(PROVIDER_PROMPT_MODES))
+        )
     harness = _string(_required(table, "harness", "experiment"), "harness")
     if harness != HARNESS:
         raise GatewaySpecError(f"harness must be {HARNESS!r} for the MVP")
@@ -727,6 +744,21 @@ def parse_experiment(data: Mapping[str, Any]) -> GatewayExperiment:
     arms = tuple(_parse_arm(raw, index, allow_private_endpoint, hosts, cidrs)
                  for index, raw in enumerate(raw_arms))
     _validate_gateway_controls(arms)
+    if provider_prompt_mode == "isolated_per_call_v1" and any(
+        arm.protocol != "openai_responses" for arm in arms
+    ):
+        raise GatewaySpecError(
+            "provider_prompt_mode='isolated_per_call_v1' requires "
+            "openai_responses for every arm"
+        )
+    if provider_prompt_mode == "isolated_per_call_v1" and any(
+        arm.route_kind == "gateway" and arm.gateway not in COLD_PREFIX_GATEWAYS
+        for arm in arms
+    ):
+        raise GatewaySpecError(
+            "provider_prompt_mode='isolated_per_call_v1' is admitted only for "
+            "OpenRouter, Vercel, and Concentrate gateway arms"
+        )
     lane = _string(_required(table, "execution_lane", "experiment"), "execution_lane")
     if lane not in {"local", "docker"}:
         raise GatewaySpecError("execution_lane must be 'local' or 'docker'")
@@ -736,6 +768,7 @@ def parse_experiment(data: Mapping[str, Any]) -> GatewayExperiment:
                               "experiment_id", _ID_RE),
         track=track,
         model_match=model_match,
+        provider_prompt_mode=provider_prompt_mode,
         harness=harness,
         tasks=tasks,
         repetitions_per_window=_integer(
@@ -816,6 +849,7 @@ def compile_route_plans(
             experiment_digest=experiment.digest,
             track=experiment.track,
             model_match=experiment.model_match,
+            provider_prompt_mode=experiment.provider_prompt_mode,
             arm_digest=arm.digest,
             arm_id=arm.arm_id,
             route_kind=arm.route_kind,

--- a/obench/gateway_spec.py
+++ b/obench/gateway_spec.py
@@ -183,7 +183,7 @@ class GatewayExperiment:
     arms: tuple[Arm, ...]
 
     def to_dict(self) -> dict[str, Any]:
-        result = {
+        return {
             "schema_version": self.schema_version,
             "experiment_id": self.experiment_id,
             "track": self.track,
@@ -201,7 +201,6 @@ class GatewayExperiment:
             "budget": self.budget.to_dict(),
             "arms": [arm.to_dict() for arm in self.arms],
         }
-        return result
 
     @property
     def canonical_json(self) -> str:
@@ -758,6 +757,18 @@ def parse_experiment(data: Mapping[str, Any]) -> GatewayExperiment:
         raise GatewaySpecError(
             "provider_prompt_mode='isolated_per_call_v1' is admitted only for "
             "OpenRouter, Vercel, and Concentrate gateway arms"
+        )
+    if provider_prompt_mode == "isolated_per_call_v1" and any(
+        arm.route_kind == "direct"
+        and (
+            arm.requested_provider.casefold() != "openai"
+            or urllib.parse.urlsplit(arm.endpoint).hostname != "api.openai.com"
+        )
+        for arm in arms
+    ):
+        raise GatewaySpecError(
+            "provider_prompt_mode='isolated_per_call_v1' requires the direct "
+            "OpenAI API arm"
         )
     lane = _string(_required(table, "execution_lane", "experiment"), "execution_lane")
     if lane not in {"local", "docker"}:

--- a/obench/proxy.py
+++ b/obench/proxy.py
@@ -392,6 +392,7 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
         managed_ledger: bool | None = None
         gateway_parser = None
         gateway_metrics = None
+        cache_control = None
         try:
             route = self._route_request()
             token = route.token
@@ -423,7 +424,13 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
                 return
             body = self._read_body()
             if route.gateway_route is not None:
-                body = self._gateway_request_body(body, route.gateway_route.plan)
+                body, cache_control = self._gateway_request_body(
+                    body, route.gateway_route.plan
+                )
+                if len(body) > self.server.max_request_bytes:  # type: ignore[attr-defined]
+                    raise RuntimeError(
+                        "transformed gateway request exceeds max_request_bytes"
+                    )
             request_body = decode_for_parsing(body, self.headers.get("content-encoding", ""))
             sampling = observed_sampling(
                 body,
@@ -541,6 +548,7 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
                         "arm_digest": route.gateway_route.plan.arm_digest,
                         "route_kind": route.gateway_route.plan.route_kind,
                     }
+                    rec["provider_cache"] = cache_control
             if gateway_metrics is not None:
                 rec["gateway_metrics"] = gateway_metrics
             if "session" in links:
@@ -699,7 +707,9 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
         headers["Content-Length"] = str(body_length)
         return headers
 
-    def _gateway_request_body(self, body: bytes, plan: RoutePlan) -> bytes:
+    def _gateway_request_body(
+        self, body: bytes, plan: RoutePlan
+    ) -> tuple[bytes, dict[str, Any]]:
         if self.headers.get("content-encoding"):
             raise RuntimeError("gateway requests do not permit content encoding")
         try:
@@ -720,6 +730,25 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
         else:
             payload.pop("seed", None)
         gateway_profiles.strip_cache_controls(payload)
+        prefix_injected = False
+        if plan.provider_prompt_mode == "isolated_per_call_v1":
+            if plan.protocol != "openai_responses":
+                raise RuntimeError(
+                    "isolated_per_call_v1 requires openai_responses"
+                )
+            instructions = payload.get("instructions", "")
+            if not isinstance(instructions, str):
+                raise RuntimeError(
+                    "isolated_per_call_v1 requires string Responses instructions"
+                )
+            nonce = secrets.token_hex(32)
+            nonce_commitment = self.server.reserve_cache_nonce(nonce)  # type: ignore[attr-defined]
+            prefix = (
+                f"[OpenBench cache isolation id: {nonce}. "
+                "Do not reference this identifier in the response.]\n"
+            )
+            payload["instructions"] = prefix + instructions
+            prefix_injected = True
         if plan.route_kind == "gateway":
             if plan.gateway is None:
                 raise RuntimeError("gateway route plan is missing gateway profile")
@@ -730,7 +759,16 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
             )
         else:
             payload.pop("provider", None)
-        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        shaped = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return shaped, {
+            "mode": plan.provider_prompt_mode,
+            "transform_id": (
+                gateway_spec.COLD_PREFIX_TRANSFORM_ID if prefix_injected else None
+            ),
+            "prefix_injected": prefix_injected,
+            "scope": "forwarded_request" if prefix_injected else None,
+            "nonce_commitment": nonce_commitment if prefix_injected else None,
+        }
 
     def _read_body(self) -> bytes:
         max_bytes = self.server.max_request_bytes  # type: ignore[attr-defined]
@@ -793,6 +831,15 @@ class CountingProxyServer(ThreadingHTTPServer):
     allow_reuse_address = True
     request_queue_size = 128
 
+    def reserve_cache_nonce(self, nonce: str) -> str:
+        """Bind one cold-prefix nonce without retaining the nonce itself."""
+        commitment = _identifier_hash(nonce, self.identifier_salt)  # type: ignore[attr-defined]
+        with self._ledger_condition:
+            if commitment in self._cache_nonce_commitments:
+                raise RuntimeError("cold-prefix nonce reuse detected")
+            self._cache_nonce_commitments.add(commitment)
+        return commitment
+
     def register_cell(self, token: str, *, max_calls: int | None = None) -> None:
         """Opt a gateway cell into lifecycle-managed, sealed ledger writes."""
         if not re.fullmatch(r"[A-Za-z0-9_.-]+", token):
@@ -829,6 +876,15 @@ class CountingProxyServer(ThreadingHTTPServer):
             raise ValueError("gateway route must allow exactly the requested provider")
         if plan.retry_count or plan.cache_enabled:
             raise ValueError("gateway route retries and cache must be disabled")
+        if plan.provider_prompt_mode not in gateway_spec.PROVIDER_PROMPT_MODES:
+            raise ValueError("unsupported provider cache mode")
+        if (
+            plan.provider_prompt_mode == "isolated_per_call_v1"
+            and plan.protocol != "openai_responses"
+        ):
+            raise ValueError(
+                "isolated_per_call_v1 requires openai_responses"
+            )
         if plan.track != TRACK:
             raise ValueError(f"gateway route track must be {TRACK!r}")
         if plan.fallback_enabled:
@@ -1139,6 +1195,7 @@ def make_server(listen_host: str, port: int, ledger_dir: str | os.PathLike[str],
     httpd._cell_ledgers = {}
     httpd._legacy_in_flight = {}
     httpd._gateway_routes = {}
+    httpd._cache_nonce_commitments = set()
     # Docker requires a non-loopback bind. In that mode the runner enables this
     # gate so arbitrary LAN clients cannot spend through a subscription route.
     httpd.require_registered_tokens = require_registered_tokens

--- a/obench/proxy.py
+++ b/obench/proxy.py
@@ -393,6 +393,7 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
         gateway_parser = None
         gateway_metrics = None
         cache_control = None
+        forwarded_upstream = False
         try:
             route = self._route_request()
             token = route.token
@@ -444,6 +445,7 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
                 raise RuntimeError("upstream URL missing host")
             conn = conn_cls(route.upstream.hostname, port=route.upstream.port, timeout=self.server.timeout_s)  # type: ignore[attr-defined]
             conn.request(self.command, route.upstream_path, body=body, headers=headers)
+            forwarded_upstream = True
             resp = conn.getresponse()
             status = resp.status
             resp_headers = resp.getheaders()
@@ -549,6 +551,7 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
                         "route_kind": route.gateway_route.plan.route_kind,
                     }
                     rec["provider_cache"] = cache_control
+                    rec["forwarded_upstream"] = forwarded_upstream
             if gateway_metrics is not None:
                 rec["gateway_metrics"] = gateway_metrics
             if "session" in links:

--- a/obench/results.py
+++ b/obench/results.py
@@ -26,7 +26,7 @@ _EXPERIMENT_FIELDS = frozenset({"id", "digest"})
 _ARM_FIELDS = frozenset({"id", "digest"})
 _COMPARISON_FIELDS = frozenset({
     "policy_digest", "catalog_digest", "price_digest", "sampling_digest",
-    "schedule_digest",
+    "schedule_digest", "provider_prompt_mode",
 })
 _TASK_FIELDS = frozenset({
     "name", "digest", "checker_digest", "workspace_source_sha",
@@ -210,6 +210,7 @@ class CellIdentity:
     repetition: int
     block_id: str
     block_attempt: int
+    provider_prompt_mode: str
 
     def __post_init__(self) -> None:
         if self.schema_version != CURRENT_SCHEMA_VERSION:
@@ -240,6 +241,7 @@ class CellIdentity:
         _require_positive_number("checker_timeout_s", self.checker_timeout_s)
         _require_positive_int("repetition", self.repetition)
         _require_non_negative_int("block_attempt", self.block_attempt)
+        _require_non_empty_string("provider_prompt_mode", self.provider_prompt_mode)
 
     @classmethod
     def for_gateway(cls, **values: Any) -> "CellIdentity":
@@ -252,6 +254,14 @@ class CellIdentity:
 
     def as_dict(self) -> dict[str, Any]:
         """Return the canonical nested identity representation."""
+        comparison = {
+            "policy_digest": self.policy_digest,
+            "catalog_digest": self.catalog_digest,
+            "price_digest": self.price_digest,
+            "sampling_digest": self.sampling_digest,
+            "schedule_digest": self.schedule_digest,
+        }
+        comparison["provider_prompt_mode"] = self.provider_prompt_mode
         return {
             "schema_version": self.schema_version,
             "benchmark": {"name": self.benchmark, "track": self.track},
@@ -260,13 +270,7 @@ class CellIdentity:
                 "digest": self.experiment_digest,
             },
             "arm": {"id": self.arm_id, "digest": self.arm_digest},
-            "comparison": {
-                "policy_digest": self.policy_digest,
-                "catalog_digest": self.catalog_digest,
-                "price_digest": self.price_digest,
-                "sampling_digest": self.sampling_digest,
-                "schedule_digest": self.schedule_digest,
-            },
+            "comparison": comparison,
             "task": {
                 "name": self.task,
                 "digest": self.task_digest,
@@ -364,6 +368,7 @@ def validate_gateway_identity(value: CellIdentity | Mapping[str, Any]) -> CellId
         repetition=schedule["repetition"],
         block_id=schedule["block_id"],
         block_attempt=schedule["block_attempt"],
+        provider_prompt_mode=comparison["provider_prompt_mode"],
     )
 
 
@@ -376,6 +381,12 @@ def gateway_identity_from_row(row: Mapping[str, Any]) -> CellIdentity:
         raise ResultIdentityError("gateway row schema_version conflicts with its identity")
     if row.get("benchmark") != identity.benchmark:
         raise ResultIdentityError("gateway row benchmark conflicts with its identity")
+    if (
+        row.get("provider_prompt_mode") != identity.provider_prompt_mode
+    ):
+        raise ResultIdentityError(
+            "gateway row provider_prompt_mode conflicts with its identity"
+        )
     return identity
 
 

--- a/obench/results.py
+++ b/obench/results.py
@@ -260,8 +260,8 @@ class CellIdentity:
             "price_digest": self.price_digest,
             "sampling_digest": self.sampling_digest,
             "schedule_digest": self.schedule_digest,
+            "provider_prompt_mode": self.provider_prompt_mode,
         }
-        comparison["provider_prompt_mode"] = self.provider_prompt_mode
         return {
             "schema_version": self.schema_version,
             "benchmark": {"name": self.benchmark, "track": self.track},
@@ -381,9 +381,7 @@ def gateway_identity_from_row(row: Mapping[str, Any]) -> CellIdentity:
         raise ResultIdentityError("gateway row schema_version conflicts with its identity")
     if row.get("benchmark") != identity.benchmark:
         raise ResultIdentityError("gateway row benchmark conflicts with its identity")
-    if (
-        row.get("provider_prompt_mode") != identity.provider_prompt_mode
-    ):
+    if row.get("provider_prompt_mode") != identity.provider_prompt_mode:
         raise ResultIdentityError(
             "gateway row provider_prompt_mode conflicts with its identity"
         )

--- a/obench/tests/test_gateway_publish.py
+++ b/obench/tests/test_gateway_publish.py
@@ -103,6 +103,7 @@ class GatewayPublishTests(unittest.TestCase):
         self.policy = {
             "schema_version": 1,
             "policy_id": "strict",
+            "provider_prompt_mode": "provider_default",
             "allowed_models": ["openai/gpt-test"],
             "allowed_providers": ["OpenAI"],
             "fallback_enabled": False,
@@ -211,6 +212,35 @@ class GatewayPublishTests(unittest.TestCase):
         }
         self._write_ledger()
 
+    def test_provider_prompt_mode_is_bound_across_publication_artifacts(self):
+        gateway_publish._require_provider_prompt_mode_binding(  # noqa: SLF001
+            self.experiment.to_dict(),
+            self.policy,
+            [self.row],
+        )
+
+        wrong_policy = dict(self.policy, provider_prompt_mode="isolated_per_call_v1")
+        with self.assertRaisesRegex(
+            gateway_publish.GatewayPublishError,
+            "policy provider_prompt_mode",
+        ):
+            gateway_publish._require_provider_prompt_mode_binding(  # noqa: SLF001
+                self.experiment.to_dict(),
+                wrong_policy,
+                [self.row],
+            )
+
+        wrong_row = dict(self.row, provider_prompt_mode="isolated_per_call_v1")
+        with self.assertRaisesRegex(
+            gateway_publish.GatewayPublishError,
+            "result .* provider_prompt_mode",
+        ):
+            gateway_publish._require_provider_prompt_mode_binding(  # noqa: SLF001
+                self.experiment.to_dict(),
+                self.policy,
+                [wrong_row],
+            )
+
     def _write_results(self, *rows):
         self.results_path.write_text(
             "".join(canonical_line(row) for row in rows),
@@ -244,6 +274,14 @@ class GatewayPublishTests(unittest.TestCase):
                 "arm_digest": self.identity.arm_digest,
                 "route_kind": "gateway",
             },
+            "provider_cache": {
+                "mode": "provider_default",
+                "transform_id": None,
+                "prefix_injected": False,
+                "scope": None,
+                "nonce_commitment": None,
+            },
+            "forwarded_upstream": True,
             "error": "request body and credentials must never publish",
         }
         if partial:
@@ -433,6 +471,128 @@ class GatewayPublishTests(unittest.TestCase):
             gateway_publish._require_complete_schedule(
                 self.experiment.to_dict(),
                 [self.row],
+            )
+
+    def test_publication_binds_rows_to_one_declared_matched_block(self):
+        direct_identity = dataclasses.replace(
+            self.identity,
+            arm_id="direct",
+            arm_digest=self.experiment.arms[0].digest,
+        )
+        direct_row = copy.deepcopy(self.row)
+        direct_row["identity"] = direct_identity.as_dict()
+        direct_row["cell_id"] = results.make_gateway_cell_id(direct_identity)
+        direct_row["run_id"] = results.make_gateway_run_id(direct_identity)
+        rows = [self.row, direct_row]
+        gateway_publish._require_complete_schedule(  # noqa: SLF001
+            self.experiment.to_dict(),
+            rows,
+        )
+
+        wrong_block = dataclasses.replace(direct_identity, block_id="other-block")
+        direct_row["identity"] = wrong_block.as_dict()
+        with self.assertRaisesRegex(
+            gateway_publish.GatewayPublishError,
+            "conflicting block IDs",
+        ):
+            gateway_publish._require_complete_schedule(  # noqa: SLF001
+                self.experiment.to_dict(),
+                rows,
+            )
+
+        wrong_arm = dataclasses.replace(direct_identity, arm_digest=digest("wrong-arm"))
+        direct_row["identity"] = wrong_arm.as_dict()
+        with self.assertRaisesRegex(
+            gateway_publish.GatewayPublishError,
+            "arm digest does not match",
+        ):
+            gateway_publish._require_complete_schedule(  # noqa: SLF001
+                self.experiment.to_dict(),
+                rows,
+            )
+
+    def test_publication_rejects_reused_cold_prefix_commitment(self):
+        evidence = {
+            "mode": "isolated_per_call_v1",
+            "transform_id": gateway_spec.COLD_PREFIX_TRANSFORM_ID,
+            "prefix_injected": True,
+            "scope": "forwarded_request",
+            "nonce_commitment": "a" * 64,
+        }
+        cache_metrics = {
+            "usage": {"input_tokens_details": {"cached_tokens": 0}},
+        }
+        with self.assertRaisesRegex(
+            gateway_publish.GatewayPublishError,
+            "reuses a cold-prefix commitment",
+        ):
+            gateway_publish._provider_prompt_commitments(
+                [
+                    {
+                        "status": 200,
+                        "forwarded_upstream": True,
+                        "provider_cache": evidence,
+                        "gateway_metrics": cache_metrics,
+                    },
+                    {
+                        "status": 200,
+                        "forwarded_upstream": True,
+                        "provider_cache": evidence,
+                        "gateway_metrics": cache_metrics,
+                    },
+                ],
+                "isolated_per_call_v1",
+                "fixture",
+            )
+
+    def test_publication_requires_zero_cached_tokens_in_isolated_mode(self):
+        evidence = {
+            "mode": "isolated_per_call_v1",
+            "transform_id": gateway_spec.COLD_PREFIX_TRANSFORM_ID,
+            "prefix_injected": True,
+            "scope": "forwarded_request",
+            "nonce_commitment": "a" * 64,
+        }
+        for details in (None, {"cached_tokens": 1}):
+            with self.subTest(details=details), self.assertRaisesRegex(
+                gateway_publish.GatewayPublishError,
+                "zero cached-token evidence",
+            ):
+                gateway_publish._provider_prompt_commitments(
+                    [{
+                        "status": 200,
+                        "forwarded_upstream": True,
+                        "provider_cache": evidence,
+                        "gateway_metrics": {
+                            "usage": {"input_tokens_details": details},
+                        },
+                    }],
+                    "isolated_per_call_v1",
+                    "fixture",
+                )
+
+    def test_publication_requires_mode_evidence_only_after_forwarding(self):
+        gateway_publish._provider_prompt_commitments(  # noqa: SLF001
+            [{
+                "status": 502,
+                "forwarded_upstream": False,
+                "provider_cache": None,
+            }],
+            "isolated_per_call_v1",
+            "fixture",
+        )
+        with self.assertRaisesRegex(
+            gateway_publish.GatewayPublishError,
+            "provider-default evidence",
+        ):
+            gateway_publish._provider_prompt_commitments(  # noqa: SLF001
+                [{
+                    "status": 200,
+                    "forwarded_upstream": True,
+                    "provider_cache": None,
+                }],
+                "provider_default",
+                "fixture",
             )
 
     def test_gateway_route_evidence_is_minimized_and_opaque_in_public_ledger(self):

--- a/obench/tests/test_gateway_publish.py
+++ b/obench/tests/test_gateway_publish.py
@@ -26,9 +26,10 @@ def canonical_line(value):
 
 def experiment():
     return gateway_spec.parse_experiment({
-        "schema_version": 1,
+        "schema_version": 2,
         "experiment_id": "gateway-bench-publish",
         "track": "fixed_model_provider",
+        "provider_prompt_mode": "provider_default",
         "harness": "pi",
         "tasks": ["make-it-run"],
         "repetitions_per_window": 1,
@@ -140,7 +141,8 @@ class GatewayPublishTests(unittest.TestCase):
             catalog_digest=results.canonical_digest(self.catalog),
             price_digest=results.canonical_digest(self.prices),
             sampling_digest=digest("sampling"),
-            schedule_digest=digest("schedule"),
+        schedule_digest=digest("schedule"),
+        provider_prompt_mode="provider_default",
             task="make-it-run",
             task_digest=digest("task"),
             checker_digest=digest("checker"),
@@ -171,6 +173,7 @@ class GatewayPublishTests(unittest.TestCase):
             "expected_arm_ids": ["direct", "gateway"],
             "arm_role": "gateway",
             "baseline": False,
+            "provider_prompt_mode": "provider_default",
             "result": {
                 "solved": True,
                 "checker_score": 1.0,
@@ -272,6 +275,85 @@ class GatewayPublishTests(unittest.TestCase):
         self._write_results(self.row)
 
     def publish(self):
+        ledgers = {self.cell_id: self.source_ledger}
+        raw_results = self.results_path.read_bytes()
+        try:
+            source_rows = [
+                json.loads(line)
+                for line in self.results_path.read_text(encoding="utf-8").splitlines()
+                if line
+            ]
+        except (OSError, json.JSONDecodeError):
+            source_rows = []
+        if hasattr(self, "_direct_cell_id") and any(
+            row.get("cell_id") == self._direct_cell_id for row in source_rows
+        ):
+            ledgers[self._direct_cell_id] = self._direct_ledger
+        if (
+            raw_results.endswith(b"\n")
+            and len(source_rows) == 1
+            and source_rows[0].get("cell_id") == self.cell_id
+        ):
+            direct_identity = dataclasses.replace(
+                self.identity,
+                arm_id="direct",
+                arm_digest=self.experiment.arms[0].digest,
+            )
+            direct = copy.deepcopy(source_rows[0])
+            direct["identity"] = direct_identity.as_dict()
+            direct["run_id"] = results.make_gateway_run_id(direct_identity)
+            direct["cell_id"] = results.make_gateway_cell_id(direct_identity)
+            direct["arm_role"] = "direct"
+            direct["baseline"] = True
+
+            direct_ledger = self.root / "direct-companion-ledger.jsonl"
+            source_ledger_rows = [
+                json.loads(line)
+                for line in self.source_ledger.read_text(encoding="utf-8").splitlines()
+                if line
+            ]
+            requests = source_ledger_rows[:-1]
+            previous = hashlib.sha256(b"").hexdigest()
+            rewritten = []
+            for sequence, request in enumerate(requests, 1):
+                request = copy.deepcopy(request)
+                request["sequence"] = sequence
+                request["previous_hash"] = previous
+                request["serving_arm"] = {
+                    "arm_id": "direct",
+                    "arm_digest": direct_identity.arm_digest,
+                    "route_kind": "direct",
+                }
+                request["record_hash"] = hashlib.sha256(
+                    results.canonical_json_bytes({
+                        key: value
+                        for key, value in request.items()
+                        if key != "record_hash"
+                    })
+                ).hexdigest()
+                previous = request["record_hash"]
+                rewritten.append(request)
+            seal = {
+                "record_type": "ledger_seal",
+                "state": "SEALED",
+                "record_count": len(rewritten),
+                "last_sequence": len(rewritten),
+                "root_hash": previous,
+            }
+            direct_ledger.write_text(
+                "".join(canonical_line(item) for item in [*rewritten, seal]),
+                encoding="utf-8",
+            )
+            direct["ledger_seal"] = {
+                "record_count": len(rewritten),
+                "last_sequence": len(rewritten),
+                "root_hash": previous,
+                "ledger_file": direct_ledger.name,
+            }
+            self._write_results(direct, source_rows[0])
+            ledgers[direct["cell_id"]] = direct_ledger
+            self._direct_cell_id = direct["cell_id"]
+            self._direct_ledger = direct_ledger
         return gateway_publish.publish_bundle(
             self.results_path,
             self.bundle,
@@ -279,7 +361,17 @@ class GatewayPublishTests(unittest.TestCase):
             policy=self.policy,
             catalog=self.catalog,
             prices=self.prices,
-            ledgers={self.cell_id: self.source_ledger},
+            ledgers=ledgers,
+        )
+
+    def _public_gateway_row(self):
+        rows = [
+            json.loads(line)
+            for line in (self.bundle / "results.jsonl").read_text().splitlines()
+        ]
+        return next(
+            row for row in rows
+            if row["identity"]["arm"]["id"] == "gateway"
         )
 
     def test_round_trip_uses_allowlisted_dtos_and_binds_all_artifacts(self):
@@ -316,7 +408,7 @@ class GatewayPublishTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, bundle_text)
 
-        public_row = json.loads((self.bundle / "results.jsonl").read_text())
+        public_row = self._public_gateway_row()
         self.assertEqual(
             public_row["proxy_metrics"]["calls"][0]["cache"],
             {
@@ -332,6 +424,16 @@ class GatewayPublishTests(unittest.TestCase):
         self.assertEqual(seal["cell_id"], self.cell_id)
         self.assertEqual(seal["root_hash"], binding["root_hash"])
         self.assertEqual(seal["seal_sha256"], binding["seal_sha256"])
+
+    def test_publication_rejects_incomplete_declared_schedule(self):
+        with self.assertRaisesRegex(
+            gateway_publish.GatewayPublishError,
+            "latest matched block is incomplete",
+        ):
+            gateway_publish._require_complete_schedule(
+                self.experiment.to_dict(),
+                [self.row],
+            )
 
     def test_gateway_route_evidence_is_minimized_and_opaque_in_public_ledger(self):
         generation_id = "vercel-generation-raw-id"
@@ -386,7 +488,7 @@ class GatewayPublishTests(unittest.TestCase):
             ["openai/gpt-test", "gpt-test-2026-07-22"],
         )
 
-        public_row = json.loads((self.bundle / "results.jsonl").read_text())
+        public_row = self._public_gateway_row()
         public_ledger = self.bundle / public_row["ledger"]["artifact"]
         request = json.loads(public_ledger.read_text().splitlines()[0])
         route = request["gateway_metrics"]["route"]
@@ -527,7 +629,7 @@ class GatewayPublishTests(unittest.TestCase):
         provenance = self.publish()
 
         self.assertEqual(gateway_publish.verify_bundle(self.bundle), provenance)
-        public_row = json.loads((self.bundle / "results.jsonl").read_text())
+        public_row = self._public_gateway_row()
         self.assertEqual(
             public_row["result"]["budget_exhausted_reason"],
             "max_calls",
@@ -554,7 +656,7 @@ class GatewayPublishTests(unittest.TestCase):
 
         provenance = self.publish()
         self.assertEqual(gateway_publish.verify_bundle(self.bundle), provenance)
-        public_row = json.loads((self.bundle / "results.jsonl").read_text())
+        public_row = self._public_gateway_row()
         public_call = public_row["proxy_metrics"]["calls"][0]
         self.assertNotIn("timing", public_call)
         self.assertIsNone(public_call["generation"])

--- a/obench/tests/test_gateway_report.py
+++ b/obench/tests/test_gateway_report.py
@@ -60,6 +60,7 @@ def make_row(
         price_digest=DIGESTS["price"],
         sampling_digest=DIGESTS["sampling"],
         schedule_digest=DIGESTS["schedule"],
+        provider_prompt_mode="provider_default",
         task=task,
         task_digest=DIGESTS[task],
         checker_digest=DIGESTS["checker"],
@@ -95,6 +96,7 @@ def make_row(
         "identity": identity.as_dict(),
         "arm_role": role,
         "model_match": model_match,
+        "provider_prompt_mode": "provider_default",
         "baseline": baseline,
         "result": result,
         "route_integrity": {
@@ -113,6 +115,7 @@ def call(
     ttfb=1.0,
     ttft=2.0,
     tokens=10,
+    input_tokens=100,
     generation_s=2.0,
     costs=True,
     attempts=None,
@@ -136,6 +139,11 @@ def call(
     result = {
         "timing": {"ttfb_s": ttfb, "semantic_ttft_s": ttft},
         "generation": {"output_tokens": tokens, "duration_s": generation_s},
+        "tokens": {
+            "input_tokens": input_tokens,
+            "output_tokens": tokens,
+            "total_tokens": input_tokens + tokens,
+        },
         "route": {
             "provider": provider,
             "served_model": model,
@@ -413,10 +421,11 @@ class GatewayReportTests(unittest.TestCase):
         self.assertEqual(
             metrics["mean_cache_write_input_tokens_per_call"]["estimate"], 25.0
         )
-        self.assertNotIn("cache_hit_call_rate", metrics)
-        self.assertNotIn(
-            "cache_hit_call_rate",
-            report["arms"]["direct"]["metrics"],
+        self.assertEqual(metrics["cache_hit_call_rate"]["estimate"], 0.75)
+        self.assertAlmostEqual(metrics["cached_input_fraction"]["estimate"], 0.35)
+        self.assertEqual(
+            report["arms"]["direct"]["metrics"]["cache_hit_call_rate"]["estimate"],
+            0.0,
         )
         for name in (
             "mean_cached_input_tokens_per_call",
@@ -439,7 +448,7 @@ class GatewayReportTests(unittest.TestCase):
         self.assertEqual(
             contrasts["mean_cached_input_tokens_per_call"]["estimate"], 35.0
         )
-        self.assertNotIn("cache_hit_call_rate", contrasts)
+        self.assertEqual(contrasts["cache_hit_call_rate"]["estimate"], 0.75)
         self.assertEqual(
             contrasts["mean_cache_write_input_tokens_per_call"]["estimate"], 25.0
         )

--- a/obench/tests/test_gateway_route.py
+++ b/obench/tests/test_gateway_route.py
@@ -120,9 +120,10 @@ def route_plan(
     arm_digest,
     gateway=None,
     protocol="openai_chat",
+    provider_prompt_mode="provider_default",
 ):
     return gateway_spec.RoutePlan(
-        schema_version=1,
+        schema_version=2,
         experiment_digest="e" * 64,
         arm_digest=arm_digest,
         arm_id=arm_id,
@@ -143,6 +144,7 @@ def route_plan(
         private_host_allowlist=("127.0.0.1",),
         private_cidr_allowlist=(),
         gateway=gateway or ("openrouter" if route_kind == "gateway" else None),
+        provider_prompt_mode=provider_prompt_mode,
     )
 
 
@@ -211,6 +213,76 @@ class GatewayRouteTests(unittest.TestCase):
         self.assertNotIn("client-cache", ledger)
         self.assertNotIn("client-safety", ledger)
         self.assertNotIn("client-safety", json.dumps(rows))
+
+    def test_cold_prefix_is_unique_per_responses_call_and_safely_evidenced(self):
+        plan = route_plan(
+            endpoint=self.upstream_base + "/responses",
+            route_kind="direct",
+            arm_id="direct-cold-responses",
+            arm_digest="c" * 64,
+            protocol="openai_responses",
+            provider_prompt_mode="isolated_per_call_v1",
+        )
+        token = "cold-responses-cell"
+        self.server.register_cell(token)
+        self.server.register_route(token, plan, secret_plan(plan.arm_id))
+
+        body = {
+            "model": "attacker-model",
+            "instructions": "Keep the workspace correct.",
+            "input": "private",
+        }
+        for _ in range(2):
+            status, _response = self._post(token, plan.arm_digest, body=body)
+            self.assertEqual(status, 200)
+
+        first, second = self.upstream.requests[-2:]
+        first_instructions = first["body"]["instructions"]
+        second_instructions = second["body"]["instructions"]
+        self.assertTrue(first_instructions.endswith(body["instructions"]))
+        self.assertTrue(second_instructions.endswith(body["instructions"]))
+        self.assertNotEqual(first_instructions, second_instructions)
+
+        rows = self._seal_rows(token)
+        call_rows = [row for row in rows if row.get("record_type") != "ledger_seal"]
+        cache_evidence = [row["provider_cache"] for row in call_rows]
+        self.assertTrue(all(
+            item["mode"] == "isolated_per_call_v1"
+            and item["transform_id"] == gateway_spec.COLD_PREFIX_TRANSFORM_ID
+            and item["prefix_injected"] is True
+            and item["scope"] == "forwarded_request"
+            and len(item["nonce_commitment"]) == 64
+            for item in cache_evidence
+        ))
+        self.assertNotEqual(
+            cache_evidence[0]["nonce_commitment"],
+            cache_evidence[1]["nonce_commitment"],
+        )
+        ledger = self.server._ledger_path(token).read_text(encoding="utf-8")
+        self.assertNotIn("OpenBench cache isolation id", ledger)
+        self.assertNotIn("Keep the workspace correct.", ledger)
+
+    def test_cold_prefix_rejects_nonce_reuse_before_second_upstream_call(self):
+        plan = route_plan(
+            endpoint=self.upstream_base + "/responses",
+            route_kind="direct",
+            arm_id="direct-cold-reuse",
+            arm_digest="9" * 64,
+            protocol="openai_responses",
+            provider_prompt_mode="isolated_per_call_v1",
+        )
+        token = "cold-reuse-cell"
+        self.server.register_cell(token)
+        self.server.register_route(token, plan, secret_plan(plan.arm_id))
+        body = {"model": "wrong", "instructions": "Stable", "input": "private"}
+
+        with mock.patch("obench.proxy.secrets.token_hex", return_value="a" * 64):
+            first, _ = self._post(token, plan.arm_digest, body=body)
+            second, _ = self._post(token, plan.arm_digest, body=body)
+
+        self.assertEqual(first, 200)
+        self.assertEqual(second, 502)
+        self.assertEqual(len(self.upstream.requests), 1)
 
     def test_programmatic_route_rejects_host_outside_explicit_allowlist(self):
         token = "unlisted-host"

--- a/obench/tests/test_gateway_route.py
+++ b/obench/tests/test_gateway_route.py
@@ -245,6 +245,7 @@ class GatewayRouteTests(unittest.TestCase):
 
         rows = self._seal_rows(token)
         call_rows = [row for row in rows if row.get("record_type") != "ledger_seal"]
+        self.assertTrue(all(row["forwarded_upstream"] is True for row in call_rows))
         cache_evidence = [row["provider_cache"] for row in call_rows]
         self.assertTrue(all(
             item["mode"] == "isolated_per_call_v1"
@@ -283,6 +284,12 @@ class GatewayRouteTests(unittest.TestCase):
         self.assertEqual(first, 200)
         self.assertEqual(second, 502)
         self.assertEqual(len(self.upstream.requests), 1)
+        rows = self._seal_rows(token)
+        call_rows = [row for row in rows if row.get("record_type") != "ledger_seal"]
+        self.assertEqual(
+            [row["forwarded_upstream"] for row in call_rows],
+            [True, False],
+        )
 
     def test_programmatic_route_rejects_host_outside_explicit_allowlist(self):
         token = "unlisted-host"

--- a/obench/tests/test_gateway_run.py
+++ b/obench/tests/test_gateway_run.py
@@ -27,6 +27,13 @@ PRICE_JSON = json.dumps({
         "effective_at": "2026-07-22T00:00:00Z",
     }
 })
+PROVIDER_DEFAULT_EVIDENCE = {
+    "mode": "provider_default",
+    "transform_id": None,
+    "prefix_injected": False,
+    "scope": None,
+    "nonce_commitment": None,
+}
 
 
 class _UpstreamHandler(BaseHTTPRequestHandler):
@@ -631,7 +638,11 @@ direct_control_arm_id = "direct"
         for budget, call_metrics, expected in cases:
             with self.subTest(expected=expected):
                 calls, integrity, reason = gateway_run._proxy_evidence(
-                    [{"status": 200, "gateway_metrics": call_metrics}, rejection],
+                    [{
+                        "status": 200,
+                        "gateway_metrics": call_metrics,
+                        "provider_cache": PROVIDER_DEFAULT_EVIDENCE,
+                    }, rejection],
                     price,
                     budget,
                     plan,
@@ -759,6 +770,7 @@ direct_control_arm_id = "direct"
                 "status": 200,
                 "ts": "2026-07-22T12:00:00Z",
                 "gateway_metrics": metrics,
+                "provider_cache": PROVIDER_DEFAULT_EVIDENCE,
             }],
             {plan.canonical_model: gateway_run.Price(
                 gateway_run.Decimal("1"),
@@ -785,6 +797,7 @@ direct_control_arm_id = "direct"
                 "status": 200,
                 "ts": "2026-07-22T12:00:00Z",
                 "gateway_metrics": metrics,
+                "provider_cache": PROVIDER_DEFAULT_EVIDENCE,
             }],
             {plan.canonical_model: gateway_run.Price(
                 gateway_run.Decimal("1"),
@@ -811,6 +824,7 @@ direct_control_arm_id = "direct"
                 "status": 200,
                 "ts": "2026-07-22T12:00:00Z",
                 "gateway_metrics": metrics,
+                "provider_cache": PROVIDER_DEFAULT_EVIDENCE,
             }],
             {plan.canonical_model: gateway_run.Price(
                 gateway_run.Decimal("1"),
@@ -858,7 +872,12 @@ direct_control_arm_id = "direct"
         }
         observed_at = "2026-07-22T12:34:56Z"
         calls, integrity, reason = gateway_run._proxy_evidence(
-            [{"status": 200, "ts": observed_at, "gateway_metrics": metrics}],
+            [{
+                "status": 200,
+                "ts": observed_at,
+                "gateway_metrics": metrics,
+                "provider_cache": PROVIDER_DEFAULT_EVIDENCE,
+            }],
             {
                 plan.canonical_model: gateway_run.Price(
                     gateway_run.Decimal("1"),
@@ -978,7 +997,11 @@ direct_control_arm_id = "direct"
             "route_evidence": {"pass": True, "reasons": []},
         }
         calls, integrity, reason = gateway_run._proxy_evidence(
-            [{"status": 200, "gateway_metrics": metrics}],
+            [{
+                "status": 200,
+                "gateway_metrics": metrics,
+                "provider_cache": PROVIDER_DEFAULT_EVIDENCE,
+            }],
             {
                 plan.canonical_model: gateway_run.Price(
                     gateway_run.Decimal("1"),
@@ -1036,7 +1059,12 @@ direct_control_arm_id = "direct"
         )
         observed_at = "2026-07-22T12:34:56Z"
         calls, integrity, reason = gateway_run._proxy_evidence(
-            [{"status": 200, "ts": observed_at, "gateway_metrics": metrics}],
+            [{
+                "status": 200,
+                "ts": observed_at,
+                "gateway_metrics": metrics,
+                "provider_cache": PROVIDER_DEFAULT_EVIDENCE,
+            }],
             {
                 plan.canonical_model: gateway_run.Price(
                     gateway_run.Decimal("1"),

--- a/obench/tests/test_gateway_run.py
+++ b/obench/tests/test_gateway_run.py
@@ -196,9 +196,10 @@ top_p = 1.0
 seed = 7
 '''
         return f'''\
-schema_version = 1
+schema_version = 2
 experiment_id = "fake-gateway-bench"
 track = "fixed_model_provider"
+provider_prompt_mode = "provider_default"
 harness = "pi"
 tasks = ["fake-task"]
 repetitions_per_window = 1
@@ -523,6 +524,61 @@ direct_control_arm_id = "direct"
             },
         }
         self.assertIn("malformed_sse_event", gateway_run._route_reasons(metrics, plan))
+
+    def test_cold_prefix_evidence_fails_closed_on_missing_or_cached_usage(self):
+        experiment = gateway_run.gateway_spec.load_experiment(self.experiment)
+        plans, _secrets = gateway_run.gateway_spec.compile_route_plans(
+            experiment,
+            environ=self.env,
+            admitted_auth_envs={"DIRECT_KEY", "GATEWAY_KEY"},
+        )
+        plan = dataclasses.replace(
+            next(item for item in plans if item.route_kind == "direct"),
+            protocol="openai_responses",
+            provider_prompt_mode="isolated_per_call_v1",
+        )
+        base = {
+            "route": {
+                "requested_model": plan.requested_model,
+                "served_model": plan.requested_model,
+                "provider": plan.requested_provider,
+            },
+            "stream": {"done": True},
+            "route_evidence": {"pass": True, "reasons": []},
+        }
+        evidence = {
+            "mode": "isolated_per_call_v1",
+            "transform_id": gateway_run.gateway_spec.COLD_PREFIX_TRANSFORM_ID,
+            "prefix_injected": True,
+            "scope": "forwarded_request",
+            "nonce_commitment": "a" * 64,
+        }
+        self.assertEqual(
+            gateway_run._provider_cache_reasons(
+                {"provider_cache": evidence}, base, plan
+            ),
+            ["cold_cache_usage_missing"],
+        )
+        cached = {
+            **base,
+            "usage": {"input_tokens_details": {"cached_tokens": 128}},
+        }
+        self.assertEqual(
+            gateway_run._provider_cache_reasons(
+                {"provider_cache": evidence}, cached, plan
+            ),
+            ["cold_cache_hit"],
+        )
+        uncached = {
+            **base,
+            "usage": {"input_tokens_details": {"cached_tokens": 0}},
+        }
+        self.assertEqual(
+            gateway_run._provider_cache_reasons(
+                {"provider_cache": evidence}, uncached, plan
+            ),
+            [],
+        )
 
     def test_posthoc_caps_override_combined_max_calls_exhaustion(self):
         experiment = gateway_run.gateway_spec.load_experiment(self.experiment)
@@ -868,12 +924,14 @@ direct_control_arm_id = "direct"
         self.assertTrue(integrity["pass"])
         self.assertIsNone(reason)
         self.assertEqual(calls, [{
+            "request_ordinal": None,
             "timing": None,
             "generation": None,
             "route": {
                 "provider": plan.requested_provider,
                 "served_model": plan.requested_model,
             },
+            "tokens": None,
             "cache": None,
             "costs": None,
         }])

--- a/obench/tests/test_gateway_spec.py
+++ b/obench/tests/test_gateway_spec.py
@@ -69,9 +69,10 @@ def manifest(**replacements):
     values.update(replacements)
     return textwrap.dedent(
         f"""
-        schema_version = 1
+        schema_version = 2
         experiment_id = "gateway-bench-smoke"
         track = "{values['track']}"
+        provider_prompt_mode = "provider_default"
         harness = "{values['harness']}"
         tasks = {values['tasks']}
         repetitions_per_window = {values['repetitions']}
@@ -159,6 +160,45 @@ class GatewayExperimentTests(unittest.TestCase):
                 )
             )
 
+    def test_provider_prompt_mode_is_required_and_isolation_is_responses_only(self):
+        natural = parse_experiment_toml(manifest())
+        self.assertEqual(natural.provider_prompt_mode, "provider_default")
+
+        responses = (
+            manifest()
+            .replace(
+                'provider_prompt_mode = "provider_default"',
+                'provider_prompt_mode = "isolated_per_call_v1"',
+            )
+            .replace("/chat/completions", "/responses")
+            .replace('protocol = "openai_chat"', 'protocol = "openai_responses"')
+        )
+        cold = parse_experiment_toml(responses)
+        self.assertEqual(cold.provider_prompt_mode, "isolated_per_call_v1")
+        self.assertNotEqual(natural.digest, cold.digest)
+
+        with self.assertRaisesRegex(GatewaySpecError, "requires openai_responses"):
+            parse_experiment_toml(
+                manifest().replace(
+                    'provider_prompt_mode = "provider_default"',
+                    'provider_prompt_mode = "isolated_per_call_v1"',
+                )
+            )
+        with self.assertRaisesRegex(GatewaySpecError, "provider_prompt_mode"):
+            parse_experiment_toml(
+                manifest().replace(
+                    'provider_prompt_mode = "provider_default"',
+                    'provider_prompt_mode = "disabled"',
+                )
+            )
+        with self.assertRaisesRegex(GatewaySpecError, "provider_prompt_mode"):
+            parse_experiment_toml(
+                manifest().replace(
+                    'provider_prompt_mode = "provider_default"\n',
+                    "",
+                )
+            )
+
     def test_rejects_router_track_and_auto_only_fields(self):
         with self.assertRaisesRegex(GatewaySpecError, "track must be"):
             parse_experiment_toml(
@@ -213,6 +253,7 @@ class GatewayExperimentTests(unittest.TestCase):
         self.assertIn("OPENAI_API_KEY", persisted)
         self.assertNotIn("direct-secret-value", persisted)
         self.assertNotIn("gateway-secret-value", persisted)
+        self.assertEqual(plans[0].provider_prompt_mode, "provider_default")
         self.assertEqual(secrets.value_for("direct-openai"), "direct-secret-value")
         self.assertNotIn("direct-secret-value", repr(secrets))
         with self.assertRaises(TypeError):
@@ -246,7 +287,7 @@ class GatewayExperimentTests(unittest.TestCase):
     def test_rejects_unknown_keys_at_every_level(self):
         cases = (
             manifest().replace(
-                "schema_version = 1", "schema_version = 1\nunexpected = true", 1),
+                "schema_version = 2", "schema_version = 2\nunexpected = true", 1),
             manifest(budget=manifest_budget() + "\nextra = 1"),
             manifest(gateway_extra='direct_control_arm_id = "direct-openai"\nextra = 1'),
             manifest(gateway_extra=(

--- a/obench/tests/test_gateway_spec.py
+++ b/obench/tests/test_gateway_spec.py
@@ -177,6 +177,24 @@ class GatewayExperimentTests(unittest.TestCase):
         self.assertEqual(cold.provider_prompt_mode, "isolated_per_call_v1")
         self.assertNotEqual(natural.digest, cold.digest)
 
+        non_openai_direct = responses.replace(
+            'requested_provider = "openai"',
+            'requested_provider = "anthropic"',
+        ).replace(
+            'allowed_providers = ["openai"]',
+            'allowed_providers = ["anthropic"]',
+        )
+        with self.assertRaisesRegex(GatewaySpecError, "direct OpenAI"):
+            parse_experiment_toml(non_openai_direct)
+
+        non_openai_endpoint = responses.replace(
+            "https://api.openai.com",
+            "https://api.example.com",
+            1,
+        )
+        with self.assertRaisesRegex(GatewaySpecError, "direct OpenAI"):
+            parse_experiment_toml(non_openai_endpoint)
+
         with self.assertRaisesRegex(GatewaySpecError, "requires openai_responses"):
             parse_experiment_toml(
                 manifest().replace(

--- a/obench/tests/test_pi_gateway.py
+++ b/obench/tests/test_pi_gateway.py
@@ -16,7 +16,7 @@ from obench.gateway_spec import (
 
 def plan_dict(**updates):
     plan = RoutePlan(
-        schema_version=1,
+        schema_version=2,
         experiment_digest="a" * 64,
         arm_digest="b" * 64,
         arm_id="gateway",

--- a/obench/tests/test_results.py
+++ b/obench/tests/test_results.py
@@ -23,6 +23,7 @@ def gateway_identity():
         price_digest=digest("price"),
         sampling_digest=digest("sampling"),
         schedule_digest=digest("schedule"),
+        provider_prompt_mode="provider_default",
         task="make-it-run",
         task_digest=digest("task"),
         checker_digest=digest("checker"),
@@ -54,6 +55,7 @@ SHARED_CHANGES = {
     "price_digest": digest("price-changed"),
     "sampling_digest": digest("sampling-changed"),
     "schedule_digest": digest("schedule-changed"),
+    "provider_prompt_mode": "isolated_per_call_v1",
     "harness": "other-harness",
     "candidate": "other-candidate",
     "harness_version": "0.80.11",
@@ -214,6 +216,7 @@ class ResumeTests(unittest.TestCase):
             "schema_version": 2,
             "benchmark": "gateway",
             "identity": identity.as_dict(),
+            "provider_prompt_mode": identity.provider_prompt_mode,
             "run_id": results.make_gateway_run_id(identity),
             "cell_id": results.make_gateway_cell_id(identity),
         }

--- a/obench/tests/test_stall_kill.py
+++ b/obench/tests/test_stall_kill.py
@@ -59,11 +59,11 @@ class ProxyLivenessTrackingTests(unittest.TestCase):
 
     def test_stale_cell_reports_large_age(self):
         """A cell with old last_activity reports age >= the stall window."""
-        stale_ts = time.monotonic() - 700  # 700s ago (>600s default stall)
-        with self.server._ledger_condition:
-            ledger = self.server._cell_ledgers.get("test-cell-1")
-            ledger.last_activity_monotonic = stale_ts
-        age = self.server.cell_last_activity_age("test-cell-1")
+        with mock.patch("obench.proxy.time.monotonic", return_value=1000.0):
+            with self.server._ledger_condition:
+                ledger = self.server._cell_ledgers.get("test-cell-1")
+                ledger.last_activity_monotonic = 300.0
+            age = self.server.cell_last_activity_age("test-cell-1")
         self.assertIsNotNone(age)
         self.assertGreaterEqual(age, 700)
 


### PR DESCRIPTION
## Summary
- replace the Gateway Bench schema with an explicit provider prompt mode contract
- add a provider-default headline mode and a Responses-only per-call isolation control
- bind prompt mode, token/cache evidence, matched schedules, and nonce commitments through results, reports, publication, and verification

## Verification
- `python3 -m unittest discover -s obench/tests -q` (929 passed)
- `python3 -m obench.cli validate` (40/40 tasks)
- focused Gateway suite (87 passed)
- autoreview P1 threshold: pass, no actionable findings

## Scope
This is intentionally a clean breaking Gateway Bench schema change. It does not add backward-compatibility shims.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minghinmatthewlam/openbench/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->