### PR TITLE
Gateway Probe with managed Cloudflare comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ Versioned packs (`org/name@version`, tasks or harness manifests) are covered in
 [`docs/task-packs.md`](docs/task-packs.md) (`obench pack install …`).
 To compare a fixed coding harness and model over direct and gateway serving
 routes, see [`docs/gateway-bench.md`](docs/gateway-bench.md) (`obench gateway
-validate|doctor|run|report|publish|verify`).
+validate|doctor|run|report|publish|verify`). For direct request latency,
+accounting, and route-integrity probes without a coding harness, see
+[`docs/gateway-probe.md`](docs/gateway-probe.md) (`obench gateway probe
+validate|doctor|run|report`).
 
 **Live results:** https://minghinmatthewlam.github.io/openbench/ — the landing
 page is the leaderboard itself, with a tab each for Harness Bench and Gateway
@@ -41,7 +44,9 @@ provider, sampling, and task fixed while varying the API gateway. It uses the
 `fixed_model_provider` track and compares each gateway with the provider's
 direct API under matched blocks. See
 [`docs/gateway-bench.md`](docs/gateway-bench.md) for its methodology, metrics,
-examples, and separate `obench gateway` command group.
+examples, and separate `obench gateway` command group. **Gateway Probe** is the
+request-level companion: it compares cold and verified warm same-socket
+requests without Pi, tasks, checkers, or correctness scores.
 
 Automatic model or provider selection is a different product surface. A future
 **Router Bench** will own that work under `obench router`; Gateway Bench does

--- a/docs/gateway-bench.md
+++ b/docs/gateway-bench.md
@@ -5,6 +5,11 @@ model family, inference provider, sampling, budgets, and repetition schedule
 fixed. It measures the path through a gateway against the provider's direct API
 and against other gateways.
 
+The headline comparison uses each gateway's managed service and billing path.
+Cloudflare therefore uses its Unified Billing REST API, not provider-native
+BYOK passthrough. Provider-native experiments answer a different question and
+must be published as a separate track.
+
 This is not a model-router benchmark. A router chooses a model or provider for
 each request. Gateway Bench forbids that behavior: every arm must request one
 declared model and one declared provider, with fallback, retries, and request
@@ -46,8 +51,9 @@ forwarding a request.
 - Vercel: `providerOptions.gateway.only` contains one provider.
 - Concentrate: `routing.providers` contains one provider and no alternate
   models.
-- Cloudflare: cache is skipped and maximum attempts is one; the requested model
-  remains provider-qualified.
+- Cloudflare Unified Billing: the named managed gateway is bound into the
+  experiment and sent as `cf-aig-gateway-id`; cache is skipped, maximum
+  attempts is one, and the requested model remains provider-qualified.
 
 Client retries are zero. Request cache controls are stripped. A returned
 cached-input count is retained as measured provider behavior, not treated as a
@@ -107,11 +113,12 @@ Gateway Bench supports:
 - `openai_chat` endpoints ending in `/chat/completions`;
 - `openai_responses` endpoints ending in `/responses`.
 
-Concentrate is admitted only through its Responses endpoint. Cloudflare supports
-its AI Gateway REST route for both protocols and its compatibility route for
-Chat Completions. Public experiments require strict known endpoints; private
-test endpoints require `allow_private_endpoint=true` plus an explicit hostname
-or CIDR allowlist.
+Concentrate is admitted only through its Responses endpoint. Cloudflare is
+admitted only through its managed Unified Billing REST route for both
+protocols; provider-native and compatibility/BYOK routes belong in separate
+experiments. Public experiments require strict known endpoints; private test
+endpoints require `allow_private_endpoint=true` plus an explicit hostname or
+CIDR allowlist.
 
 ## Run
 

--- a/docs/gateway-probe.md
+++ b/docs/gateway-probe.md
@@ -4,6 +4,11 @@ Gateway Probe measures request serving through fixed direct and gateway routes.
 It is separate from Gateway Bench: it runs no coding harness, task workspace, or
 checker and makes no solve-rate or output-quality claim.
 
+The headline multi-gateway probe uses managed gateway and billing routes,
+including Cloudflare Unified Billing. Provider-native BYOK passthrough is not
+mixed into that cohort because it uses a materially different upstream account
+and billing path.
+
 ## Contract
 
 Each matched block sends the same case, model, provider, sampling, and output
@@ -77,13 +82,19 @@ resolver call, not proof that a cold request performed an uncached DNS lookup.
 Start from the minimal two-way
 [`gateway-probe-responses.toml`](../obench/examples/gateway-probe-responses.toml),
 or use the
-[`gateway-probe-four-way-responses.toml`](../obench/examples/gateway-probe-four-way-responses.toml)
-comparison across direct OpenAI, OpenRouter, Vercel, and Concentrate. Set the
-credentials declared by the selected experiment and a frozen price snapshot:
+[`gateway-probe-five-way-responses.toml`](../obench/examples/gateway-probe-five-way-responses.toml)
+managed-gateway comparison across direct OpenAI, OpenRouter, Vercel,
+Concentrate, and Cloudflare Unified Billing. Cloudflare's named gateway ID is
+bound into the experiment and sent as `cf-aig-gateway-id`; its response cache
+is skipped and its maximum attempt count is one. Set the credentials declared
+by the selected experiment and a frozen price snapshot:
 
 ```bash
 export OPENAI_API_KEY=...
 export OPENROUTER_API_KEY=...
+export VERCEL_API_KEY=...
+export CONCENTRATE_API_KEY=...
+export CLOUDFLARE_API_TOKEN=...
 export OPENBENCH_GATEWAY_FROZEN_PRICES_JSON='{
   "openai/gpt-4o-mini": {
     "input_per_million": "0.15",

--- a/docs/gateway-probe.md
+++ b/docs/gateway-probe.md
@@ -1,0 +1,85 @@
+# Gateway Probe
+
+Gateway Probe measures request serving through fixed direct and gateway routes.
+It is separate from Gateway Bench: it runs no coding harness, task workspace, or
+checker and makes no solve-rate or output-quality claim.
+
+## Contract
+
+Each matched block sends the same case, model, provider, sampling, and output
+limit through every arm. Blocks are deterministically interleaved between:
+
+- `cold`: one measured request on a fresh connection;
+- `warm`: one unmeasured primer followed by the measured request on the verified
+  same socket.
+
+Primer and measured prompts use distinct deterministic nonces. The same nonce is
+used across arms within a block, so connection reuse cannot be confused with
+prompt or response cache reuse. Retries, redirects, fallback, and requested
+caching are disabled.
+
+The runner streams OpenAI Chat Completions or Responses directly. It retains only
+derived DNS, TCP, TLS, request-to-first-byte, semantic TTFT, total duration,
+throughput, usage/cache tokens, cost, route evidence, outcome classification, and
+socket-reuse evidence. Prompt and output bytes are never written to results.
+Responses requests set `store: false` to disable API application-state storage.
+This does not override ordinary provider abuse-monitoring or safety-retention
+policies.
+
+Reports separate cold and warm conditions. They show scheduled, attempted,
+successful, request-failed, route-verified, route-unverifiable, and route-failed
+denominators. Arm metrics use p50/p95 with explicit coverage. Paired
+gateway-minus-direct median contrasts use deterministic bootstrap confidence
+intervals. Missing values are not zero-filled or trimmed. Runs with fewer than
+100 complete blocks in either condition are labeled `exploratory`.
+
+## Timing definitions
+
+Cold request TTFB and semantic TTFT are end-to-end measurements starting
+immediately before the resolver call and fresh connection setup. Warm request
+timing starts immediately before request send on the established socket whose
+primer and route were verified; primer DNS, TCP, and TLS setup is reported
+separately and is not included in warm request latency.
+
+DNS cache state is uncontrolled. `dns_s` is the observed duration of the local
+resolver call, not proof that a cold request performed an uncached DNS lookup.
+
+## Run
+
+Start from the minimal two-way
+[`gateway-probe-responses.toml`](../obench/examples/gateway-probe-responses.toml),
+or use the
+[`gateway-probe-four-way-responses.toml`](../obench/examples/gateway-probe-four-way-responses.toml)
+comparison across direct OpenAI, OpenRouter, Vercel, and Concentrate. Set the
+credentials declared by the selected experiment and a frozen price snapshot:
+
+```bash
+export OPENAI_API_KEY=...
+export OPENROUTER_API_KEY=...
+export OPENBENCH_GATEWAY_FROZEN_PRICES_JSON='{
+  "openai/gpt-4o-mini": {
+    "input_per_million": "0.15",
+    "output_per_million": "0.60",
+    "effective_at": "2026-07-25T00:00:00Z"
+  }
+}'
+```
+
+The prices above illustrate the required shape; verify current prices before a
+real run.
+
+```bash
+obench gateway probe validate obench/examples/gateway-probe-responses.toml
+obench gateway probe doctor obench/examples/gateway-probe-responses.toml
+obench gateway probe run obench/examples/gateway-probe-responses.toml
+obench gateway probe report results/gateway-probe-gpt-4o-mini-responses-probe.jsonl
+```
+
+`validate`, `doctor`, and `report` make no model API calls. `run` writes fsynced
+JSONL and resumes only rows bound to the immutable experiment, schedule, and
+price digests. The USD cap is cumulative across measured requests and paid warm
+primers; execution stops after the first request that reaches the cap, or after
+a request whose cost cannot be accounted. A partial latest block is replaced as
+a complete new attempt.
+
+Publication and verification bundles are not part of Gateway Probe v1.

--- a/docs/gateway-probe.md
+++ b/docs/gateway-probe.md
@@ -18,13 +18,20 @@ used across arms within a block, so connection reuse cannot be confused with
 prompt or response cache reuse. Retries, redirects, fallback, and requested
 caching are disabled.
 
-The runner streams OpenAI Chat Completions or Responses directly. It retains only
-derived DNS, TCP, TLS, request-to-first-byte, semantic TTFT, total duration,
-throughput, usage/cache tokens, cost, route evidence, outcome classification, and
-socket-reuse evidence. Prompt and output bytes are never written to results.
+The runner streams OpenAI Chat Completions or Responses directly. Result rows
+retain only derived phase timing, throughput, usage/cache tokens, cost, route
+evidence, outcome classification, socket-reuse evidence, and allowlisted receipt
+identifiers. Prompt and output bytes are never written to results or reports.
 Responses requests set `store: false` to disable API application-state storage.
 This does not override ordinary provider abuse-monitoring or safety-retention
 policies.
+
+The only response headers that can be persisted are `x-request-id`,
+`request-id`, `openai-request-id`, `anthropic-request-id`, `x-vercel-id`, and
+`cf-ray`. Values must be non-empty receipt identifiers using only ASCII letters,
+digits, `.`, `_`, `:`, `/`, `@`, `+`, `=`, or `-`, at most 256 characters, and
+unambiguous (duplicate fields are omitted). All other response headers are
+discarded.
 
 Reports separate cold and warm conditions. They show scheduled, attempted,
 successful, request-failed, route-verified, route-unverifiable, and route-failed
@@ -35,11 +42,32 @@ intervals. Missing values are not zero-filled or trimmed. Runs with fewer than
 
 ## Timing definitions
 
-Cold request TTFB and semantic TTFT are end-to-end measurements starting
-immediately before the resolver call and fresh connection setup. Warm request
-timing starts immediately before request send on the established socket whose
-primer and route were verified; primer DNS, TCP, and TLS setup is reported
-separately and is not included in warm request latency.
+Gateway Probe v3 does not call response-header availability "TTFB".
+`http.client` does not expose a literal first-wire-byte timestamp, so the schema
+uses observable boundaries:
+
+- `setup_dns_s`, `setup_tcp_s`, and `setup_tls_s`: separate fresh-connection
+  setup phases. They are measured-request metrics only for `cold`.
+- `request_to_response_headers_s`: after the complete request body has been
+  sent through the point where `getresponse()` has parsed the response headers.
+- `request_to_first_body_byte_s`: after request send through the first
+  non-empty SSE body chunk observed by the parser.
+- `request_to_semantic_ttft_s`: after request send through the first semantic
+  output delta.
+- `request_stream_total_s`: after request send through stream consumption and
+  the observed end of the response stream.
+- `cold_end_to_end_response_headers_s`,
+  `cold_end_to_end_first_body_byte_s`,
+  `cold_end_to_end_semantic_ttft_s`, and
+  `cold_end_to_end_stream_total_s`: the corresponding cold durations from one
+  timestamp taken before DNS. These are absolute elapsed durations; setup is
+  not summed into them again.
+
+Warm measured-request timing contains only the four `request_*` metrics. The
+primer must complete successfully with verified route evidence, and the
+measured request must still have the same socket object, descriptor, and peer
+immediately after dispatch. Primer DNS/TCP/TLS and receipt evidence live only
+under `reuse_evidence`.
 
 DNS cache state is uncontrolled. `dns_s` is the observed duration of the local
 resolver call, not proof that a cold request performed an uncached DNS lookup.
@@ -68,18 +96,50 @@ export OPENBENCH_GATEWAY_FROZEN_PRICES_JSON='{
 The prices above illustrate the required shape; verify current prices before a
 real run.
 
+Run the complete preflight, resumable benchmark, and report workflow:
+
 ```bash
-obench gateway probe validate obench/examples/gateway-probe-responses.toml
-obench gateway probe doctor obench/examples/gateway-probe-responses.toml
-obench gateway probe run obench/examples/gateway-probe-responses.toml
-obench gateway probe report results/gateway-probe-gpt-4o-mini-responses-probe.jsonl
+obench gateway probe benchmark \
+  obench/examples/gateway-probe-responses.toml
 ```
 
-`validate`, `doctor`, and `report` make no model API calls. `run` writes fsynced
-JSONL and resumes only rows bound to the immutable experiment, schedule, and
-price digests. The USD cap is cumulative across measured requests and paid warm
-primers; execution stops after the first request that reaches the cap, or after
-a request whose cost cannot be accounted. A partial latest block is replaced as
-a complete new attempt.
+By default this creates a fresh UTC timestamped directory:
 
-Publication and verification bundles are not part of Gateway Probe v1.
+```text
+results/gateway-probe-<experiment-id>-<timestamp>/
+  experiment.toml
+  prices.json
+  results.jsonl
+  report.md
+  report.json
+  manifest.json
+```
+
+`experiment.toml` is the exact input snapshot and therefore contains the
+configured case prompts. Generated results, reports, and the manifest do not
+contain prompt or output content. `prices.json` is the parsed non-secret frozen
+price table; no other environment values are persisted. The manifest binds the
+five content files with SHA-256 digests.
+
+Use an explicit stable directory for CI and resume:
+
+```bash
+obench gateway probe benchmark \
+  obench/examples/gateway-probe-responses.toml \
+  --output-dir results/gateway-probe-ci
+```
+
+On resume, the exact experiment and canonical price snapshots must match the
+existing directory. The results JSONL is fsynced and resumes only rows bound to
+the immutable experiment, schedule, and price digests. Reports and the manifest
+are invalidated before execution and regenerated atomically after a successful
+run/resume, so a failed resume cannot leave stale reports labeled as current.
+Valid budget-stopped partial runs still produce reports; unavailable arms and
+paired metrics have explicit zero coverage. The USD cap is cumulative across
+measured requests and paid warm primers; execution stops
+after the first request that reaches the cap, or after a request whose cost
+cannot be accounted. A partial latest block is replaced as a complete new
+attempt.
+
+The lower-level `validate`, `doctor`, `run`, and `report` commands remain
+available. `validate`, `doctor`, and `report` make no model API calls.

--- a/obench/examples/gateway-bench-five-way-responses.toml
+++ b/obench/examples/gateway-bench-five-way-responses.toml
@@ -95,6 +95,7 @@ seed = 20260723
 arm_id = "cloudflare-openai-responses"
 route_kind = "gateway"
 gateway = "cloudflare"
+gateway_id = "openbench-gateway-bench"
 # Replace the illustrative account ID before running.
 endpoint = "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/ai/v1/responses"
 protocol = "openai_responses"

--- a/obench/examples/gateway-bench-four-way.toml
+++ b/obench/examples/gateway-bench-four-way.toml
@@ -98,6 +98,7 @@ seed = 20260723
 arm_id = "cloudflare-openai"
 route_kind = "gateway"
 gateway = "cloudflare"
+gateway_id = "openbench-gateway-bench"
 # Replace the illustrative account ID before running.
 endpoint = "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/ai/v1/chat/completions"
 protocol = "openai_chat"

--- a/obench/examples/gateway-bench-responses.toml
+++ b/obench/examples/gateway-bench-responses.toml
@@ -47,6 +47,7 @@ seed = 20260723
 arm_id = "cloudflare-openai-responses"
 route_kind = "gateway"
 gateway = "cloudflare"
+gateway_id = "openbench-gateway-bench"
 # Replace the illustrative account ID before running.
 endpoint = "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/ai/v1/responses"
 protocol = "openai_responses"

--- a/obench/examples/gateway-probe-five-way-responses.toml
+++ b/obench/examples/gateway-probe-five-way-responses.toml
@@ -1,5 +1,5 @@
 schema_version = 1
-experiment_id = "gpt-4o-mini-four-way-responses-probe"
+experiment_id = "gpt-4o-mini-five-way-responses-probe"
 track = "request_probe"
 model_match = "rolling_alias"
 repetitions = 5
@@ -30,6 +30,30 @@ fallback_enabled = false
 retry_count = 0
 cache_enabled = false
 auth_env = "OPENAI_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260725
+
+[[arms]]
+arm_id = "cloudflare-openai"
+route_kind = "gateway"
+gateway = "cloudflare"
+gateway_id = "openbench-gateway-bench"
+direct_control_arm_id = "direct-openai"
+# Replace the illustrative account ID before running.
+endpoint = "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/ai/v1/responses"
+protocol = "openai_responses"
+baseline = false
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "openai/gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["openai/gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "CLOUDFLARE_API_TOKEN"
 [arms.sampling]
 temperature = 0.0
 top_p = 1.0

--- a/obench/examples/gateway-probe-four-way-responses.toml
+++ b/obench/examples/gateway-probe-four-way-responses.toml
@@ -1,0 +1,102 @@
+schema_version = 1
+experiment_id = "gpt-4o-mini-four-way-responses-probe"
+track = "request_probe"
+model_match = "rolling_alias"
+repetitions = 5
+schedule_seed = 20260725
+allow_private_endpoint = false
+
+[budget]
+timeout_s = 60
+max_output_tokens = 64
+usd_cap = 0.10
+
+[[cases]]
+case_id = "short-text"
+prompt = "Reply with one short sentence describing a blue circle."
+
+[[arms]]
+arm_id = "direct-openai"
+route_kind = "direct"
+endpoint = "https://api.openai.com/v1/responses"
+protocol = "openai_responses"
+baseline = true
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENAI_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260725
+
+[[arms]]
+arm_id = "openrouter-openai"
+route_kind = "gateway"
+gateway = "openrouter"
+direct_control_arm_id = "direct-openai"
+endpoint = "https://openrouter.ai/api/v1/responses"
+protocol = "openai_responses"
+baseline = false
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "openai/gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["openai/gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENROUTER_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260725
+
+[[arms]]
+arm_id = "vercel-openai"
+route_kind = "gateway"
+gateway = "vercel"
+direct_control_arm_id = "direct-openai"
+endpoint = "https://ai-gateway.vercel.sh/v1/responses"
+protocol = "openai_responses"
+baseline = false
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "openai/gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["openai/gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "VERCEL_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260725
+
+[[arms]]
+arm_id = "concentrate-openai"
+route_kind = "gateway"
+gateway = "concentrate"
+direct_control_arm_id = "direct-openai"
+endpoint = "https://api.concentrate.ai/v1/responses"
+protocol = "openai_responses"
+baseline = false
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "openai/gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["openai/gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "CONCENTRATE_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260725

--- a/obench/examples/gateway-probe-responses.toml
+++ b/obench/examples/gateway-probe-responses.toml
@@ -1,0 +1,58 @@
+schema_version = 1
+experiment_id = "gpt-4o-mini-responses-probe"
+track = "request_probe"
+model_match = "rolling_alias"
+repetitions = 5
+schedule_seed = 20260725
+allow_private_endpoint = false
+
+[budget]
+timeout_s = 60
+max_output_tokens = 64
+usd_cap = 0.05
+
+[[cases]]
+case_id = "short-text"
+prompt = "Reply with one short sentence describing a blue circle."
+
+[[arms]]
+arm_id = "direct-openai"
+route_kind = "direct"
+endpoint = "https://api.openai.com/v1/responses"
+protocol = "openai_responses"
+baseline = true
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENAI_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260725
+
+[[arms]]
+arm_id = "openrouter-openai"
+route_kind = "gateway"
+gateway = "openrouter"
+direct_control_arm_id = "direct-openai"
+endpoint = "https://openrouter.ai/api/v1/responses"
+protocol = "openai_responses"
+baseline = false
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "openai/gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["openai/gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENROUTER_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260725

--- a/obench/gateway_cli.py
+++ b/obench/gateway_cli.py
@@ -121,6 +121,10 @@ def _verify(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv and argv[0] == "probe":
+        from .gateway_probe_cli import main as probe_main
+        return probe_main(argv[1:])
     parser = argparse.ArgumentParser(
         prog="obench gateway",
         description="Compare fixed model/provider routes through AI gateways.",
@@ -160,6 +164,10 @@ def main(argv: list[str] | None = None) -> int:
     verify = sub.add_parser("verify", help="verify a Gateway Bench evidence bundle")
     verify.add_argument("bundle")
     verify.set_defaults(handler=_verify)
+
+    probe = sub.add_parser("probe", help="run request-level gateway probes")
+    probe.add_argument("probe_args", nargs=argparse.REMAINDER)
+    probe.set_defaults(handler=lambda args: 0)
 
     args = parser.parse_args(argv)
     try:

--- a/obench/gateway_probe_cli.py
+++ b/obench/gateway_probe_cli.py
@@ -1,0 +1,99 @@
+"""CLI for request-level Gateway Probe experiments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from . import (
+    gateway_probe_report,
+    gateway_probe_results,
+    gateway_probe_run,
+    gateway_probe_spec,
+    gateway_run,
+    gateway_spec,
+)
+from .gateway_probe_models import GatewayProbeRunError
+
+
+def _validate(args: argparse.Namespace) -> int:
+    experiment = gateway_probe_run.validate_experiment(args.experiment)
+    print(
+        f"valid probe={experiment.experiment_id} digest={experiment.digest} "
+        f"cases={len(experiment.cases)} arms={len(experiment.arms)}"
+    )
+    return 0
+
+
+def _doctor(args: argparse.Namespace) -> int:
+    report = gateway_probe_run.doctor_experiment(args.experiment)
+    print(json.dumps(report, sort_keys=True))
+    return 0 if report["ok"] else 2
+
+
+def _run(args: argparse.Namespace) -> int:
+    experiment = gateway_probe_spec.load_experiment(args.experiment)
+    results_path = args.results or f"results/gateway-probe-{experiment.experiment_id}.jsonl"
+    summary = gateway_probe_run.run_experiment(
+        args.experiment,
+        results_path=results_path,
+        force=args.force,
+    )
+    print(
+        f"results={summary.results_path} rows_appended={summary.rows_appended} "
+        f"blocks_completed={summary.blocks_completed} "
+        f"blocks_replaced={summary.blocks_replaced} "
+        f"blocks_skipped={summary.blocks_skipped}"
+    )
+    return 0
+
+
+def _report(args: argparse.Namespace) -> int:
+    rows = gateway_probe_results.load_results(args.results)
+    report = gateway_probe_report.aggregate(rows)
+    if args.json:
+        print(json.dumps(report, allow_nan=False, sort_keys=True))
+    else:
+        print(gateway_probe_report.render_text(report))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="obench gateway probe",
+        description="Measure fixed request routes through AI gateways.",
+    )
+    sub = parser.add_subparsers(dest="probe_command", required=True)
+    validate = sub.add_parser("validate", help="validate a probe experiment")
+    validate.add_argument("experiment")
+    validate.set_defaults(handler=_validate)
+    doctor = sub.add_parser("doctor", help="check credentials and frozen prices")
+    doctor.add_argument("experiment")
+    doctor.set_defaults(handler=_doctor)
+    run = sub.add_parser("run", help="run or resume a probe experiment")
+    run.add_argument("experiment")
+    run.add_argument("--results")
+    run.add_argument("--force", action="store_true")
+    run.set_defaults(handler=_run)
+    report = sub.add_parser("report", help="report probe results")
+    report.add_argument("results")
+    report.add_argument("--json", action="store_true")
+    report.set_defaults(handler=_report)
+    args = parser.parse_args(argv)
+    try:
+        return args.handler(args)
+    except (
+        OSError,
+        gateway_probe_spec.GatewayProbeSpecError,
+        GatewayProbeRunError,
+        gateway_probe_report.GatewayProbeReportError,
+        gateway_run.GatewayRunError,
+        gateway_spec.GatewaySpecError,
+    ) as exc:
+        print(f"obench gateway probe: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/obench/gateway_probe_cli.py
+++ b/obench/gateway_probe_cli.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
+import hashlib
 import json
+import os
 import sys
+from pathlib import Path
+from typing import Any
 
 from . import (
     gateway_probe_report,
@@ -59,6 +64,207 @@ def _report(args: argparse.Namespace) -> int:
     return 0
 
 
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=True,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def _write_or_verify(path: Path, content: bytes, label: str) -> None:
+    if path.exists():
+        if path.read_bytes() != content:
+            raise GatewayProbeRunError(
+                f"{label} snapshot does not match existing {path}"
+            )
+        return
+    with path.open("xb") as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    temporary = path.with_name(f".{path.name}.tmp")
+    with temporary.open("w", encoding="utf-8") as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _remove_generated_bundle_files(output_dir: Path) -> None:
+    for name in ("report.md", "report.json", "manifest.json"):
+        try:
+            (output_dir / name).unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _utc_stamp() -> str:
+    return (
+        dt.datetime.now(dt.timezone.utc)
+        .strftime("%Y%m%dT%H%M%S%fZ")
+    )
+
+
+def _price_snapshot_env(snapshot: Any) -> str:
+    if (
+        not isinstance(snapshot, dict)
+        or set(snapshot) != {
+            "schema_version", "price_id", "currency", "prices",
+        }
+        or snapshot.get("schema_version") != 1
+        or snapshot.get("price_id") != "frozen-env-v1"
+        or snapshot.get("currency") != "USD"
+        or not isinstance(snapshot.get("prices"), list)
+        or not snapshot["prices"]
+    ):
+        raise GatewayProbeRunError("frozen price snapshot is malformed")
+    prices = {}
+    for item in snapshot["prices"]:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {
+                "model", "input_per_million", "output_per_million",
+                "effective_at", "currency",
+            }
+            or item.get("currency") != "USD"
+            or not isinstance(item.get("model"), str)
+            or item["model"] in prices
+        ):
+            raise GatewayProbeRunError("frozen price snapshot is malformed")
+        prices[item["model"]] = {
+            "input_per_million": item.get("input_per_million"),
+            "output_per_million": item.get("output_per_million"),
+            "effective_at": item.get("effective_at"),
+        }
+    return json.dumps(
+        prices,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _bundle_manifest(
+    *,
+    output_dir: Path,
+    experiment: gateway_probe_spec.GatewayProbeExperiment,
+) -> dict[str, Any]:
+    names = (
+        "experiment.toml",
+        "prices.json",
+        "results.jsonl",
+        "report.md",
+        "report.json",
+    )
+    return {
+        "schema_version": 1,
+        "benchmark": gateway_probe_results.BENCHMARK,
+        "result_schema_version": gateway_probe_results.RESULT_SCHEMA_VERSION,
+        "experiment_id": experiment.experiment_id,
+        "experiment_digest": experiment.digest,
+        "files": {
+            name: {"sha256": _sha256(output_dir / name)}
+            for name in names
+        },
+    }
+
+
+def _benchmark(args: argparse.Namespace) -> int:
+    experiment_path = Path(args.experiment).resolve()
+    experiment = gateway_probe_spec.load_experiment(experiment_path)
+    output_dir = (
+        Path(args.output_dir).resolve()
+        if args.output_dir
+        else Path(
+            "results",
+            f"gateway-probe-{experiment.experiment_id}-{_utc_stamp()}",
+        ).resolve()
+    )
+    if not args.output_dir and output_dir.exists():
+        raise GatewayProbeRunError(
+            f"default artifact directory already exists: {output_dir}"
+        )
+    prices_path = output_dir / "prices.json"
+    run_environ = dict(os.environ)
+    if prices_path.exists():
+        try:
+            stored_prices = json.loads(prices_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise GatewayProbeRunError(
+                f"frozen price snapshot is invalid: {prices_path}"
+            ) from exc
+        run_environ[gateway_probe_run.FROZEN_PRICES_ENV] = (
+            _price_snapshot_env(stored_prices)
+        )
+    doctor = gateway_probe_run.doctor_experiment(
+        experiment_path,
+        environ=run_environ,
+    )
+    if not doctor["ok"]:
+        missing = []
+        if doctor["missing_auth_envs"]:
+            missing.append(
+                "auth=" + ",".join(doctor["missing_auth_envs"])
+            )
+        if doctor["missing_price_models"]:
+            missing.append(
+                "prices=" + ",".join(doctor["missing_price_models"])
+            )
+        raise GatewayProbeRunError(
+            "doctor failed: " + "; ".join(missing)
+        )
+    _prices, price_snapshot = gateway_run.load_frozen_prices(run_environ)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = output_dir / "experiment.toml"
+    _write_or_verify(
+        snapshot_path,
+        experiment_path.read_bytes(),
+        "experiment",
+    )
+    _write_or_verify(
+        prices_path,
+        _canonical_json(price_snapshot).encode("ascii"),
+        "frozen price",
+    )
+    _remove_generated_bundle_files(output_dir)
+    results_path = output_dir / "results.jsonl"
+    summary = gateway_probe_run.run_experiment(
+        snapshot_path,
+        results_path=results_path,
+        environ=run_environ,
+        force=args.force,
+    )
+    rows = gateway_probe_results.load_results(results_path)
+    report = gateway_probe_report.aggregate(rows, experiment=experiment)
+    report_json = _canonical_json(report)
+    report_markdown = gateway_probe_report.render_text(report) + "\n"
+    _write_atomic(output_dir / "report.json", report_json)
+    _write_atomic(output_dir / "report.md", report_markdown)
+    manifest = _bundle_manifest(
+        output_dir=output_dir,
+        experiment=experiment,
+    )
+    _write_atomic(output_dir / "manifest.json", _canonical_json(manifest))
+    print(
+        f"artifacts={output_dir} results={results_path} "
+        f"rows_appended={summary.rows_appended} "
+        f"blocks_completed={summary.blocks_completed} "
+        f"blocks_replaced={summary.blocks_replaced} "
+        f"blocks_skipped={summary.blocks_skipped}"
+    )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="obench gateway probe",
@@ -80,6 +286,14 @@ def main(argv: list[str] | None = None) -> int:
     report.add_argument("results")
     report.add_argument("--json", action="store_true")
     report.set_defaults(handler=_report)
+    benchmark = sub.add_parser(
+        "benchmark",
+        help="doctor, run/resume, and write a reproducible artifact bundle",
+    )
+    benchmark.add_argument("experiment")
+    benchmark.add_argument("--output-dir")
+    benchmark.add_argument("--force", action="store_true")
+    benchmark.set_defaults(handler=_benchmark)
     args = parser.parse_args(argv)
     try:
         return args.handler(args)

--- a/obench/gateway_probe_http.py
+++ b/obench/gateway_probe_http.py
@@ -1,0 +1,511 @@
+"""Direct streaming HTTP execution for Gateway Probe requests."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import http.client
+import ipaddress
+import json
+import socket
+import ssl
+import time
+import urllib.parse
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any
+
+from . import gateway_metrics, gateway_profiles, gateway_run, gateway_spec
+from . import gateway_probe_spec as probe_spec
+from .gateway_probe_models import GatewayProbeRunError, PrimerError, ProbeBlock
+
+
+class _TimedConnection(http.client.HTTPConnection):
+    """HTTP connection with separately observed DNS and TCP setup."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        timeout: float,
+        allow_private: bool,
+        private_hosts: tuple[str, ...],
+        private_cidrs: tuple[str, ...],
+    ):
+        super().__init__(host, port=port, timeout=timeout)
+        self._allow_private = allow_private
+        self._private_hosts = private_hosts
+        self._private_networks = tuple(ipaddress.ip_network(item) for item in private_cidrs)
+        self.phase_s = {"dns_s": None, "tcp_s": None, "tls_s": None}
+
+    def _address_allowed(self, address: str) -> bool:
+        parsed = ipaddress.ip_address(address)
+        if not self._allow_private:
+            return parsed.is_global
+        if self.host.lower().rstrip(".") in self._private_hosts:
+            return True
+        return any(parsed in network for network in self._private_networks)
+
+    def _connect_tcp(self) -> socket.socket:
+        started = time.monotonic()
+        addresses = socket.getaddrinfo(
+            self.host, self.port, type=socket.SOCK_STREAM
+        )
+        self.phase_s["dns_s"] = time.monotonic() - started
+        allowed = [item for item in addresses if self._address_allowed(item[4][0])]
+        if not allowed:
+            raise GatewayProbeRunError(
+                "resolved endpoint addresses violate the endpoint policy"
+            )
+        last_error: OSError | None = None
+        started = time.monotonic()
+        for family, socktype, proto, _canonname, sockaddr in allowed:
+            candidate = socket.socket(family, socktype, proto)
+            candidate.settimeout(self.timeout)
+            try:
+                candidate.connect(sockaddr)
+                self.phase_s["tcp_s"] = time.monotonic() - started
+                return candidate
+            except OSError as exc:
+                last_error = exc
+                candidate.close()
+        raise last_error or OSError("no endpoint address could be connected")
+
+    def connect(self) -> None:
+        self.sock = self._connect_tcp()
+
+
+class _TimedHTTPSConnection(_TimedConnection):
+    def __init__(
+        self, *args: Any, context: ssl.SSLContext | None = None, **kwargs: Any
+    ):
+        super().__init__(*args, **kwargs)
+        self._context = context or ssl.create_default_context()
+
+    def connect(self) -> None:
+        raw = self._connect_tcp()
+        started = time.monotonic()
+        try:
+            self.sock = self._context.wrap_socket(raw, server_hostname=self.host)
+        except Exception:
+            raw.close()
+            raise
+        self.phase_s["tls_s"] = time.monotonic() - started
+
+
+def nonce(experiment_digest: str, block: ProbeBlock, role: str) -> str:
+    return hashlib.sha256(
+        f"{experiment_digest}:{block.case_id}:{block.condition}:"
+        f"{block.repetition}:{role}".encode()
+    ).hexdigest()[:24]
+
+
+def request_body(
+    prompt: str,
+    request_nonce: str,
+    plan: gateway_spec.RoutePlan,
+    max_output_tokens: int,
+) -> bytes:
+    content = f"[openbench_probe_nonce:{request_nonce}]\n\n{prompt}"
+    if plan.protocol == "openai_chat":
+        payload: dict[str, Any] = {
+            "messages": [{"role": "user", "content": content}],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "max_completion_tokens": max_output_tokens,
+            "seed": plan.sampling.seed,
+        }
+    else:
+        payload = {
+            "input": content,
+            "stream": True,
+            "store": False,
+            "max_output_tokens": max_output_tokens,
+        }
+    payload.update({
+        "model": plan.requested_model,
+        "temperature": plan.sampling.temperature,
+        "top_p": plan.sampling.top_p,
+    })
+    gateway_profiles.strip_cache_controls(payload)
+    if plan.route_kind == "gateway":
+        if plan.gateway is None:
+            raise GatewayProbeRunError("gateway route has no gateway profile")
+        gateway_profiles.shape_body(
+            payload,
+            gateway=plan.gateway,
+            requested_provider=plan.requested_provider,
+        )
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _new_connection(
+    plan: gateway_spec.RoutePlan, timeout_s: int
+) -> tuple[Any, str]:
+    endpoint = urllib.parse.urlsplit(plan.endpoint)
+    port = endpoint.port or (443 if endpoint.scheme == "https" else 80)
+    cls = _TimedHTTPSConnection if endpoint.scheme == "https" else _TimedConnection
+    connection = cls(
+        endpoint.hostname,
+        port,
+        timeout=timeout_s,
+        allow_private=plan.allow_private_endpoint,
+        private_hosts=plan.private_host_allowlist,
+        private_cidrs=plan.private_cidr_allowlist,
+    )
+    path = endpoint.path or "/"
+    if endpoint.query:
+        path = f"{path}?{endpoint.query}"
+    return connection, path
+
+
+def _headers(
+    plan: gateway_spec.RoutePlan, secret: str, body: bytes
+) -> dict[str, str]:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Content-Length": str(len(body)),
+        "Connection": "keep-alive",
+    }
+    headers.update(
+        gateway_profiles.request_headers(gateway=plan.gateway, secret=secret)
+    )
+    return headers
+
+
+def _consume(
+    connection: Any,
+    path: str,
+    body: bytes,
+    headers: Mapping[str, str],
+    plan: gateway_spec.RoutePlan,
+    *,
+    capture_metrics: bool,
+) -> tuple[int, dict[str, Any] | None, bool]:
+    started = time.monotonic()
+    deadline = started + float(connection.timeout)
+    connection.request("POST", path, body=body, headers=dict(headers))
+    if connection.sock is not None:
+        connection.sock.settimeout(max(0.001, deadline - time.monotonic()))
+    response = connection.getresponse()
+    response_headers = {key.lower(): value for key, value in response.getheaders()}
+    parser = None
+    if capture_metrics and "text/event-stream" in response_headers.get(
+        "content-type", ""
+    ).lower():
+        parser = gateway_metrics.sse_parser(
+            plan.protocol,
+            requested_model=plan.requested_model,
+            started_at=started,
+            route_kind=plan.route_kind,
+            requested_provider=plan.requested_provider,
+            allowed_models=plan.allowed_models,
+            allowed_providers=plan.allowed_providers,
+            fallback_enabled=plan.fallback_enabled,
+            model_match=plan.model_match,
+            gateway=plan.gateway,
+            response_headers=response_headers,
+        )
+    while True:
+        if time.monotonic() >= deadline:
+            raise TimeoutError("probe request exceeded its total timeout")
+        if connection.sock is not None:
+            connection.sock.settimeout(max(0.001, deadline - time.monotonic()))
+        chunk = response.read1(65536)
+        if not chunk:
+            break
+        if parser is not None:
+            parser.feed(chunk, time.monotonic())
+    metrics = parser.finalize(time.monotonic()) if parser is not None else None
+    return response.status, metrics, response.will_close
+
+
+def _route_status(
+    metrics: Mapping[str, Any] | None,
+) -> tuple[str, list[str]]:
+    if not isinstance(metrics, Mapping):
+        return "unverifiable", ["missing_stream_metrics"]
+    evidence = metrics.get("route_evidence")
+    if not isinstance(evidence, Mapping):
+        return "unverifiable", ["missing_route_evidence"]
+    reasons = evidence.get("reasons")
+    reasons = reasons if isinstance(reasons, list) else ["malformed_route_evidence"]
+    normalized_reasons = list(dict.fromkeys(str(reason) for reason in reasons))
+    if evidence.get("pass") is True:
+        return "verified", []
+    conflict_markers = ("conflict", "fallback", "malformed")
+    status = (
+        "failed"
+        if any(
+            any(marker in reason for marker in conflict_markers)
+            for reason in normalized_reasons
+        )
+        else "unverifiable"
+    )
+    return status, normalized_reasons
+
+
+def _transport_error_detail(exc: Exception) -> str:
+    if isinstance(exc, http.client.BadStatusLine):
+        return "bad_status_line"
+    if isinstance(exc, http.client.HTTPException):
+        return "http_protocol"
+    if isinstance(exc, ssl.SSLError):
+        return "tls"
+    if isinstance(exc, socket.gaierror):
+        return "dns"
+    if isinstance(exc, ConnectionRefusedError):
+        return "connection_refused"
+    if isinstance(exc, ConnectionResetError):
+        return "connection_reset"
+    if isinstance(exc, BrokenPipeError):
+        return "connection_closed"
+    if isinstance(exc, GatewayProbeRunError):
+        return "probe_policy"
+    if isinstance(exc, OSError):
+        return "network_io"
+    return "internal"
+
+
+def execute_request(
+    *,
+    experiment: probe_spec.GatewayProbeExperiment,
+    case: probe_spec.ProbeCase,
+    block: ProbeBlock,
+    plan: gateway_spec.RoutePlan,
+    secret: str,
+    prices: Mapping[str, gateway_run.Price],
+    remaining_usd_cap: Decimal | None = None,
+) -> dict[str, Any]:
+    connection, path = _new_connection(plan, experiment.budget.timeout_s)
+    primer_nonce = nonce(experiment.digest, block, "primer")
+    measured_nonce = nonce(experiment.digest, block, "measured")
+    primer = {
+        "required": block.condition == "warm",
+        "completed": False,
+        "http_status": None,
+        "socket_reused": None,
+        "primer_nonce_sha256": hashlib.sha256(primer_nonce.encode()).hexdigest(),
+        "measured_nonce_sha256": hashlib.sha256(measured_nonce.encode()).hexdigest(),
+        "connection": {"dns_s": None, "tcp_s": None, "tls_s": None},
+        "route_integrity": None,
+        "usage": None,
+        "cache": None,
+        "costs": {},
+    }
+    status = None
+    metrics = None
+    error_class = None
+    error_detail = None
+    timed_out = False
+    measured_started = None
+    measured_attempted = False
+    primer_attempted = False
+    primer_amount = None
+    measured_amount = None
+    budget_reason = None
+    stop_for_budget = False
+    try:
+        if block.condition == "warm":
+            primer_attempted = True
+            body = request_body(
+                case.prompt, primer_nonce, plan, experiment.budget.max_output_tokens
+            )
+            primer_status, primer_metrics, primer_closed = _consume(
+                connection,
+                path,
+                body,
+                _headers(plan, secret, body),
+                plan,
+                capture_metrics=True,
+            )
+            primer["connection"] = dict(connection.phase_s)
+            primer_route_status, primer_route_reasons = _route_status(primer_metrics)
+            primer["route_integrity"] = {
+                "status": primer_route_status,
+                "pass": primer_route_status == "verified",
+                "reasons": primer_route_reasons,
+            }
+            primer_stream = (
+                primer_metrics.get("stream")
+                if isinstance(primer_metrics, Mapping)
+                else None
+            )
+            primer_terminal = (
+                primer_stream.get("terminal_status")
+                if isinstance(primer_stream, Mapping)
+                else None
+            )
+            primer_stream_completed = (
+                isinstance(primer_stream, Mapping)
+                and primer_stream.get("done") is True
+                and primer_terminal in {None, "completed"}
+            )
+            if isinstance(primer_metrics, Mapping):
+                observed_at = dt.datetime.now(dt.timezone.utc).isoformat().replace(
+                    "+00:00", "Z"
+                )
+                primer_costs, primer_amount = gateway_run.price_call(
+                    primer_metrics, prices, plan, observed_at
+                )
+                primer["usage"] = primer_metrics.get("usage")
+                primer["cache"] = gateway_run.cache_accounting(primer_metrics)
+                primer["costs"] = primer_costs
+            primer.update({
+                "completed": (
+                    200 <= primer_status < 300
+                    and not primer_closed
+                    and primer_stream_completed
+                    and primer_route_status == "verified"
+                ),
+                "http_status": primer_status,
+            })
+            if not primer["completed"] or connection.sock is None:
+                raise PrimerError(
+                    "warm primer was not successful, route-verified, and reusable"
+                )
+            socket_object = connection.sock
+            socket_fileno = socket_object.fileno()
+            socket_peer = socket_object.getpeername()
+            if primer_amount is None:
+                budget_reason = "primer_cost_unavailable"
+                stop_for_budget = True
+            elif remaining_usd_cap is not None and primer_amount >= remaining_usd_cap:
+                budget_reason = "usd_cap_reached_by_primer"
+                stop_for_budget = True
+        if not stop_for_budget:
+            measured_started = time.monotonic()
+            measured_attempted = True
+            body = request_body(
+                case.prompt, measured_nonce, plan, experiment.budget.max_output_tokens
+            )
+            status, metrics, _closed = _consume(
+                connection,
+                path,
+                body,
+                _headers(plan, secret, body),
+                plan,
+                capture_metrics=True,
+            )
+            if block.condition == "warm":
+                primer["socket_reused"] = bool(
+                    connection.sock is socket_object
+                    and connection.sock is not None
+                    and connection.sock.fileno() == socket_fileno
+                    and connection.sock.getpeername() == socket_peer
+                )
+                if not primer["socket_reused"]:
+                    raise GatewayProbeRunError(
+                        "warm measured request did not reuse the primer socket"
+                    )
+    except (socket.timeout, TimeoutError):
+        timed_out = True
+        error_class = "timeout"
+        error_detail = "timeout"
+    except PrimerError:
+        error_class = "primer"
+        error_detail = "primer_invalid"
+    except Exception as exc:  # noqa: BLE001 - classified in the result row
+        error_class = "transport"
+        error_detail = _transport_error_detail(exc)
+    finally:
+        connection.close()
+    total_s = (
+        time.monotonic() - measured_started
+        if measured_started is not None
+        else None
+    )
+    route_status, route_reasons = _route_status(metrics)
+    costs: dict[str, Any] = {}
+    cache = {"cached_input_tokens": None, "cache_write_input_tokens": None}
+    if isinstance(metrics, Mapping):
+        observed_at = dt.datetime.now(dt.timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        )
+        costs, measured_amount = gateway_run.price_call(
+            metrics, prices, plan, observed_at
+        )
+        cache = gateway_run.cache_accounting(metrics)
+    if measured_attempted and measured_amount is None:
+        budget_reason = "measured_cost_unavailable"
+        stop_for_budget = True
+    if primer_attempted and primer_amount is None and budget_reason is None:
+        budget_reason = "primer_cost_unavailable"
+        stop_for_budget = True
+    charged_amount = (primer_amount or Decimal(0)) + (measured_amount or Decimal(0))
+    if (
+        remaining_usd_cap is not None
+        and charged_amount >= remaining_usd_cap
+        and budget_reason is None
+    ):
+        budget_reason = "usd_cap_reached"
+        stop_for_budget = True
+    stream = metrics.get("stream") if isinstance(metrics, Mapping) else None
+    terminal = stream.get("terminal_status") if isinstance(stream, Mapping) else None
+    stream_done = stream.get("done") is True if isinstance(stream, Mapping) else False
+    completed = stream_done and terminal in {None, "completed"}
+    if error_class is None and isinstance(status, int) and not 200 <= status < 300:
+        error_class = "http"
+        error_detail = "http_status"
+    elif error_class is None and isinstance(status, int) and not completed:
+        error_class = "stream"
+        error_detail = (
+            "stream_terminal" if terminal is not None else "stream_incomplete"
+        )
+    available = (
+        isinstance(status, int)
+        and 200 <= status < 300
+        and error_class is None
+        and completed
+    )
+    timing = dict(metrics.get("timing", {})) if isinstance(metrics, Mapping) else {}
+    timing["total_s"] = total_s
+    return {
+        "outcome": {
+            "attempted": measured_attempted,
+            "success": available,
+            "available": available,
+            "http_status": status,
+            "timed_out": timed_out,
+            "error_class": error_class,
+            "error_detail": error_detail,
+            "budget_exhausted_reason": budget_reason,
+        },
+        "route_integrity": {
+            "status": route_status,
+            "pass": route_status == "verified",
+            "reasons": route_reasons,
+        },
+        "request_metrics": {
+            "connection": (
+                dict(connection.phase_s)
+                if block.condition == "cold"
+                else {"dns_s": None, "tcp_s": None, "tls_s": None}
+            ),
+            "timing": timing,
+            "usage": metrics.get("usage") if isinstance(metrics, Mapping) else None,
+            "generation": (
+                metrics.get("generation") if isinstance(metrics, Mapping) else None
+            ),
+            "cache": cache,
+            "route": metrics.get("route") if isinstance(metrics, Mapping) else None,
+            "costs": costs,
+            "stream": stream,
+            "coverage": (
+                metrics.get("coverage") if isinstance(metrics, Mapping) else None
+            ),
+        },
+        "reuse_evidence": primer,
+        "billing": {
+            "primer_cost_usd": (
+                str(primer_amount) if primer_amount is not None else None
+            ),
+            "measured_cost_usd": (
+                str(measured_amount) if measured_amount is not None else None
+            ),
+            "charged_cost_usd": str(charged_amount),
+            "stop_required": stop_for_budget,
+        },
+    }

--- a/obench/gateway_probe_http.py
+++ b/obench/gateway_probe_http.py
@@ -376,18 +376,8 @@ def execute_request(
                 budget_reason = "usd_cap_reached_by_primer"
                 stop_for_budget = True
         if not stop_for_budget:
-            measured_started = time.monotonic()
-            measured_attempted = True
             body = request_body(
                 case.prompt, measured_nonce, plan, experiment.budget.max_output_tokens
-            )
-            status, metrics, _closed = _consume(
-                connection,
-                path,
-                body,
-                _headers(plan, secret, body),
-                plan,
-                capture_metrics=True,
             )
             if block.condition == "warm":
                 primer["socket_reused"] = bool(
@@ -400,6 +390,16 @@ def execute_request(
                     raise GatewayProbeRunError(
                         "warm measured request did not reuse the primer socket"
                     )
+            measured_started = time.monotonic()
+            measured_attempted = True
+            status, metrics, _closed = _consume(
+                connection,
+                path,
+                body,
+                _headers(plan, secret, body),
+                plan,
+                capture_metrics=True,
+            )
     except (socket.timeout, TimeoutError):
         timed_out = True
         error_class = "timeout"

--- a/obench/gateway_probe_http.py
+++ b/obench/gateway_probe_http.py
@@ -20,6 +20,43 @@ from . import gateway_probe_spec as probe_spec
 from .gateway_probe_models import GatewayProbeRunError, PrimerError, ProbeBlock
 
 
+_ROUTE_REASON_STATUS = {
+    "missing_stream_metrics": "unverifiable",
+    "missing_route_evidence": "unverifiable",
+    "missing_requested_model": "unverifiable",
+    "missing_served_model": "unverifiable",
+    "stream_not_done": "unverifiable",
+    "missing_gateway_profile": "unverifiable",
+    "missing_cloudflare_metadata": "unverifiable",
+    "missing_concentrate_metadata": "unverifiable",
+    "missing_openrouter_metadata": "unverifiable",
+    "missing_vercel_metadata": "unverifiable",
+    "missing_provider": "unverifiable",
+    "unqualified_served_model": "unverifiable",
+    "missing_metadata_requested_model": "unverifiable",
+    "missing_attempt_count": "unverifiable",
+    "missing_model_attempts": "unverifiable",
+    "missing_successful_attempt": "unverifiable",
+    "missing_attempt_evidence": "unverifiable",
+    "missing_attempt_provider": "unverifiable",
+    "missing_attempt_model": "unverifiable",
+    "missing_attempt_status": "unverifiable",
+    "malformed_route_evidence": "failed",
+    "malformed_events": "failed",
+    "fallback_enabled": "failed",
+    "served_model_conflict": "failed",
+    "provider_conflict": "failed",
+    "multiple_attempts": "failed",
+    "served_model_not_allowed": "failed",
+    "provider_not_allowed": "failed",
+    "requested_model_conflict": "failed",
+    "malformed_attempts": "failed",
+    "fallback_attempt": "failed",
+    "attempt_provider_not_allowed": "failed",
+    "unsuccessful_attempt": "failed",
+}
+
+
 class _TimedConnection(http.client.HTTPConnection):
     """HTTP connection with separately observed DNS and TCP setup."""
 
@@ -233,16 +270,16 @@ def _route_status(
     reasons = evidence.get("reasons")
     reasons = reasons if isinstance(reasons, list) else ["malformed_route_evidence"]
     normalized_reasons = list(dict.fromkeys(str(reason) for reason in reasons))
-    if evidence.get("pass") is True:
+    if evidence.get("pass") is True and not normalized_reasons:
         return "verified", []
-    conflict_markers = ("conflict", "fallback", "malformed")
+    statuses = {
+        _ROUTE_REASON_STATUS.get(reason, "failed")
+        for reason in normalized_reasons
+    }
     status = (
-        "failed"
-        if any(
-            any(marker in reason for marker in conflict_markers)
-            for reason in normalized_reasons
-        )
-        else "unverifiable"
+        "unverifiable"
+        if normalized_reasons and statuses == {"unverifiable"}
+        else "failed"
     )
     return status, normalized_reasons
 

--- a/obench/gateway_probe_http.py
+++ b/obench/gateway_probe_http.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 from typing import Any
 
 from . import gateway_metrics, gateway_profiles, gateway_run, gateway_spec
+from . import gateway_probe_results as probe_results
 from . import gateway_probe_spec as probe_spec
 from .gateway_probe_models import GatewayProbeRunError, PrimerError, ProbeBlock
 
@@ -259,6 +260,42 @@ def _headers(
     return headers
 
 
+def _receipt_headers(headers: list[tuple[str, str]]) -> dict[str, str]:
+    """Return only bounded, printable receipt identifiers."""
+    receipts: dict[str, str] = {}
+    duplicates = set()
+    for raw_name, raw_value in headers:
+        name = raw_name.lower()
+        if (
+            name not in probe_results.RECEIPT_HEADER_ALLOWLIST
+            or name in duplicates
+        ):
+            continue
+        value = raw_value.strip()
+        if (
+            not value
+            or len(value) > probe_results.RECEIPT_VALUE_MAX_LENGTH
+            or probe_results.RECEIPT_VALUE_RE.fullmatch(value) is None
+        ):
+            continue
+        if name in receipts:
+            receipts.pop(name)
+            duplicates.add(name)
+            continue
+        receipts[name] = value
+    return receipts
+
+
+def _same_socket(connection: Any, expected: tuple[Any, int, Any]) -> bool:
+    socket_object, socket_fileno, socket_peer = expected
+    return bool(
+        connection.sock is socket_object
+        and connection.sock is not None
+        and connection.sock.fileno() == socket_fileno
+        and connection.sock.getpeername() == socket_peer
+    )
+
+
 def _consume(
     connection: Any,
     path: str,
@@ -267,15 +304,27 @@ def _consume(
     plan: gateway_spec.RoutePlan,
     *,
     capture_metrics: bool,
-) -> tuple[int, dict[str, Any] | None, bool]:
-    started = time.monotonic()
-    deadline = started + float(connection.timeout)
+    cold_started_at: float | None = None,
+    expected_socket: tuple[Any, int, Any] | None = None,
+) -> tuple[int, dict[str, Any] | None, bool, dict[str, Any]]:
+    operation_started_at = time.monotonic()
+    deadline = operation_started_at + float(connection.timeout)
     connection.set_request_deadline(deadline)
     connection.request("POST", path, body=body, headers=dict(headers))
+    request_sent_at = time.monotonic()
+    socket_reused = (
+        _same_socket(connection, expected_socket)
+        if expected_socket is not None
+        else None
+    )
+    if expected_socket is not None and not socket_reused:
+        raise PrimerError("warm measured request did not reuse the primer socket")
     if connection.sock is not None:
         connection.sock.settimeout(connection._remaining_timeout())
     response = connection.getresponse()
-    response_headers = {key.lower(): value for key, value in response.getheaders()}
+    response_headers_at = time.monotonic()
+    raw_response_headers = response.getheaders()
+    response_headers = {key.lower(): value for key, value in raw_response_headers}
     parser = None
     if capture_metrics and "text/event-stream" in response_headers.get(
         "content-type", ""
@@ -283,7 +332,7 @@ def _consume(
         parser = gateway_metrics.sse_parser(
             plan.protocol,
             requested_model=plan.requested_model,
-            started_at=started,
+            started_at=request_sent_at,
             route_kind=plan.route_kind,
             requested_provider=plan.requested_provider,
             allowed_models=plan.allowed_models,
@@ -303,8 +352,48 @@ def _consume(
             break
         if parser is not None:
             parser.feed(chunk, time.monotonic())
-    metrics = parser.finalize(time.monotonic()) if parser is not None else None
-    return response.status, metrics, response.will_close
+    completed_at = time.monotonic()
+    metrics = parser.finalize(completed_at) if parser is not None else None
+    first_body_byte_s = None
+    semantic_ttft_s = None
+    if isinstance(metrics, Mapping):
+        parser_timing = metrics.get("timing")
+        if isinstance(parser_timing, Mapping):
+            first_body_byte_s = parser_timing.get("ttfb_s")
+            semantic_ttft_s = parser_timing.get("semantic_ttft_s")
+    timing = {
+        "request_to_response_headers_s": response_headers_at - request_sent_at,
+        "request_to_first_body_byte_s": first_body_byte_s,
+        "request_to_semantic_ttft_s": semantic_ttft_s,
+        "request_stream_total_s": completed_at - request_sent_at,
+        "cold_end_to_end_response_headers_s": None,
+        "cold_end_to_end_first_body_byte_s": None,
+        "cold_end_to_end_semantic_ttft_s": None,
+        "cold_end_to_end_stream_total_s": None,
+    }
+    if cold_started_at is not None:
+        timing.update({
+            "cold_end_to_end_response_headers_s": (
+                response_headers_at - cold_started_at
+            ),
+            "cold_end_to_end_first_body_byte_s": (
+                None
+                if first_body_byte_s is None
+                else request_sent_at - cold_started_at + first_body_byte_s
+            ),
+            "cold_end_to_end_semantic_ttft_s": (
+                None
+                if semantic_ttft_s is None
+                else request_sent_at - cold_started_at + semantic_ttft_s
+            ),
+            "cold_end_to_end_stream_total_s": completed_at - cold_started_at,
+        })
+    evidence = {
+        "timing": timing,
+        "receipt_headers": _receipt_headers(raw_response_headers),
+        "socket_reused": socket_reused,
+    }
+    return response.status, metrics, response.will_close, evidence
 
 
 def _route_status(
@@ -374,7 +463,8 @@ def execute_request(
         "socket_reused": None,
         "primer_nonce_sha256": hashlib.sha256(primer_nonce.encode()).hexdigest(),
         "measured_nonce_sha256": hashlib.sha256(measured_nonce.encode()).hexdigest(),
-        "connection": {"dns_s": None, "tcp_s": None, "tls_s": None},
+        "setup": {"dns_s": None, "tcp_s": None, "tls_s": None},
+        "receipt_headers": {},
         "route_integrity": None,
         "usage": None,
         "cache": None,
@@ -385,7 +475,7 @@ def execute_request(
     error_class = None
     error_detail = None
     timed_out = False
-    measured_started = None
+    measured_evidence = None
     measured_attempted = False
     primer_attempted = False
     primer_amount = None
@@ -398,7 +488,7 @@ def execute_request(
             body = request_body(
                 case.prompt, primer_nonce, plan, experiment.budget.max_output_tokens
             )
-            primer_status, primer_metrics, primer_closed = _consume(
+            primer_status, primer_metrics, primer_closed, primer_evidence = _consume(
                 connection,
                 path,
                 body,
@@ -406,7 +496,8 @@ def execute_request(
                 plan,
                 capture_metrics=True,
             )
-            primer["connection"] = dict(connection.phase_s)
+            primer["setup"] = dict(connection.phase_s)
+            primer["receipt_headers"] = primer_evidence["receipt_headers"]
             primer_route_status, primer_route_reasons = _route_status(primer_metrics)
             primer["route_integrity"] = {
                 "status": primer_route_status,
@@ -451,9 +542,11 @@ def execute_request(
                 raise PrimerError(
                     "warm primer was not successful, route-verified, and reusable"
                 )
-            socket_object = connection.sock
-            socket_fileno = socket_object.fileno()
-            socket_peer = socket_object.getpeername()
+            primer_socket = (
+                connection.sock,
+                connection.sock.fileno(),
+                connection.sock.getpeername(),
+            )
             if primer_amount is None:
                 budget_reason = "primer_cost_unavailable"
                 stop_for_budget = True
@@ -464,32 +557,31 @@ def execute_request(
             body = request_body(
                 case.prompt, measured_nonce, plan, experiment.budget.max_output_tokens
             )
-            if block.condition == "warm":
-                primer["socket_reused"] = bool(
-                    connection.sock is socket_object
-                    and connection.sock is not None
-                    and connection.sock.fileno() == socket_fileno
-                    and connection.sock.getpeername() == socket_peer
-                )
-                if not primer["socket_reused"]:
-                    raise GatewayProbeRunError(
-                        "warm measured request did not reuse the primer socket"
-                    )
-            measured_started = time.monotonic()
+            cold_started_at = (
+                time.monotonic() if block.condition == "cold" else None
+            )
             measured_attempted = True
-            status, metrics, _closed = _consume(
+            status, metrics, _closed, measured_evidence = _consume(
                 connection,
                 path,
                 body,
                 _headers(plan, secret, body),
                 plan,
                 capture_metrics=True,
+                cold_started_at=cold_started_at,
+                expected_socket=(
+                    primer_socket if block.condition == "warm" else None
+                ),
             )
+            if block.condition == "warm":
+                primer["socket_reused"] = measured_evidence["socket_reused"]
     except (socket.timeout, TimeoutError):
         timed_out = True
         error_class = "timeout"
         error_detail = "timeout"
     except PrimerError:
+        if block.condition == "warm" and measured_attempted:
+            primer["socket_reused"] = False
         error_class = "primer"
         error_detail = "primer_invalid"
     except Exception as exc:  # noqa: BLE001 - classified in the result row
@@ -497,11 +589,6 @@ def execute_request(
         error_detail = _transport_error_detail(exc)
     finally:
         connection.close()
-    total_s = (
-        time.monotonic() - measured_started
-        if measured_started is not None
-        else None
-    )
     route_status, route_reasons = _route_status(metrics)
     costs: dict[str, Any] = {}
     cache = {"cached_input_tokens": None, "cache_write_input_tokens": None}
@@ -539,14 +626,36 @@ def execute_request(
         error_detail = (
             "stream_terminal" if terminal is not None else "stream_incomplete"
         )
+    elif (
+        error_class is None
+        and isinstance(status, int)
+        and isinstance(measured_evidence, Mapping)
+        and measured_evidence["timing"].get(
+            "request_to_semantic_ttft_s"
+        ) is None
+    ):
+        error_class = "stream"
+        error_detail = "stream_no_semantic_output"
     available = (
         isinstance(status, int)
         and 200 <= status < 300
         and error_class is None
         and completed
     )
-    timing = dict(metrics.get("timing", {})) if isinstance(metrics, Mapping) else {}
-    timing["total_s"] = total_s
+    timing = (
+        measured_evidence["timing"]
+        if isinstance(measured_evidence, Mapping)
+        else {
+            "request_to_response_headers_s": None,
+            "request_to_first_body_byte_s": None,
+            "request_to_semantic_ttft_s": None,
+            "request_stream_total_s": None,
+            "cold_end_to_end_response_headers_s": None,
+            "cold_end_to_end_first_body_byte_s": None,
+            "cold_end_to_end_semantic_ttft_s": None,
+            "cold_end_to_end_stream_total_s": None,
+        }
+    )
     return {
         "outcome": {
             "attempted": measured_attempted,
@@ -564,12 +673,17 @@ def execute_request(
             "reasons": route_reasons,
         },
         "request_metrics": {
-            "connection": (
+            "setup": (
                 dict(connection.phase_s)
                 if block.condition == "cold"
-                else {"dns_s": None, "tcp_s": None, "tls_s": None}
+                else None
             ),
             "timing": timing,
+            "receipt_headers": (
+                measured_evidence["receipt_headers"]
+                if isinstance(measured_evidence, Mapping)
+                else {}
+            ),
             "usage": metrics.get("usage") if isinstance(metrics, Mapping) else None,
             "generation": (
                 metrics.get("generation") if isinstance(metrics, Mapping) else None

--- a/obench/gateway_probe_http.py
+++ b/obench/gateway_probe_http.py
@@ -7,8 +7,10 @@ import hashlib
 import http.client
 import ipaddress
 import json
+import queue
 import socket
 import ssl
+import threading
 import time
 import urllib.parse
 from collections.abc import Mapping
@@ -74,7 +76,21 @@ class _TimedConnection(http.client.HTTPConnection):
         self._allow_private = allow_private
         self._private_hosts = private_hosts
         self._private_networks = tuple(ipaddress.ip_network(item) for item in private_cidrs)
+        self._request_deadline: float | None = None
         self.phase_s = {"dns_s": None, "tcp_s": None, "tls_s": None}
+
+    def set_request_deadline(self, deadline: float) -> None:
+        self._request_deadline = deadline
+        if self.sock is not None:
+            self.sock.settimeout(self._remaining_timeout())
+
+    def _remaining_timeout(self) -> float:
+        if self._request_deadline is None:
+            return float(self.timeout)
+        remaining = self._request_deadline - time.monotonic()
+        if remaining <= 0:
+            raise socket.timeout("probe request exceeded its total timeout")
+        return max(0.001, remaining)
 
     def _address_allowed(self, address: str) -> bool:
         parsed = ipaddress.ip_address(address)
@@ -84,11 +100,34 @@ class _TimedConnection(http.client.HTTPConnection):
             return True
         return any(parsed in network for network in self._private_networks)
 
+    def _resolve(self) -> list[tuple[Any, ...]]:
+        results: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
+        host, port = self.host, self.port
+
+        def resolve() -> None:
+            try:
+                value = socket.getaddrinfo(
+                    host, port, type=socket.SOCK_STREAM
+                )
+            except Exception as exc:  # noqa: BLE001 - returned to request thread
+                results.put_nowait((False, exc))
+            else:
+                results.put_nowait((True, value))
+
+        threading.Thread(target=resolve, daemon=True).start()
+        try:
+            ok, value = results.get(timeout=self._remaining_timeout())
+        except queue.Empty as exc:
+            raise socket.timeout(
+                "probe request exceeded its total timeout"
+            ) from exc
+        if not ok:
+            raise value
+        return value
+
     def _connect_tcp(self) -> socket.socket:
         started = time.monotonic()
-        addresses = socket.getaddrinfo(
-            self.host, self.port, type=socket.SOCK_STREAM
-        )
+        addresses = self._resolve()
         self.phase_s["dns_s"] = time.monotonic() - started
         allowed = [item for item in addresses if self._address_allowed(item[4][0])]
         if not allowed:
@@ -99,8 +138,8 @@ class _TimedConnection(http.client.HTTPConnection):
         started = time.monotonic()
         for family, socktype, proto, _canonname, sockaddr in allowed:
             candidate = socket.socket(family, socktype, proto)
-            candidate.settimeout(self.timeout)
             try:
+                candidate.settimeout(self._remaining_timeout())
                 candidate.connect(sockaddr)
                 self.phase_s["tcp_s"] = time.monotonic() - started
                 return candidate
@@ -111,6 +150,12 @@ class _TimedConnection(http.client.HTTPConnection):
 
     def connect(self) -> None:
         self.sock = self._connect_tcp()
+        self.sock.settimeout(self._remaining_timeout())
+
+    def send(self, data: Any) -> None:
+        if self.sock is not None:
+            self.sock.settimeout(self._remaining_timeout())
+        super().send(data)
 
 
 class _TimedHTTPSConnection(_TimedConnection):
@@ -124,11 +169,13 @@ class _TimedHTTPSConnection(_TimedConnection):
         raw = self._connect_tcp()
         started = time.monotonic()
         try:
+            raw.settimeout(self._remaining_timeout())
             self.sock = self._context.wrap_socket(raw, server_hostname=self.host)
         except Exception:
             raw.close()
             raise
         self.phase_s["tls_s"] = time.monotonic() - started
+        self.sock.settimeout(self._remaining_timeout())
 
 
 def nonce(experiment_digest: str, block: ProbeBlock, role: str) -> str:
@@ -223,9 +270,10 @@ def _consume(
 ) -> tuple[int, dict[str, Any] | None, bool]:
     started = time.monotonic()
     deadline = started + float(connection.timeout)
+    connection.set_request_deadline(deadline)
     connection.request("POST", path, body=body, headers=dict(headers))
     if connection.sock is not None:
-        connection.sock.settimeout(max(0.001, deadline - time.monotonic()))
+        connection.sock.settimeout(connection._remaining_timeout())
     response = connection.getresponse()
     response_headers = {key.lower(): value for key, value in response.getheaders()}
     parser = None
@@ -249,7 +297,7 @@ def _consume(
         if time.monotonic() >= deadline:
             raise TimeoutError("probe request exceeded its total timeout")
         if connection.sock is not None:
-            connection.sock.settimeout(max(0.001, deadline - time.monotonic()))
+            connection.sock.settimeout(connection._remaining_timeout())
         chunk = response.read1(65536)
         if not chunk:
             break

--- a/obench/gateway_probe_http.py
+++ b/obench/gateway_probe_http.py
@@ -255,7 +255,11 @@ def _headers(
         "Connection": "keep-alive",
     }
     headers.update(
-        gateway_profiles.request_headers(gateway=plan.gateway, secret=secret)
+        gateway_profiles.request_headers(
+            gateway=plan.gateway,
+            gateway_id=plan.gateway_id,
+            secret=secret,
+        )
     )
     return headers
 

--- a/obench/gateway_probe_models.py
+++ b/obench/gateway_probe_models.py
@@ -1,0 +1,36 @@
+"""Shared value types for Gateway Probe execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class GatewayProbeRunError(RuntimeError):
+    """Raised when a probe cannot produce unambiguous request evidence."""
+
+
+class PrimerError(GatewayProbeRunError):
+    """Raised when a warm primer cannot admit a measured request."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeBlock:
+    case_id: str
+    prompt_digest: str
+    condition: str
+    repetition: int
+    arm_ids: tuple[str, ...]
+
+    @property
+    def coordinate(self) -> tuple[str, str, int]:
+        return self.case_id, self.condition, self.repetition
+
+
+@dataclass(frozen=True, slots=True)
+class RunSummary:
+    results_path: Path
+    rows_appended: int
+    blocks_completed: int
+    blocks_replaced: int
+    blocks_skipped: int

--- a/obench/gateway_probe_report.py
+++ b/obench/gateway_probe_report.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
-from . import gateway_probe_results, stats
+from . import gateway_probe_results, gateway_probe_spec, stats
 
 
 class GatewayProbeReportError(ValueError):
@@ -17,12 +17,33 @@ class GatewayProbeReportError(ValueError):
 
 
 _METRICS = {
-    "dns_s": ("request_metrics", "connection", "dns_s"),
-    "tcp_s": ("request_metrics", "connection", "tcp_s"),
-    "tls_s": ("request_metrics", "connection", "tls_s"),
-    "request_to_first_byte_s": ("request_metrics", "timing", "ttfb_s"),
-    "semantic_ttft_s": ("request_metrics", "timing", "semantic_ttft_s"),
-    "total_s": ("request_metrics", "timing", "total_s"),
+    "setup_dns_s": ("request_metrics", "setup", "dns_s"),
+    "setup_tcp_s": ("request_metrics", "setup", "tcp_s"),
+    "setup_tls_s": ("request_metrics", "setup", "tls_s"),
+    "request_to_response_headers_s": (
+        "request_metrics", "timing", "request_to_response_headers_s",
+    ),
+    "request_to_first_body_byte_s": (
+        "request_metrics", "timing", "request_to_first_body_byte_s",
+    ),
+    "request_to_semantic_ttft_s": (
+        "request_metrics", "timing", "request_to_semantic_ttft_s",
+    ),
+    "request_stream_total_s": (
+        "request_metrics", "timing", "request_stream_total_s",
+    ),
+    "cold_end_to_end_response_headers_s": (
+        "request_metrics", "timing", "cold_end_to_end_response_headers_s",
+    ),
+    "cold_end_to_end_first_body_byte_s": (
+        "request_metrics", "timing", "cold_end_to_end_first_body_byte_s",
+    ),
+    "cold_end_to_end_semantic_ttft_s": (
+        "request_metrics", "timing", "cold_end_to_end_semantic_ttft_s",
+    ),
+    "cold_end_to_end_stream_total_s": (
+        "request_metrics", "timing", "cold_end_to_end_stream_total_s",
+    ),
     "throughput_tokens_per_s": (
         "request_metrics", "generation", "tokens_per_second",
     ),
@@ -40,6 +61,29 @@ _METRICS = {
     ),
     "charged_cost_usd": ("billing", "charged_cost_usd"),
 }
+
+_PHASE_METRIC_LABELS = (
+    ("setup_dns_s", "Setup DNS"),
+    ("setup_tcp_s", "Setup TCP"),
+    ("setup_tls_s", "Setup TLS"),
+    ("request_to_response_headers_s", "Request to response headers"),
+    ("request_to_first_body_byte_s", "Request to first body byte"),
+    ("request_to_semantic_ttft_s", "Request to semantic TTFT"),
+    ("request_stream_total_s", "Request stream total"),
+    (
+        "cold_end_to_end_response_headers_s",
+        "Cold end-to-end response headers",
+    ),
+    (
+        "cold_end_to_end_first_body_byte_s",
+        "Cold end-to-end first body byte",
+    ),
+    (
+        "cold_end_to_end_semantic_ttft_s",
+        "Cold end-to-end semantic TTFT",
+    ),
+    ("cold_end_to_end_stream_total_s", "Cold end-to-end stream total"),
+)
 
 
 def _number(value: Any) -> float | None:
@@ -65,6 +109,16 @@ def _metric(row: Mapping[str, Any], path: Sequence[str]) -> float | None:
             return None
         value = value.get(key)
     return _number(value)
+
+
+def _metric_items(condition: str) -> Iterable[tuple[str, Sequence[str]]]:
+    for name, path in _METRICS.items():
+        if condition == "warm" and (
+            name.startswith("setup_")
+            or name.startswith("cold_end_to_end_")
+        ):
+            continue
+        yield name, path
 
 
 def _percentile(values: Sequence[float], probability: float) -> float | None:
@@ -121,6 +175,7 @@ def aggregate(
     rows: Iterable[Mapping[str, Any]],
     *,
     bootstrap_replicates: int = 2_000,
+    experiment: gateway_probe_spec.GatewayProbeExperiment | None = None,
 ) -> dict[str, Any]:
     materialized = list(rows)
     if not materialized:
@@ -136,6 +191,10 @@ def aggregate(
             or row.get("benchmark") != gateway_probe_results.BENCHMARK
         ):
             raise GatewayProbeReportError("results contain an invalid probe row")
+        try:
+            gateway_probe_results.validate_row_shape(row)
+        except Exception as exc:
+            raise GatewayProbeReportError(str(exc)) from exc
         identity = row.get("identity")
         if not isinstance(identity, Mapping):
             raise GatewayProbeReportError("result identity is missing")
@@ -146,16 +205,19 @@ def aggregate(
         if row.get("cell_id") != expected_cell_id:
             raise GatewayProbeReportError("result cell_id does not match identity")
         benchmark = identity.get("benchmark")
-        experiment = identity.get("experiment")
+        experiment_provenance = identity.get("experiment")
         comparison = identity.get("comparison")
         if benchmark != {
             "name": gateway_probe_results.BENCHMARK,
             "track": "request_probe",
         }:
             raise GatewayProbeReportError("rows contain invalid benchmark provenance")
-        if not isinstance(experiment, Mapping):
+        if not isinstance(experiment_provenance, Mapping):
             raise GatewayProbeReportError("rows omit experiment provenance")
-        experiment_identity = (experiment.get("id"), experiment.get("digest"))
+        experiment_identity = (
+            experiment_provenance.get("id"),
+            experiment_provenance.get("digest"),
+        )
         if not all(isinstance(item, str) and item for item in experiment_identity):
             raise GatewayProbeReportError("rows omit experiment provenance")
         experiment_identities.add(experiment_identity)
@@ -266,6 +328,29 @@ def aggregate(
             raise GatewayProbeReportError("rows contain inconsistent block provenance")
         block_provenance[block_key] = block_id
         attempts[(case, condition, repetition)][attempt].append(row)
+    if experiment is not None:
+        if (
+            experiment.experiment_id != experiment_id
+            or experiment.digest != experiment_digest
+            or tuple(sorted(arm.arm_id for arm in experiment.arms))
+            != expected_arms
+        ):
+            raise GatewayProbeReportError(
+                "experiment snapshot does not match result provenance"
+            )
+        for arm in experiment.arms:
+            metadata = (
+                arm.digest,
+                arm.route_kind,
+                arm.baseline,
+                experiment.model_match,
+            )
+            existing = arm_metadata.get(arm.arm_id)
+            if existing is not None and existing != metadata:
+                raise GatewayProbeReportError(
+                    "experiment snapshot conflicts with arm provenance"
+                )
+            arm_metadata[arm.arm_id] = metadata
     missing_arm_metadata = sorted(set(expected_arms) - set(arm_metadata))
     if missing_arm_metadata:
         raise GatewayProbeReportError(
@@ -342,7 +427,7 @@ def aggregate(
                         ],
                         success,
                     )
-                    for name, path in _METRICS.items()
+                    for name, path in _metric_items(condition)
                 },
             }
 
@@ -358,7 +443,7 @@ def aggregate(
                 for coordinate, rows_by_arm in complete_blocks.items()
                 if coordinate[1] == condition
             ]
-            for name, path in _METRICS.items():
+            for name, path in _metric_items(condition):
                 deltas = []
                 for rows_by_arm in condition_blocks:
                     direct = rows_by_arm[baseline]
@@ -393,7 +478,7 @@ def aggregate(
 
     minimum_blocks = min(complete_by_condition.get("cold", 0), complete_by_condition.get("warm", 0))
     return {
-        "schema_version": 1,
+        "schema_version": 3,
         "benchmark": gateway_probe_results.BENCHMARK,
         "experiment_id": experiment_id,
         "experiment_digest": experiment_digest,
@@ -420,11 +505,6 @@ def render_text(report: Mapping[str, Any]) -> str:
             return "n/a"
         prefix = "+" if signed and value > 0 else ""
         return f"{prefix}{value:.3f}s"
-
-    def number(value: Any) -> str:
-        if not isinstance(value, (int, float)) or not math.isfinite(value):
-            return "n/a"
-        return f"{value:.1f}"
 
     def coverage(value: Mapping[str, Any] | None) -> str:
         if not isinstance(value, Mapping):
@@ -471,27 +551,12 @@ def render_text(report: Mapping[str, Any]) -> str:
         rendered = f"${value:.6f}" if isinstance(value, (int, float)) else "n/a"
         return f"{rendered} ({coverage(cov)})"
 
-    def delta(
-        condition_metrics: Mapping[str, Any],
-        name: str,
-    ) -> str:
-        value = condition_metrics.get(name, {}).get("median_gateway_minus_direct")
-        return seconds(value, signed=True)
-
-    def pair_coverage(condition_metrics: Mapping[str, Any]) -> str:
-        names = (
-            ("TTFT", "semantic_ttft_s"),
-            ("TTFB", "request_to_first_byte_s"),
-            ("Total", "total_s"),
-        )
-        rendered = [
-            (label, coverage(condition_metrics.get(name, {}).get("coverage")))
-            for label, name in names
-        ]
-        values = {value for _label, value in rendered}
-        if len(values) == 1:
-            return rendered[0][1]
-        return ", ".join(f"{label} {value}" for label, value in rendered)
+    def count_metric(item: Mapping[str, Any], name: str) -> str:
+        summary = item.get("metrics", {}).get(name, {})
+        value = summary.get("p50") if isinstance(summary, Mapping) else None
+        cov = summary.get("coverage") if isinstance(summary, Mapping) else None
+        rendered = f"{value:.1f}" if isinstance(value, (int, float)) else "n/a"
+        return f"{rendered} ({coverage(cov)})"
 
     lines = [
         f"Gateway Probe ({report['label']})",
@@ -505,10 +570,12 @@ def render_text(report: Mapping[str, Any]) -> str:
         "",
         (
             "| Arm | Condition | Success / availability | Route verified | "
-            "Semantic TTFT p50 / p95 | Total p50 | TTFB p50 | "
-            "Tokens p50 | Measured cost p50 (coverage) |"
+            "Request to headers p50 | Request to first body byte p50 | "
+            "Request to semantic TTFT p50 / p95 | Request stream total p50 | "
+            "Total tokens p50 (coverage) | Cached input p50 (coverage) | "
+            "Measured cost p50 (coverage) |"
         ),
-        "|---|---|---:|---:|---:|---:|---:|---:|---:|",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for arm, arm_report in report["arms"].items():
         for condition, item in arm_report["conditions"].items():
@@ -516,27 +583,63 @@ def render_text(report: Mapping[str, Any]) -> str:
             lines.append(
                 f"| {arm} | {condition} | {availability(item['availability'])} | "
                 f"{count_ratio(den['route_verified'], den['attempted'])} | "
-                f"{seconds(metric(item, 'semantic_ttft_s'))} / "
-                f"{seconds(metric(item, 'semantic_ttft_s', 'p95'))} | "
-                f"{seconds(metric(item, 'total_s'))} | "
-                f"{seconds(metric(item, 'request_to_first_byte_s'))} | "
-                f"{number(metric(item, 'total_tokens'))} | {cost(item)} |"
+                f"{seconds(metric(item, 'request_to_response_headers_s'))} | "
+                f"{seconds(metric(item, 'request_to_first_body_byte_s'))} | "
+                f"{seconds(metric(item, 'request_to_semantic_ttft_s'))} / "
+                f"{seconds(metric(item, 'request_to_semantic_ttft_s', 'p95'))} | "
+                f"{seconds(metric(item, 'request_stream_total_s'))} | "
+                f"{count_metric(item, 'total_tokens')} | "
+                f"{count_metric(item, 'cached_input_tokens')} | {cost(item)} |"
             )
     lines.extend([
         "",
+        "| Arm | Cold setup DNS p50 | TCP p50 | TLS p50 |",
+        "|---|---:|---:|---:|",
+    ])
+    for arm, arm_report in report["arms"].items():
+        item = arm_report["conditions"]["cold"]
+        lines.append(
+            f"| {arm} | {seconds(metric(item, 'setup_dns_s'))} | "
+            f"{seconds(metric(item, 'setup_tcp_s'))} | "
+            f"{seconds(metric(item, 'setup_tls_s'))} |"
+        )
+    lines.extend([
+        "",
         (
-            "| Gateway | Condition | Median delta TTFT | Median delta TTFB | "
-            "Median delta total | Pair coverage |"
+            "| Arm | Cold end-to-end response headers p50 | "
+            "First body byte p50 | Semantic TTFT p50 | Stream total p50 |"
         ),
-        "|---|---|---:|---:|---:|---:|",
+        "|---|---:|---:|---:|---:|",
+    ])
+    for arm, arm_report in report["arms"].items():
+        item = arm_report["conditions"]["cold"]
+        lines.append(
+            f"| {arm} | "
+            f"{seconds(metric(item, 'cold_end_to_end_response_headers_s'))} | "
+            f"{seconds(metric(item, 'cold_end_to_end_first_body_byte_s'))} | "
+            f"{seconds(metric(item, 'cold_end_to_end_semantic_ttft_s'))} | "
+            f"{seconds(metric(item, 'cold_end_to_end_stream_total_s'))} |"
+        )
+    lines.extend([
+        "",
+        (
+            "| Gateway | Condition | Phase metric | "
+            "Median gateway - direct | Pair coverage |"
+        ),
+        "|---|---|---|---:|---:|",
     ])
     for arm, conditions in report["paired_contrasts"].items():
         for condition, condition_metrics in conditions.items():
-            lines.append(
-                f"| {arm} | {condition} | "
-                f"{delta(condition_metrics, 'semantic_ttft_s')} | "
-                f"{delta(condition_metrics, 'request_to_first_byte_s')} | "
-                f"{delta(condition_metrics, 'total_s')} | "
-                f"{pair_coverage(condition_metrics)} |"
-            )
+            for name, label in _PHASE_METRIC_LABELS:
+                if condition == "warm" and (
+                    name.startswith("setup_")
+                    or name.startswith("cold_end_to_end_")
+                ):
+                    continue
+                contrast = condition_metrics.get(name, {})
+                lines.append(
+                    f"| {arm} | {condition} | {label} | "
+                    f"{seconds(contrast.get('median_gateway_minus_direct'), signed=True)} | "
+                    f"{coverage(contrast.get('coverage'))} |"
+                )
     return "\n".join(lines)

--- a/obench/gateway_probe_report.py
+++ b/obench/gateway_probe_report.py
@@ -1,0 +1,540 @@
+"""Coverage-explicit reporting for request-level Gateway Probe rows."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import random
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from . import gateway_probe_results, stats
+
+
+class GatewayProbeReportError(ValueError):
+    """Raised when probe rows cannot support an unambiguous report."""
+
+
+_METRICS = {
+    "dns_s": ("request_metrics", "connection", "dns_s"),
+    "tcp_s": ("request_metrics", "connection", "tcp_s"),
+    "tls_s": ("request_metrics", "connection", "tls_s"),
+    "request_to_first_byte_s": ("request_metrics", "timing", "ttfb_s"),
+    "semantic_ttft_s": ("request_metrics", "timing", "semantic_ttft_s"),
+    "total_s": ("request_metrics", "timing", "total_s"),
+    "throughput_tokens_per_s": (
+        "request_metrics", "generation", "tokens_per_second",
+    ),
+    "input_tokens": ("request_metrics", "usage", "input_tokens"),
+    "output_tokens": ("request_metrics", "usage", "output_tokens"),
+    "total_tokens": ("request_metrics", "usage", "total_tokens"),
+    "cached_input_tokens": (
+        "request_metrics", "cache", "cached_input_tokens",
+    ),
+    "cache_write_input_tokens": (
+        "request_metrics", "cache", "cache_write_input_tokens",
+    ),
+    "measured_cost_usd": (
+        "request_metrics", "costs", "frozen_list_estimate", "amount_usd",
+    ),
+    "charged_cost_usd": ("billing", "charged_cost_usd"),
+}
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, str):
+        try:
+            value = float(value)
+        except ValueError:
+            return None
+    if (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and value >= 0
+    ):
+        return float(value)
+    return None
+
+
+def _metric(row: Mapping[str, Any], path: Sequence[str]) -> float | None:
+    value: Any = row
+    for key in path:
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(key)
+    return _number(value)
+
+
+def _percentile(values: Sequence[float], probability: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = probability * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def _summary(values: Sequence[float], total: int) -> dict[str, Any]:
+    return {
+        "p50": _percentile(values, 0.5),
+        "p95": _percentile(values, 0.95),
+        "coverage": {
+            "covered": len(values),
+            "total": total,
+            "ratio": len(values) / total if total else 0.0,
+        },
+    }
+
+
+def _bootstrap_median(
+    values: Sequence[float],
+    *,
+    seed: int,
+    replicates: int,
+) -> dict[str, Any] | None:
+    if not values:
+        return None
+    rng = random.Random(seed)
+    samples = []
+    for _ in range(replicates):
+        draw = [rng.choice(values) for _ in values]
+        samples.append(_percentile(draw, 0.5))
+    return {
+        "confidence": 0.95,
+        "low": _percentile(samples, 0.025),
+        "high": _percentile(samples, 0.975),
+        "replicates": replicates,
+    }
+
+
+def _seed(label: str) -> int:
+    return int.from_bytes(hashlib.sha256(label.encode()).digest()[:8], "big")
+
+
+def aggregate(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    bootstrap_replicates: int = 2_000,
+) -> dict[str, Any]:
+    materialized = list(rows)
+    if not materialized:
+        raise GatewayProbeReportError("at least one Gateway Probe row is required")
+    if bootstrap_replicates < 1:
+        raise GatewayProbeReportError("bootstrap_replicates must be positive")
+    experiment_identities = set()
+    comparison_digests = set()
+    for row in materialized:
+        if (
+            not isinstance(row, Mapping)
+            or row.get("schema_version") != gateway_probe_results.RESULT_SCHEMA_VERSION
+            or row.get("benchmark") != gateway_probe_results.BENCHMARK
+        ):
+            raise GatewayProbeReportError("results contain an invalid probe row")
+        identity = row.get("identity")
+        if not isinstance(identity, Mapping):
+            raise GatewayProbeReportError("result identity is missing")
+        try:
+            expected_cell_id = gateway_probe_results.cell_id(identity)
+        except (TypeError, ValueError) as exc:
+            raise GatewayProbeReportError("result identity is not canonical JSON") from exc
+        if row.get("cell_id") != expected_cell_id:
+            raise GatewayProbeReportError("result cell_id does not match identity")
+        benchmark = identity.get("benchmark")
+        experiment = identity.get("experiment")
+        comparison = identity.get("comparison")
+        if benchmark != {
+            "name": gateway_probe_results.BENCHMARK,
+            "track": "request_probe",
+        }:
+            raise GatewayProbeReportError("rows contain invalid benchmark provenance")
+        if not isinstance(experiment, Mapping):
+            raise GatewayProbeReportError("rows omit experiment provenance")
+        experiment_identity = (experiment.get("id"), experiment.get("digest"))
+        if not all(isinstance(item, str) and item for item in experiment_identity):
+            raise GatewayProbeReportError("rows omit experiment provenance")
+        experiment_identities.add(experiment_identity)
+        if not isinstance(comparison, Mapping):
+            raise GatewayProbeReportError("rows omit comparison digests")
+        comparison_pair = (
+            comparison.get("schedule_digest"),
+            comparison.get("price_digest"),
+        )
+        if not all(isinstance(item, str) and item for item in comparison_pair):
+            raise GatewayProbeReportError("rows omit comparison digests")
+        comparison_digests.add(comparison_pair)
+    if len(experiment_identities) != 1:
+        raise GatewayProbeReportError("rows mix experiment provenance")
+    if len(comparison_digests) != 1:
+        raise GatewayProbeReportError("rows mix schedule or price digests")
+    experiment_id, experiment_digest = next(iter(experiment_identities))
+    schedule_digest, price_digest = next(iter(comparison_digests))
+    expected_sets = {
+        tuple(row.get("expected_arm_ids", ())) for row in materialized
+    }
+    if len(expected_sets) != 1 or not next(iter(expected_sets)):
+        raise GatewayProbeReportError("rows mix or omit expected_arm_ids")
+    expected_arms = next(iter(expected_sets))
+    if (
+        any(not isinstance(arm, str) or not arm for arm in expected_arms)
+        or tuple(sorted(set(expected_arms))) != expected_arms
+    ):
+        raise GatewayProbeReportError("expected_arm_ids must be sorted and unique")
+    scheduled_values = {
+        row.get("scheduled_blocks_per_condition") for row in materialized
+    }
+    if len(scheduled_values) != 1:
+        raise GatewayProbeReportError("rows mix scheduled block counts")
+    scheduled_blocks = next(iter(scheduled_values))
+    if not isinstance(scheduled_blocks, int) or scheduled_blocks < 1:
+        raise GatewayProbeReportError("scheduled block count is invalid")
+
+    attempts: dict[tuple[str, str, int], dict[int, list[Mapping[str, Any]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    arm_metadata = {}
+    case_provenance = {}
+    block_provenance = {}
+    logical_rows = set()
+    for row in materialized:
+        identity = row.get("identity")
+        arm_identity = identity.get("arm")
+        case_identity = identity.get("case")
+        schedule = identity.get("schedule")
+        if not all(
+            isinstance(item, Mapping)
+            for item in (arm_identity, case_identity, schedule)
+        ):
+            raise GatewayProbeReportError("result provenance is malformed")
+        arm = arm_identity.get("id")
+        arm_digest = arm_identity.get("digest")
+        case = case_identity.get("id")
+        prompt_digest = case_identity.get("prompt_digest")
+        condition = schedule.get("condition")
+        repetition = schedule.get("repetition")
+        attempt = schedule.get("block_attempt")
+        block_id = schedule.get("block_id")
+        if (
+            arm not in expected_arms
+            or not isinstance(arm_digest, str)
+            or condition not in {"cold", "warm"}
+            or not isinstance(case, str)
+            or not isinstance(prompt_digest, str)
+            or not isinstance(repetition, int)
+            or isinstance(repetition, bool)
+            or not isinstance(attempt, int)
+            or isinstance(attempt, bool)
+            or attempt < 0
+            or not isinstance(block_id, str)
+        ):
+            raise GatewayProbeReportError("result has invalid schedule identity")
+        logical_key = (case, condition, repetition, attempt, arm)
+        if logical_key in logical_rows:
+            raise GatewayProbeReportError("results contain a duplicate logical arm row")
+        logical_rows.add(logical_key)
+        metadata = (
+            arm_digest,
+            row.get("arm_role"),
+            row.get("baseline"),
+            row.get("model_match"),
+        )
+        if (
+            metadata[1] not in {"direct", "gateway"}
+            or not isinstance(metadata[2], bool)
+            or not isinstance(metadata[3], str)
+        ):
+            raise GatewayProbeReportError("result arm metadata is malformed")
+        previous_metadata = arm_metadata.get(arm)
+        if previous_metadata is not None and previous_metadata != metadata:
+            raise GatewayProbeReportError("rows contain inconsistent arm provenance")
+        arm_metadata[arm] = metadata
+        previous_prompt_digest = case_provenance.get(case)
+        if (
+            previous_prompt_digest is not None
+            and previous_prompt_digest != prompt_digest
+        ):
+            raise GatewayProbeReportError("rows contain inconsistent case provenance")
+        case_provenance[case] = prompt_digest
+        block_key = (case, condition, repetition, attempt)
+        previous_block_id = block_provenance.get(block_key)
+        if previous_block_id is not None and previous_block_id != block_id:
+            raise GatewayProbeReportError("rows contain inconsistent block provenance")
+        block_provenance[block_key] = block_id
+        attempts[(case, condition, repetition)][attempt].append(row)
+    missing_arm_metadata = sorted(set(expected_arms) - set(arm_metadata))
+    if missing_arm_metadata:
+        raise GatewayProbeReportError(
+            "rows omit metadata for expected arms: " + ", ".join(missing_arm_metadata)
+        )
+    baselines = [arm for arm, item in arm_metadata.items() if item[2] is True]
+    if len(baselines) != 1:
+        raise GatewayProbeReportError("exactly one baseline arm is required")
+    baseline = baselines[0]
+
+    latest_rows = []
+    complete_blocks: dict[tuple[str, str, int], dict[str, Mapping[str, Any]]] = {}
+    complete_by_condition = defaultdict(int)
+    for coordinate, by_attempt in attempts.items():
+        latest = max(by_attempt)
+        rows_for_attempt = by_attempt[latest]
+        by_arm = {row["identity"]["arm"]["id"]: row for row in rows_for_attempt}
+        latest_rows.extend(rows_for_attempt)
+        if set(by_arm) == set(expected_arms):
+            complete_blocks[coordinate] = by_arm
+            complete_by_condition[coordinate[1]] += 1
+
+    arms: dict[str, Any] = {}
+    for condition in ("cold", "warm"):
+        for arm in expected_arms:
+            selected = [
+                row for row in latest_rows
+                if row["identity"]["arm"]["id"] == arm
+                and row["identity"]["schedule"]["condition"] == condition
+            ]
+            attempted = sum(row.get("outcome", {}).get("attempted") is True for row in selected)
+            success = sum(row.get("outcome", {}).get("success") is True for row in selected)
+            route_counts = {
+                status: sum(
+                    row.get("route_integrity", {}).get("status") == status
+                    for row in selected
+                )
+                for status in ("verified", "unverifiable", "failed")
+            }
+            availability_low, availability_high = stats.wilson_ci(success, attempted)
+            arm_report = arms.setdefault(arm, {
+                "role": arm_metadata[arm][1],
+                "baseline": arm_metadata[arm][2],
+                "conditions": {},
+            })
+            arm_report["conditions"][condition] = {
+                "denominators": {
+                    "scheduled": scheduled_blocks,
+                    "attempted": attempted,
+                    "success": success,
+                    "request_failed": attempted - success,
+                    "route_verified": route_counts["verified"],
+                    "route_unverifiable": route_counts["unverifiable"],
+                    "route_failed": route_counts["failed"],
+                },
+                "availability": {
+                    "successes": success,
+                    "attempted": attempted,
+                    "rate": success / attempted if attempted else None,
+                    "wilson95": {
+                        "confidence": 0.95,
+                        "low": availability_low,
+                        "high": availability_high,
+                    },
+                },
+                "metrics": {
+                    name: _summary(
+                        [
+                            value for row in selected
+                            if row.get("outcome", {}).get("success") is True
+                            and (value := _metric(row, path)) is not None
+                        ],
+                        success,
+                    )
+                    for name, path in _METRICS.items()
+                },
+            }
+
+    contrasts = {}
+    for arm in expected_arms:
+        if arm == baseline:
+            continue
+        arm_contrasts = {}
+        for condition in ("cold", "warm"):
+            metrics = {}
+            condition_blocks = [
+                rows_by_arm
+                for coordinate, rows_by_arm in complete_blocks.items()
+                if coordinate[1] == condition
+            ]
+            for name, path in _METRICS.items():
+                deltas = []
+                for rows_by_arm in condition_blocks:
+                    direct = rows_by_arm[baseline]
+                    gateway = rows_by_arm[arm]
+                    if not all(
+                        row.get("outcome", {}).get("success") is True
+                        and row.get("route_integrity", {}).get("status") == "verified"
+                        for row in (direct, gateway)
+                    ):
+                        continue
+                    direct_value = _metric(direct, path)
+                    gateway_value = _metric(gateway, path)
+                    if direct_value is not None and gateway_value is not None:
+                        deltas.append(gateway_value - direct_value)
+                label = f"{experiment_digest}:{arm}:{condition}:{name}"
+                metrics[name] = {
+                    "median_gateway_minus_direct": _percentile(deltas, 0.5),
+                    "interval": _bootstrap_median(
+                        deltas,
+                        seed=_seed(label),
+                        replicates=bootstrap_replicates,
+                    ),
+                    "coverage": {
+                        "covered": len(deltas),
+                        "total": len(condition_blocks),
+                        "ratio": len(deltas) / len(condition_blocks)
+                        if condition_blocks else 0.0,
+                    },
+                }
+            arm_contrasts[condition] = metrics
+        contrasts[arm] = arm_contrasts
+
+    minimum_blocks = min(complete_by_condition.get("cold", 0), complete_by_condition.get("warm", 0))
+    return {
+        "schema_version": 1,
+        "benchmark": gateway_probe_results.BENCHMARK,
+        "experiment_id": experiment_id,
+        "experiment_digest": experiment_digest,
+        "schedule_digest": schedule_digest,
+        "price_digest": price_digest,
+        "label": "exploratory" if minimum_blocks < 100 else "confirmatory",
+        "complete_blocks": {
+            condition: complete_by_condition.get(condition, 0)
+            for condition in ("cold", "warm")
+        },
+        "scheduled_blocks_per_condition": scheduled_blocks,
+        "baseline_arm_id": baseline,
+        "arms": arms,
+        "paired_contrasts": contrasts,
+    }
+
+
+def render_text(report: Mapping[str, Any]) -> str:
+    def metric(item: Mapping[str, Any], name: str, statistic: str = "p50") -> Any:
+        return item.get("metrics", {}).get(name, {}).get(statistic)
+
+    def seconds(value: Any, *, signed: bool = False) -> str:
+        if not isinstance(value, (int, float)) or not math.isfinite(value):
+            return "n/a"
+        prefix = "+" if signed and value > 0 else ""
+        return f"{prefix}{value:.3f}s"
+
+    def number(value: Any) -> str:
+        if not isinstance(value, (int, float)) or not math.isfinite(value):
+            return "n/a"
+        return f"{value:.1f}"
+
+    def coverage(value: Mapping[str, Any] | None) -> str:
+        if not isinstance(value, Mapping):
+            return "n/a"
+        covered = value.get("covered")
+        total = value.get("total")
+        if not isinstance(covered, int) or not isinstance(total, int):
+            return "n/a"
+        return f"{covered}/{total}"
+
+    def availability(value: Mapping[str, Any]) -> str:
+        successes = value.get("successes")
+        attempted = value.get("attempted")
+        rate = value.get("rate")
+        interval = value.get("wilson95")
+        if not isinstance(attempted, int) or attempted == 0:
+            return "n/a"
+        if not isinstance(successes, int) or not isinstance(rate, (int, float)):
+            return "n/a"
+        if not isinstance(interval, Mapping):
+            return f"{successes}/{attempted} ({rate:.1%})"
+        low = interval.get("low")
+        high = interval.get("high")
+        if not isinstance(low, (int, float)) or not isinstance(high, (int, float)):
+            return f"{successes}/{attempted} ({rate:.1%})"
+        return (
+            f"{successes}/{attempted} ({rate:.1%}; "
+            f"95% CI {low:.1%}-{high:.1%})"
+        )
+
+    def count_ratio(numerator: Any, denominator: Any) -> str:
+        if (
+            not isinstance(numerator, int)
+            or not isinstance(denominator, int)
+            or denominator == 0
+        ):
+            return "n/a"
+        return f"{numerator}/{denominator}"
+
+    def cost(item: Mapping[str, Any]) -> str:
+        summary = item.get("metrics", {}).get("measured_cost_usd", {})
+        value = summary.get("p50") if isinstance(summary, Mapping) else None
+        cov = summary.get("coverage") if isinstance(summary, Mapping) else None
+        rendered = f"${value:.6f}" if isinstance(value, (int, float)) else "n/a"
+        return f"{rendered} ({coverage(cov)})"
+
+    def delta(
+        condition_metrics: Mapping[str, Any],
+        name: str,
+    ) -> str:
+        value = condition_metrics.get(name, {}).get("median_gateway_minus_direct")
+        return seconds(value, signed=True)
+
+    def pair_coverage(condition_metrics: Mapping[str, Any]) -> str:
+        names = (
+            ("TTFT", "semantic_ttft_s"),
+            ("TTFB", "request_to_first_byte_s"),
+            ("Total", "total_s"),
+        )
+        rendered = [
+            (label, coverage(condition_metrics.get(name, {}).get("coverage")))
+            for label, name in names
+        ]
+        values = {value for _label, value in rendered}
+        if len(values) == 1:
+            return rendered[0][1]
+        return ", ".join(f"{label} {value}" for label, value in rendered)
+
+    lines = [
+        f"Gateway Probe ({report['label']})",
+        (
+            "blocks "
+            f"cold={report['complete_blocks']['cold']}/"
+            f"{report['scheduled_blocks_per_condition']} "
+            f"warm={report['complete_blocks']['warm']}/"
+            f"{report['scheduled_blocks_per_condition']}"
+        ),
+        "",
+        (
+            "| Arm | Condition | Success / availability | Route verified | "
+            "Semantic TTFT p50 / p95 | Total p50 | TTFB p50 | "
+            "Tokens p50 | Measured cost p50 (coverage) |"
+        ),
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for arm, arm_report in report["arms"].items():
+        for condition, item in arm_report["conditions"].items():
+            den = item["denominators"]
+            lines.append(
+                f"| {arm} | {condition} | {availability(item['availability'])} | "
+                f"{count_ratio(den['route_verified'], den['attempted'])} | "
+                f"{seconds(metric(item, 'semantic_ttft_s'))} / "
+                f"{seconds(metric(item, 'semantic_ttft_s', 'p95'))} | "
+                f"{seconds(metric(item, 'total_s'))} | "
+                f"{seconds(metric(item, 'request_to_first_byte_s'))} | "
+                f"{number(metric(item, 'total_tokens'))} | {cost(item)} |"
+            )
+    lines.extend([
+        "",
+        (
+            "| Gateway | Condition | Median delta TTFT | Median delta TTFB | "
+            "Median delta total | Pair coverage |"
+        ),
+        "|---|---|---:|---:|---:|---:|",
+    ])
+    for arm, conditions in report["paired_contrasts"].items():
+        for condition, condition_metrics in conditions.items():
+            lines.append(
+                f"| {arm} | {condition} | "
+                f"{delta(condition_metrics, 'semantic_ttft_s')} | "
+                f"{delta(condition_metrics, 'request_to_first_byte_s')} | "
+                f"{delta(condition_metrics, 'total_s')} | "
+                f"{pair_coverage(condition_metrics)} |"
+            )
+    return "\n".join(lines)

--- a/obench/gateway_probe_report.py
+++ b/obench/gateway_probe_report.py
@@ -336,6 +336,8 @@ def aggregate(
                         [
                             value for row in selected
                             if row.get("outcome", {}).get("success") is True
+                            and row.get("route_integrity", {}).get("status")
+                            == "verified"
                             and (value := _metric(row, path)) is not None
                         ],
                         success,

--- a/obench/gateway_probe_results.py
+++ b/obench/gateway_probe_results.py
@@ -1,0 +1,361 @@
+"""Identity binding and durable JSONL storage for Gateway Probe results."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from . import gateway_spec
+from . import gateway_probe_spec as probe_spec
+from .gateway_probe_models import GatewayProbeRunError, ProbeBlock
+
+
+BENCHMARK = "gateway_probe"
+RESULT_SCHEMA_VERSION = 2
+
+
+def block_id(
+    experiment_digest: str,
+    block: ProbeBlock,
+    attempt: int,
+) -> str:
+    block_material = {
+        "experiment_digest": experiment_digest,
+        "case_id": block.case_id,
+        "condition": block.condition,
+        "repetition": block.repetition,
+        "attempt": attempt,
+    }
+    return "gateway-probe-block-" + gateway_spec.canonical_digest(block_material)
+
+
+def make_identity(
+    experiment: probe_spec.GatewayProbeExperiment,
+    arm: gateway_spec.Arm,
+    block: ProbeBlock,
+    attempt: int,
+    schedule_digest: str,
+    price_digest: str,
+) -> dict[str, Any]:
+    return {
+        "benchmark": {"name": BENCHMARK, "track": probe_spec.TRACK},
+        "experiment": {"id": experiment.experiment_id, "digest": experiment.digest},
+        "arm": {"id": arm.arm_id, "digest": arm.digest},
+        "case": {"id": block.case_id, "prompt_digest": block.prompt_digest},
+        "comparison": {
+            "schedule_digest": schedule_digest,
+            "price_digest": price_digest,
+        },
+        "schedule": {
+            "condition": block.condition,
+            "repetition": block.repetition,
+            "block_id": block_id(experiment.digest, block, attempt),
+            "block_attempt": attempt,
+        },
+    }
+
+
+def cell_id(identity: Mapping[str, Any]) -> str:
+    return "gateway-probe-cell-v2-" + gateway_spec.canonical_digest(identity)
+
+
+def read_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    raw = path.read_bytes()
+    if raw and not raw.endswith(b"\n"):
+        raise GatewayProbeRunError("results JSONL has an unterminated final line")
+    rows = []
+    seen = set()
+    for line_number, line in enumerate(raw.splitlines(), 1):
+        if not line:
+            raise GatewayProbeRunError(
+                f"results JSONL has a blank line at {line_number}"
+            )
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise GatewayProbeRunError(
+                f"results JSONL line {line_number} is invalid JSON"
+            ) from exc
+        if not isinstance(row, dict) or row.get("benchmark") != BENCHMARK:
+            raise GatewayProbeRunError("results JSONL contains a non-probe row")
+        row_cell_id = row.get("cell_id")
+        if not isinstance(row_cell_id, str) or row_cell_id in seen:
+            raise GatewayProbeRunError(
+                "results JSONL contains an invalid or duplicate cell_id"
+            )
+        seen.add(row_cell_id)
+        rows.append(row)
+    return rows
+
+
+def load_results(path: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    return read_rows(Path(path))
+
+
+def _exact_mapping(value: Any, fields: set[str], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != fields:
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    return value
+
+
+def _validate_result_shape(row: Mapping[str, Any]) -> None:
+    expected_fields = {
+        "schema_version", "benchmark", "cell_id", "identity",
+        "expected_arm_ids", "scheduled_blocks_per_condition", "arm_role",
+        "baseline", "model_match", "outcome", "route_integrity",
+        "request_metrics", "reuse_evidence", "billing",
+    }
+    if set(row) != expected_fields:
+        raise GatewayProbeRunError("results row does not match schema v2")
+    outcome = _exact_mapping(
+        row.get("outcome"),
+        {
+            "attempted", "success", "available", "http_status", "timed_out",
+            "error_class", "error_detail", "budget_exhausted_reason",
+        },
+        "outcome",
+    )
+    if any(
+        not isinstance(outcome.get(field), bool)
+        for field in ("attempted", "success", "available", "timed_out")
+    ):
+        raise GatewayProbeRunError("results row outcome is malformed")
+    if outcome.get("http_status") is not None and (
+        not isinstance(outcome.get("http_status"), int)
+        or isinstance(outcome.get("http_status"), bool)
+    ):
+        raise GatewayProbeRunError("results row outcome is malformed")
+    error_classes = {None, "timeout", "primer", "transport", "http", "stream"}
+    error_details = {
+        None, "timeout", "primer_invalid", "bad_status_line", "http_protocol",
+        "tls", "dns", "connection_refused", "connection_reset",
+        "connection_closed", "probe_policy", "network_io", "internal",
+        "http_status", "stream_terminal", "stream_incomplete",
+    }
+    if (
+        outcome.get("error_class") not in error_classes
+        or outcome.get("error_detail") not in error_details
+        or (
+            outcome.get("budget_exhausted_reason") is not None
+            and not isinstance(outcome.get("budget_exhausted_reason"), str)
+        )
+    ):
+        raise GatewayProbeRunError("results row outcome taxonomy is malformed")
+    route = _exact_mapping(
+        row.get("route_integrity"),
+        {"status", "pass", "reasons"},
+        "route integrity",
+    )
+    if (
+        route.get("status") not in {"verified", "unverifiable", "failed"}
+        or route.get("pass") is not (route.get("status") == "verified")
+        or not isinstance(route.get("reasons"), list)
+        or any(not isinstance(reason, str) for reason in route["reasons"])
+    ):
+        raise GatewayProbeRunError("results row route integrity is malformed")
+    _exact_mapping(
+        row.get("request_metrics"),
+        {
+            "connection", "timing", "usage", "generation", "cache",
+            "route", "costs", "stream", "coverage",
+        },
+        "request metrics",
+    )
+    _exact_mapping(
+        row.get("reuse_evidence"),
+        {
+            "required", "completed", "http_status", "socket_reused",
+            "primer_nonce_sha256", "measured_nonce_sha256", "connection",
+            "route_integrity", "usage", "cache", "costs",
+        },
+        "reuse evidence",
+    )
+    billing = _exact_mapping(
+        row.get("billing"),
+        {
+            "primer_cost_usd", "measured_cost_usd",
+            "charged_cost_usd", "stop_required",
+        },
+        "billing evidence",
+    )
+    if not isinstance(billing.get("stop_required"), bool):
+        raise GatewayProbeRunError("results row billing evidence is malformed")
+
+
+def validate_resume_rows(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    experiment: probe_spec.GatewayProbeExperiment,
+    schedule: Sequence[ProbeBlock],
+    schedule_digest: str,
+    price_digest: str,
+) -> None:
+    expected_arm_ids = sorted(arm.arm_id for arm in experiment.arms)
+    arms_by_id = {arm.arm_id: arm for arm in experiment.arms}
+    cases_by_id = {case.case_id: case for case in experiment.cases}
+    blocks_by_coordinate = {block.coordinate: block for block in schedule}
+    scheduled_per_condition = len(experiment.cases) * experiment.repetitions
+    logical_rows = set()
+    for row in rows:
+        if row.get("schema_version") != RESULT_SCHEMA_VERSION:
+            raise GatewayProbeRunError("results row has unsupported schema_version")
+        _validate_result_shape(row)
+        identity = _exact_mapping(
+            row.get("identity"),
+            {"benchmark", "experiment", "arm", "case", "comparison", "schedule"},
+            "identity",
+        )
+        try:
+            expected_cell_id = cell_id(identity)
+        except (TypeError, ValueError, gateway_spec.GatewaySpecError) as exc:
+            raise GatewayProbeRunError(
+                "results row identity is not canonical JSON"
+            ) from exc
+        if row.get("cell_id") != expected_cell_id:
+            raise GatewayProbeRunError("results row cell_id does not match identity")
+        benchmark = _exact_mapping(
+            identity.get("benchmark"), {"name", "track"}, "benchmark identity"
+        )
+        if benchmark != {"name": BENCHMARK, "track": probe_spec.TRACK}:
+            raise GatewayProbeRunError(
+                "results row benchmark identity does not match"
+            )
+        experiment_identity = _exact_mapping(
+            identity.get("experiment"), {"id", "digest"}, "experiment identity"
+        )
+        if experiment_identity != {
+            "id": experiment.experiment_id,
+            "digest": experiment.digest,
+        }:
+            raise GatewayProbeRunError(
+                "results row experiment identity does not match"
+            )
+        comparison = _exact_mapping(
+            identity.get("comparison"),
+            {"schedule_digest", "price_digest"},
+            "comparison identity",
+        )
+        if comparison != {
+            "schedule_digest": schedule_digest,
+            "price_digest": price_digest,
+        }:
+            raise GatewayProbeRunError(
+                "results row comparison digests do not match"
+            )
+        arm_identity = _exact_mapping(
+            identity.get("arm"), {"id", "digest"}, "arm identity"
+        )
+        arm_id = arm_identity.get("id")
+        if not isinstance(arm_id, str):
+            raise GatewayProbeRunError("results row arm identity is invalid")
+        arm = arms_by_id.get(arm_id)
+        if arm is None or arm_identity.get("digest") != arm.digest:
+            raise GatewayProbeRunError("results row arm identity does not match")
+        case_identity = _exact_mapping(
+            identity.get("case"), {"id", "prompt_digest"}, "case identity"
+        )
+        case_id = case_identity.get("id")
+        if not isinstance(case_id, str):
+            raise GatewayProbeRunError("results row case identity is invalid")
+        case = cases_by_id.get(case_id)
+        if case is None or case_identity.get("prompt_digest") != case.prompt_digest:
+            raise GatewayProbeRunError("results row case identity does not match")
+        schedule_identity = _exact_mapping(
+            identity.get("schedule"),
+            {"condition", "repetition", "block_id", "block_attempt"},
+            "schedule identity",
+        )
+        condition = schedule_identity.get("condition")
+        repetition = schedule_identity.get("repetition")
+        attempt = schedule_identity.get("block_attempt")
+        if (
+            not isinstance(condition, str)
+            or not isinstance(repetition, int)
+            or isinstance(repetition, bool)
+            or not isinstance(attempt, int)
+            or isinstance(attempt, bool)
+            or attempt < 0
+        ):
+            raise GatewayProbeRunError(
+                "results row schedule identity is invalid"
+            )
+        coordinate = (case_id, condition, repetition)
+        block = blocks_by_coordinate.get(coordinate)
+        if block is None or arm_id not in block.arm_ids:
+            raise GatewayProbeRunError(
+                "results row is not a scheduled arm membership"
+            )
+        if schedule_identity.get("block_id") != block_id(
+            experiment.digest, block, attempt
+        ):
+            raise GatewayProbeRunError(
+                "results row block_id does not match schedule"
+            )
+        if row.get("expected_arm_ids") != expected_arm_ids:
+            raise GatewayProbeRunError(
+                "results row expected_arm_ids do not match"
+            )
+        if row.get("scheduled_blocks_per_condition") != scheduled_per_condition:
+            raise GatewayProbeRunError(
+                "results row scheduled block count does not match"
+            )
+        if (
+            row.get("arm_role") != arm.route_kind
+            or row.get("baseline") is not arm.baseline
+            or row.get("model_match") != experiment.model_match
+        ):
+            raise GatewayProbeRunError(
+                "results row arm provenance does not match"
+            )
+        logical_key = (case_id, condition, repetition, attempt, arm_id)
+        if logical_key in logical_rows:
+            raise GatewayProbeRunError(
+                "results contain a duplicate logical arm row"
+            )
+        logical_rows.add(logical_key)
+
+
+def append_row(path: Path, row: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(
+        row,
+        allow_nan=False,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ) + "\n"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+        handle.flush()
+        os.fsync(handle.fileno())
+    directory_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def charged_cost(row: Mapping[str, Any]) -> Decimal:
+    billing = row.get("billing")
+    if billing is None:
+        return Decimal(0)
+    if not isinstance(billing, Mapping):
+        raise GatewayProbeRunError(
+            "results row has malformed billing evidence"
+        )
+    raw = billing.get("charged_cost_usd")
+    try:
+        amount = Decimal(str(raw))
+    except (ArithmeticError, ValueError) as exc:
+        raise GatewayProbeRunError(
+            "results row has malformed charged cost"
+        ) from exc
+    if not amount.is_finite() or amount < 0:
+        raise GatewayProbeRunError("results row has malformed charged cost")
+    return amount

--- a/obench/gateway_probe_results.py
+++ b/obench/gateway_probe_results.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import math
 import os
+import re
 from collections.abc import Mapping, Sequence
 from decimal import Decimal
 from pathlib import Path
@@ -15,7 +17,18 @@ from .gateway_probe_models import GatewayProbeRunError, ProbeBlock
 
 
 BENCHMARK = "gateway_probe"
-RESULT_SCHEMA_VERSION = 2
+RESULT_SCHEMA_VERSION = 3
+RECEIPT_HEADER_ALLOWLIST = frozenset({
+    "x-request-id",
+    "request-id",
+    "openai-request-id",
+    "anthropic-request-id",
+    "x-vercel-id",
+    "cf-ray",
+})
+RECEIPT_VALUE_MAX_LENGTH = 256
+_SAFE_IDENTIFIER_RE = re.compile(r"[A-Za-z0-9._:/@+\-]{1,256}")
+RECEIPT_VALUE_RE = re.compile(r"[A-Za-z0-9._:/@+=\-]{1,256}")
 
 
 def block_id(
@@ -60,7 +73,7 @@ def make_identity(
 
 
 def cell_id(identity: Mapping[str, Any]) -> str:
-    return "gateway-probe-cell-v2-" + gateway_spec.canonical_digest(identity)
+    return "gateway-probe-cell-v3-" + gateway_spec.canonical_digest(identity)
 
 
 def read_rows(path: Path) -> list[dict[str, Any]]:
@@ -84,6 +97,7 @@ def read_rows(path: Path) -> list[dict[str, Any]]:
             ) from exc
         if not isinstance(row, dict) or row.get("benchmark") != BENCHMARK:
             raise GatewayProbeRunError("results JSONL contains a non-probe row")
+        validate_row_shape(row)
         row_cell_id = row.get("cell_id")
         if not isinstance(row_cell_id, str) or row_cell_id in seen:
             raise GatewayProbeRunError(
@@ -104,7 +118,423 @@ def _exact_mapping(value: Any, fields: set[str], label: str) -> Mapping[str, Any
     return value
 
 
-def _validate_result_shape(row: Mapping[str, Any]) -> None:
+def _duration(value: Any) -> bool:
+    return (
+        value is None
+        or (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+            and value >= 0
+        )
+    )
+
+
+def _validate_timing_order(
+    timing: Mapping[str, Any],
+    *,
+    condition: str,
+) -> None:
+    request_names = (
+        "request_to_response_headers_s",
+        "request_to_first_body_byte_s",
+        "request_to_semantic_ttft_s",
+        "request_stream_total_s",
+    )
+    cold_names = (
+        "cold_end_to_end_response_headers_s",
+        "cold_end_to_end_first_body_byte_s",
+        "cold_end_to_end_semantic_ttft_s",
+        "cold_end_to_end_stream_total_s",
+    )
+
+    def ordered(names: Sequence[str]) -> bool:
+        observed = [
+            timing.get(name)
+            for name in names
+            if timing.get(name) is not None
+        ]
+        return observed == sorted(observed)
+
+    if not ordered(request_names):
+        raise GatewayProbeRunError("results row request timing is out of order")
+    if condition == "warm":
+        if any(timing.get(name) is not None for name in cold_names):
+            raise GatewayProbeRunError(
+                "warm request contains cold timing evidence"
+            )
+        return
+    if not ordered(cold_names):
+        raise GatewayProbeRunError(
+            "results row cold end-to-end timing is out of order"
+        )
+    offsets = []
+    for request_name, cold_name in zip(request_names, cold_names):
+        request_value = timing.get(request_name)
+        cold_value = timing.get(cold_name)
+        if (request_value is None) is not (cold_value is None):
+            raise GatewayProbeRunError(
+                "cold request timing coverage is inconsistent"
+            )
+        if request_value is not None:
+            if cold_value < request_value:
+                raise GatewayProbeRunError(
+                    "cold end-to-end timing is shorter than request timing"
+                )
+            offsets.append(cold_value - request_value)
+    if offsets and max(offsets) - min(offsets) > 1e-6:
+        raise GatewayProbeRunError(
+            "cold end-to-end timing has inconsistent setup offsets"
+        )
+
+
+def _validate_setup(value: Any, label: str, *, nullable: bool) -> None:
+    if value is None and nullable:
+        return
+    setup = _exact_mapping(value, {"dns_s", "tcp_s", "tls_s"}, label)
+    if any(not _duration(setup.get(name)) for name in setup):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+
+
+def _validate_receipts(value: Any, label: str) -> None:
+    if not isinstance(value, Mapping):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    if any(name not in RECEIPT_HEADER_ALLOWLIST for name in value):
+        raise GatewayProbeRunError(f"results row has unsafe {label}")
+    for receipt in value.values():
+        if (
+            not isinstance(receipt, str)
+            or not receipt
+            or len(receipt) > RECEIPT_VALUE_MAX_LENGTH
+            or receipt != receipt.strip()
+            or RECEIPT_VALUE_RE.fullmatch(receipt) is None
+        ):
+            raise GatewayProbeRunError(f"results row has unsafe {label}")
+
+
+def _count(value: Any, *, nullable: bool = True) -> bool:
+    return (
+        value is None and nullable
+    ) or (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value >= 0
+    )
+
+
+def _safe_identifier(value: Any, *, nullable: bool = True) -> bool:
+    return (
+        value is None and nullable
+    ) or (
+        isinstance(value, str)
+        and _SAFE_IDENTIFIER_RE.fullmatch(value) is not None
+    )
+
+
+def _cost_scalar(value: Any) -> bool:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return math.isfinite(value) and value >= 0
+    if not isinstance(value, str) or len(value) > 64:
+        return False
+    try:
+        amount = Decimal(value)
+    except (ArithmeticError, ValueError):
+        return False
+    return amount.is_finite() and amount >= 0
+
+
+def _validate_usage(value: Any, label: str) -> None:
+    if value is None:
+        return
+    usage = _exact_mapping(
+        value,
+        set(value) if isinstance(value, Mapping) else set(),
+        label,
+    )
+    allowed = {
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "input_tokens_details",
+    }
+    if not set(usage) <= allowed or any(
+        not _count(usage.get(name))
+        for name in ("input_tokens", "output_tokens", "total_tokens")
+        if name in usage
+    ):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    details = usage.get("input_tokens_details")
+    if details is not None:
+        details = _exact_mapping(
+            details,
+            set(details) if isinstance(details, Mapping) else set(),
+            f"{label} details",
+        )
+        if (
+            not set(details) <= {
+                "cached_tokens",
+                "cache_write_tokens",
+                "cached_tokens_created",
+            }
+            or any(not _count(item, nullable=False) for item in details.values())
+        ):
+            raise GatewayProbeRunError(
+                f"results row has malformed {label} details"
+            )
+
+
+def _validate_generation(value: Any, label: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping) or not set(value) <= {
+        "output_tokens", "duration_s", "tokens_per_second",
+    }:
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    if "output_tokens" in value and not _count(value["output_tokens"]):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    if any(
+        not _duration(value[name])
+        for name in ("duration_s", "tokens_per_second")
+        if name in value
+    ):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+
+
+def _validate_cache(value: Any, label: str, *, nullable: bool) -> None:
+    if value is None and nullable:
+        return
+    cache = _exact_mapping(
+        value,
+        {"cached_input_tokens", "cache_write_input_tokens"},
+        label,
+    )
+    if any(not _count(item) for item in cache.values()):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+
+
+def _validate_route(value: Any, label: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping) or not set(value) <= {
+        "requested_model",
+        "metadata_requested_model",
+        "served_model",
+        "provider",
+        "attempts",
+        "gateway_metadata",
+    }:
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    for name in (
+        "requested_model",
+        "metadata_requested_model",
+        "served_model",
+        "provider",
+    ):
+        if name in value and not _safe_identifier(value[name]):
+            raise GatewayProbeRunError(f"results row has unsafe {label}")
+    attempts = value.get("attempts")
+    if attempts is not None:
+        if not isinstance(attempts, list) or len(attempts) > 64:
+            raise GatewayProbeRunError(f"results row has malformed {label}")
+        for attempt in attempts:
+            if not isinstance(attempt, Mapping) or not set(attempt) <= {
+                "provider", "model", "status",
+            }:
+                raise GatewayProbeRunError(f"results row has malformed {label}")
+            if (
+                "provider" in attempt
+                and not _safe_identifier(attempt["provider"], nullable=False)
+            ) or (
+                "model" in attempt
+                and not _safe_identifier(attempt["model"], nullable=False)
+            ) or (
+                "status" in attempt
+                and not _count(attempt["status"], nullable=False)
+            ):
+                raise GatewayProbeRunError(f"results row has unsafe {label}")
+    metadata = value.get("gateway_metadata")
+    if metadata is not None:
+        if not isinstance(metadata, Mapping) or not set(metadata) <= {
+            "cost", "marketCost", "generationId",
+        }:
+            raise GatewayProbeRunError(f"results row has malformed {label}")
+        for name, item in metadata.items():
+            if name == "generationId":
+                valid = _safe_identifier(item, nullable=False)
+            else:
+                valid = _cost_scalar(item)
+            if not valid:
+                raise GatewayProbeRunError(f"results row has unsafe {label}")
+
+
+def _validate_costs(value: Any, label: str) -> None:
+    if not isinstance(value, Mapping) or not set(value) <= {
+        "gateway_reported", "frozen_list_estimate",
+    }:
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    for item in value.values():
+        evidence = _exact_mapping(
+            item,
+            {"amount_usd", "currency", "effective_at"},
+            label,
+        )
+        if (
+            not _duration(evidence.get("amount_usd"))
+            or evidence.get("amount_usd") is None
+            or evidence.get("currency") != "USD"
+            or not _safe_identifier(
+                evidence.get("effective_at"), nullable=False
+            )
+        ):
+            raise GatewayProbeRunError(f"results row has malformed {label}")
+
+
+def _validate_stream(value: Any, label: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping) or not set(value) <= {
+        "events",
+        "ignored_events",
+        "malformed_events",
+        "done",
+        "terminal_status",
+        "finalized",
+    }:
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    for name in ("events", "ignored_events", "malformed_events"):
+        if name in value and not _count(value[name], nullable=False):
+            raise GatewayProbeRunError(f"results row has malformed {label}")
+    for name in ("done", "finalized"):
+        if name in value and not isinstance(value[name], bool):
+            raise GatewayProbeRunError(f"results row has malformed {label}")
+    if "terminal_status" in value and not _safe_identifier(
+        value["terminal_status"]
+    ):
+        raise GatewayProbeRunError(f"results row has unsafe {label}")
+
+
+def _validate_outcome_evidence(
+    outcome: Mapping[str, Any],
+    timing: Mapping[str, Any],
+    stream: Any,
+) -> None:
+    timed_out = outcome.get("timed_out")
+    error_class = outcome.get("error_class")
+    error_detail = outcome.get("error_detail")
+    if timed_out is not (error_class == "timeout"):
+        raise GatewayProbeRunError("results row timeout evidence is inconsistent")
+    if (error_class is None) is not (error_detail is None):
+        raise GatewayProbeRunError("results row error evidence is inconsistent")
+
+    attempted = outcome.get("attempted")
+    success = outcome.get("success")
+    status = outcome.get("http_status")
+    request_names = (
+        "request_to_response_headers_s",
+        "request_to_first_body_byte_s",
+        "request_to_semantic_ttft_s",
+        "request_stream_total_s",
+    )
+    if not attempted:
+        if (
+            success
+            or status is not None
+            or stream is not None
+            or any(timing.get(name) is not None for name in request_names)
+        ):
+            raise GatewayProbeRunError(
+                "unattempted request contains response evidence"
+            )
+        return
+    if success:
+        if (
+            not isinstance(status, int)
+            or not 200 <= status < 300
+            or timed_out
+            or error_class is not None
+            or any(timing.get(name) is None for name in request_names)
+            or not isinstance(stream, Mapping)
+            or stream.get("done") is not True
+            or stream.get("finalized") is not True
+            or stream.get("terminal_status") not in {None, "completed"}
+        ):
+            raise GatewayProbeRunError(
+                "successful request evidence is inconsistent"
+            )
+    elif error_class is None:
+        raise GatewayProbeRunError(
+            "unsuccessful attempted request has no error evidence"
+        )
+
+
+def _validate_coverage(value: Any, label: str) -> None:
+    if value is None:
+        return
+    allowed_flags = {
+        "ttfb",
+        "semantic_ttft",
+        "usage",
+        "generation",
+        "requested_model",
+        "served_model",
+        "openrouter_metadata",
+        "provider",
+        "attempts",
+        "attempt_evidence",
+        "stream_done",
+    }
+    if not isinstance(value, Mapping) or not set(value) <= (
+        allowed_flags | {"covered", "total", "ratio"}
+    ):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    if any(
+        not isinstance(value[name], bool)
+        for name in allowed_flags
+        if name in value
+    ):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    if any(
+        not _count(value[name], nullable=False)
+        for name in ("covered", "total")
+        if name in value
+    ):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+    ratio = value.get("ratio")
+    if ratio is not None and (
+        isinstance(ratio, bool)
+        or not isinstance(ratio, (int, float))
+        or not math.isfinite(ratio)
+        or not 0 <= ratio <= 1
+    ):
+        raise GatewayProbeRunError(f"results row has malformed {label}")
+
+
+def _validate_route_integrity(value: Any, label: str) -> None:
+    if value is None:
+        return
+    route = _exact_mapping(value, {"status", "pass", "reasons"}, label)
+    if (
+        route.get("status") not in {"verified", "unverifiable", "failed"}
+        or route.get("pass") is not (route.get("status") == "verified")
+        or not isinstance(route.get("reasons"), list)
+        or any(not _safe_identifier(reason, nullable=False) for reason in route["reasons"])
+    ):
+        raise GatewayProbeRunError(f"results row {label} is malformed")
+
+
+def _validate_money(value: Any, *, nullable: bool) -> bool:
+    if value is None:
+        return nullable
+    if not isinstance(value, str) or len(value) > 64:
+        return False
+    try:
+        amount = Decimal(value)
+    except (ArithmeticError, ValueError):
+        return False
+    return amount.is_finite() and amount >= 0
+
+
+def validate_row_shape(row: Mapping[str, Any]) -> None:
     expected_fields = {
         "schema_version", "benchmark", "cell_id", "identity",
         "expected_arm_ids", "scheduled_blocks_per_condition", "arm_role",
@@ -112,7 +542,72 @@ def _validate_result_shape(row: Mapping[str, Any]) -> None:
         "request_metrics", "reuse_evidence", "billing",
     }
     if set(row) != expected_fields:
-        raise GatewayProbeRunError("results row does not match schema v2")
+        raise GatewayProbeRunError("results row does not match schema v3")
+    if row.get("schema_version") != RESULT_SCHEMA_VERSION:
+        raise GatewayProbeRunError("results row has unsupported schema_version")
+    if row.get("benchmark") != BENCHMARK:
+        raise GatewayProbeRunError("results row benchmark is malformed")
+    identity = _exact_mapping(
+        row.get("identity"),
+        {"benchmark", "experiment", "arm", "case", "comparison", "schedule"},
+        "identity",
+    )
+    if _exact_mapping(
+        identity.get("benchmark"), {"name", "track"}, "benchmark identity"
+    ) != {"name": BENCHMARK, "track": probe_spec.TRACK}:
+        raise GatewayProbeRunError("results row benchmark identity is malformed")
+    for name, fields in (
+        ("experiment", {"id", "digest"}),
+        ("arm", {"id", "digest"}),
+        ("case", {"id", "prompt_digest"}),
+        ("comparison", {"schedule_digest", "price_digest"}),
+    ):
+        value = _exact_mapping(identity.get(name), fields, f"{name} identity")
+        if any(
+            not _safe_identifier(item, nullable=False)
+            for item in value.values()
+        ):
+            raise GatewayProbeRunError(f"results row {name} identity is malformed")
+    schedule = _exact_mapping(
+        identity.get("schedule"),
+        {"condition", "repetition", "block_id", "block_attempt"},
+        "schedule identity",
+    )
+    if (
+        schedule.get("condition") not in {"cold", "warm"}
+        or not isinstance(schedule.get("repetition"), int)
+        or isinstance(schedule.get("repetition"), bool)
+        or schedule.get("repetition") < 1
+        or not _safe_identifier(schedule.get("block_id"), nullable=False)
+        or not isinstance(schedule.get("block_attempt"), int)
+        or isinstance(schedule.get("block_attempt"), bool)
+        or schedule.get("block_attempt") < 0
+    ):
+        raise GatewayProbeRunError("results row schedule identity is malformed")
+    try:
+        expected_cell_id = cell_id(identity)
+    except (TypeError, ValueError, gateway_spec.GatewaySpecError) as exc:
+        raise GatewayProbeRunError(
+            "results row identity is not canonical JSON"
+        ) from exc
+    if row.get("cell_id") != expected_cell_id:
+        raise GatewayProbeRunError("results row cell_id does not match identity")
+    expected_arms = row.get("expected_arm_ids")
+    if (
+        not isinstance(expected_arms, list)
+        or not expected_arms
+        or any(
+            not _safe_identifier(arm, nullable=False) for arm in expected_arms
+        )
+        or expected_arms != sorted(set(expected_arms))
+        or not isinstance(row.get("scheduled_blocks_per_condition"), int)
+        or isinstance(row.get("scheduled_blocks_per_condition"), bool)
+        or row.get("scheduled_blocks_per_condition") < 1
+        or row.get("arm_role") not in {"direct", "gateway"}
+        or not isinstance(row.get("baseline"), bool)
+        or not _safe_identifier(row.get("model_match"), nullable=False)
+    ):
+        raise GatewayProbeRunError("results row top-level provenance is malformed")
     outcome = _exact_mapping(
         row.get("outcome"),
         {
@@ -137,45 +632,131 @@ def _validate_result_shape(row: Mapping[str, Any]) -> None:
         "tls", "dns", "connection_refused", "connection_reset",
         "connection_closed", "probe_policy", "network_io", "internal",
         "http_status", "stream_terminal", "stream_incomplete",
+        "stream_no_semantic_output",
+    }
+    budget_reasons = {
+        None,
+        "primer_cost_unavailable",
+        "usd_cap_reached_by_primer",
+        "measured_cost_unavailable",
+        "usd_cap_reached",
     }
     if (
         outcome.get("error_class") not in error_classes
         or outcome.get("error_detail") not in error_details
-        or (
-            outcome.get("budget_exhausted_reason") is not None
-            and not isinstance(outcome.get("budget_exhausted_reason"), str)
-        )
+        or outcome.get("budget_exhausted_reason") not in budget_reasons
     ):
         raise GatewayProbeRunError("results row outcome taxonomy is malformed")
-    route = _exact_mapping(
-        row.get("route_integrity"),
-        {"status", "pass", "reasons"},
-        "route integrity",
-    )
     if (
-        route.get("status") not in {"verified", "unverifiable", "failed"}
-        or route.get("pass") is not (route.get("status") == "verified")
-        or not isinstance(route.get("reasons"), list)
-        or any(not isinstance(reason, str) for reason in route["reasons"])
+        outcome.get("success") is not outcome.get("available")
+        or (outcome.get("success") and not outcome.get("attempted"))
     ):
+        raise GatewayProbeRunError("results row outcome is inconsistent")
+    _validate_route_integrity(row.get("route_integrity"), "route integrity")
+    route = row["route_integrity"]
+    if route is None:
         raise GatewayProbeRunError("results row route integrity is malformed")
-    _exact_mapping(
+    request_metrics = _exact_mapping(
         row.get("request_metrics"),
         {
-            "connection", "timing", "usage", "generation", "cache",
-            "route", "costs", "stream", "coverage",
+            "setup", "timing", "receipt_headers", "usage", "generation",
+            "cache", "route", "costs", "stream", "coverage",
         },
         "request metrics",
     )
-    _exact_mapping(
+    condition = schedule["condition"]
+    _validate_setup(
+        request_metrics.get("setup"),
+        "request setup",
+        nullable=condition == "warm",
+    )
+    if condition == "warm" and request_metrics.get("setup") is not None:
+        raise GatewayProbeRunError("warm request contains measured setup evidence")
+    timing = _exact_mapping(
+        request_metrics.get("timing"),
+        {
+            "request_to_response_headers_s",
+            "request_to_first_body_byte_s",
+            "request_to_semantic_ttft_s",
+            "request_stream_total_s",
+            "cold_end_to_end_response_headers_s",
+            "cold_end_to_end_first_body_byte_s",
+            "cold_end_to_end_semantic_ttft_s",
+            "cold_end_to_end_stream_total_s",
+        },
+        "request timing",
+    )
+    if any(not _duration(value) for value in timing.values()):
+        raise GatewayProbeRunError("results row has malformed request timing")
+    _validate_timing_order(timing, condition=condition)
+    _validate_receipts(request_metrics.get("receipt_headers"), "request receipts")
+    _validate_usage(request_metrics.get("usage"), "request usage")
+    _validate_generation(request_metrics.get("generation"), "request generation")
+    _validate_cache(request_metrics.get("cache"), "request cache", nullable=False)
+    _validate_route(request_metrics.get("route"), "request route")
+    _validate_costs(request_metrics.get("costs"), "request costs")
+    _validate_stream(request_metrics.get("stream"), "request stream")
+    _validate_coverage(request_metrics.get("coverage"), "request coverage")
+    _validate_outcome_evidence(
+        outcome,
+        timing,
+        request_metrics.get("stream"),
+    )
+    primer = _exact_mapping(
         row.get("reuse_evidence"),
         {
             "required", "completed", "http_status", "socket_reused",
-            "primer_nonce_sha256", "measured_nonce_sha256", "connection",
-            "route_integrity", "usage", "cache", "costs",
+            "primer_nonce_sha256", "measured_nonce_sha256", "setup",
+            "receipt_headers", "route_integrity", "usage", "cache", "costs",
         },
         "reuse evidence",
     )
+    if (
+        not isinstance(primer.get("required"), bool)
+        or not isinstance(primer.get("completed"), bool)
+        or primer.get("required") is not (condition == "warm")
+        or (
+            primer.get("http_status") is not None
+            and (
+                not isinstance(primer.get("http_status"), int)
+                or isinstance(primer.get("http_status"), bool)
+            )
+        )
+        or (
+            primer.get("socket_reused") is not None
+            and not isinstance(primer.get("socket_reused"), bool)
+        )
+    ):
+        raise GatewayProbeRunError("results row reuse evidence is malformed")
+    for name in ("primer_nonce_sha256", "measured_nonce_sha256"):
+        value = primer.get(name)
+        if (
+            not isinstance(value, str)
+            or len(value) != 64
+            or any(char not in "0123456789abcdef" for char in value)
+        ):
+            raise GatewayProbeRunError("results row reuse nonce is malformed")
+    _validate_setup(primer.get("setup"), "primer setup", nullable=False)
+    _validate_receipts(primer.get("receipt_headers"), "primer receipts")
+    _validate_route_integrity(
+        primer.get("route_integrity"), "primer route integrity"
+    )
+    _validate_usage(primer.get("usage"), "primer usage")
+    _validate_cache(primer.get("cache"), "primer cache", nullable=True)
+    _validate_costs(primer.get("costs"), "primer costs")
+    if condition == "warm" and outcome.get("success") is True:
+        primer_route = primer.get("route_integrity")
+        if (
+            primer.get("completed") is not True
+            or primer.get("socket_reused") is not True
+            or not isinstance(primer.get("http_status"), int)
+            or not 200 <= primer["http_status"] < 300
+            or not isinstance(primer_route, Mapping)
+            or primer_route.get("status") != "verified"
+        ):
+            raise GatewayProbeRunError(
+                "successful warm row lacks verified reuse evidence"
+            )
     billing = _exact_mapping(
         row.get("billing"),
         {
@@ -184,8 +765,26 @@ def _validate_result_shape(row: Mapping[str, Any]) -> None:
         },
         "billing evidence",
     )
-    if not isinstance(billing.get("stop_required"), bool):
+    if (
+        not isinstance(billing.get("stop_required"), bool)
+        or not _validate_money(billing.get("primer_cost_usd"), nullable=True)
+        or not _validate_money(billing.get("measured_cost_usd"), nullable=True)
+        or not _validate_money(billing.get("charged_cost_usd"), nullable=False)
+    ):
         raise GatewayProbeRunError("results row billing evidence is malformed")
+    component_total = sum(
+        (
+            Decimal(value)
+            for value in (
+                billing.get("primer_cost_usd"),
+                billing.get("measured_cost_usd"),
+            )
+            if value is not None
+        ),
+        Decimal(0),
+    )
+    if Decimal(billing["charged_cost_usd"]) != component_total:
+        raise GatewayProbeRunError("results row charged cost is inconsistent")
 
 
 def validate_resume_rows(
@@ -205,7 +804,7 @@ def validate_resume_rows(
     for row in rows:
         if row.get("schema_version") != RESULT_SCHEMA_VERSION:
             raise GatewayProbeRunError("results row has unsupported schema_version")
-        _validate_result_shape(row)
+        validate_row_shape(row)
         identity = _exact_mapping(
             row.get("identity"),
             {"benchmark", "experiment", "arm", "case", "comparison", "schedule"},
@@ -322,6 +921,7 @@ def validate_resume_rows(
 
 
 def append_row(path: Path, row: Mapping[str, Any]) -> None:
+    validate_row_shape(row)
     path.parent.mkdir(parents=True, exist_ok=True)
     line = json.dumps(
         row,

--- a/obench/gateway_probe_run.py
+++ b/obench/gateway_probe_run.py
@@ -1,0 +1,224 @@
+"""Schedule and orchestrate request-level Gateway Probe experiments."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import random
+from collections import defaultdict
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from . import gateway_run, gateway_spec
+from . import gateway_probe_http as probe_http
+from . import gateway_probe_results as probe_results
+from . import gateway_probe_spec as probe_spec
+from .gateway_probe_models import GatewayProbeRunError, ProbeBlock, RunSummary
+
+
+FROZEN_PRICES_ENV = gateway_run.FROZEN_PRICES_ENV
+
+
+def build_schedule(
+    experiment: probe_spec.GatewayProbeExperiment,
+) -> tuple[ProbeBlock, ...]:
+    """Interleave cold and warm matched blocks deterministically."""
+    rng = random.Random(experiment.schedule_seed)
+    by_condition: dict[str, list[tuple[probe_spec.ProbeCase, int]]] = {}
+    for condition in probe_spec.CONDITIONS:
+        coordinates = [
+            (case, repetition)
+            for repetition in range(1, experiment.repetitions + 1)
+            for case in experiment.cases
+        ]
+        rng.shuffle(coordinates)
+        by_condition[condition] = coordinates
+    first = rng.randrange(2)
+    blocks = []
+    arm_ids = [arm.arm_id for arm in experiment.arms]
+    total_per_condition = len(by_condition["cold"])
+    for index in range(total_per_condition * 2):
+        condition = probe_spec.CONDITIONS[(index + first) % 2]
+        case, repetition = by_condition[condition].pop()
+        order = list(arm_ids)
+        rotation = len(blocks) % len(order)
+        order = order[rotation:] + order[:rotation]
+        if (len(blocks) // len(order)) % 2:
+            order.reverse()
+        blocks.append(ProbeBlock(
+            case.case_id,
+            case.prompt_digest,
+            condition,
+            repetition,
+            tuple(order),
+        ))
+    return tuple(blocks)
+
+
+def validate_experiment(
+    path: str | os.PathLike[str],
+) -> probe_spec.GatewayProbeExperiment:
+    return probe_spec.load_experiment(path)
+
+
+def doctor_experiment(
+    path: str | os.PathLike[str],
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    experiment = validate_experiment(path)
+    env = dict(os.environ if environ is None else environ)
+    required_auth = sorted({arm.auth_env for arm in experiment.arms})
+    missing_auth = [name for name in required_auth if not env.get(name)]
+    prices, _snapshot = gateway_run.load_frozen_prices(env)
+    missing_prices = sorted(
+        {arm.canonical_model for arm in experiment.arms} - set(prices)
+    )
+    return {
+        "ok": not missing_auth and not missing_prices,
+        "experiment_id": experiment.experiment_id,
+        "experiment_digest": experiment.digest,
+        "arms": len(experiment.arms),
+        "cases": len(experiment.cases),
+        "blocks_per_condition": len(experiment.cases) * experiment.repetitions,
+        "missing_auth_envs": missing_auth,
+        "missing_price_models": missing_prices,
+        "live_requests": False,
+    }
+
+
+def run_experiment(
+    experiment_path: str | os.PathLike[str],
+    *,
+    results_path: str | os.PathLike[str],
+    environ: Mapping[str, str] | None = None,
+    force: bool = False,
+) -> RunSummary:
+    experiment = validate_experiment(experiment_path)
+    env = dict(os.environ if environ is None else environ)
+    prices, price_snapshot = gateway_run.load_frozen_prices(env)
+    missing_prices = sorted(
+        {arm.canonical_model for arm in experiment.arms} - set(prices)
+    )
+    if missing_prices:
+        raise GatewayProbeRunError(
+            "missing frozen prices for: " + ", ".join(missing_prices)
+        )
+    plans, secrets = probe_spec.compile_route_plans(
+        experiment,
+        environ=env,
+        admitted_auth_envs={arm.auth_env for arm in experiment.arms},
+    )
+    plans_by_arm = {plan.arm_id: plan for plan in plans}
+    arms_by_id = {arm.arm_id: arm for arm in experiment.arms}
+    cases_by_id = {case.case_id: case for case in experiment.cases}
+    schedule = build_schedule(experiment)
+    schedule_digest = gateway_spec.canonical_digest(
+        [dataclasses.asdict(block) for block in schedule]
+    )
+    price_digest = gateway_spec.canonical_digest(price_snapshot)
+    path = Path(results_path)
+    rows = probe_results.read_rows(path)
+    probe_results.validate_resume_rows(
+        rows,
+        experiment=experiment,
+        schedule=schedule,
+        schedule_digest=schedule_digest,
+        price_digest=price_digest,
+    )
+    by_coordinate: dict[
+        tuple[str, str, int], dict[int, list[dict[str, Any]]]
+    ] = defaultdict(lambda: defaultdict(list))
+    for row in rows:
+        identity = row["identity"]
+        schedule_item = identity["schedule"]
+        coordinate = (
+            identity["case"]["id"],
+            schedule_item["condition"],
+            schedule_item["repetition"],
+        )
+        by_coordinate[coordinate][schedule_item["block_attempt"]].append(row)
+    usd_cap = Decimal(experiment.budget.usd_cap)
+    spent = sum((probe_results.charged_cost(row) for row in rows), Decimal(0))
+    stop_for_budget = spent >= usd_cap or any(
+        isinstance(row.get("billing"), Mapping)
+        and row["billing"].get("stop_required") is True
+        for row in rows
+    )
+    appended = completed = replaced = skipped = 0
+    expected = {arm.arm_id for arm in experiment.arms}
+    scheduled_per_condition = len(experiment.cases) * experiment.repetitions
+    for block in schedule:
+        if stop_for_budget:
+            break
+        attempts = by_coordinate.get(block.coordinate, {})
+        latest = max(attempts) if attempts else -1
+        latest_arms = {
+            row["identity"]["arm"]["id"] for row in attempts.get(latest, [])
+        }
+        if latest >= 0 and latest_arms == expected and not force:
+            skipped += 1
+            continue
+        attempt = latest + 1
+        if latest >= 0:
+            replaced += 1
+        block_completed = True
+        for arm_id in block.arm_ids:
+            arm = arms_by_id[arm_id]
+            identity = probe_results.make_identity(
+                experiment,
+                arm,
+                block,
+                attempt,
+                schedule_digest,
+                price_digest,
+            )
+            result = probe_http.execute_request(
+                experiment=experiment,
+                case=cases_by_id[block.case_id],
+                block=block,
+                plan=plans_by_arm[arm_id],
+                secret=secrets.value_for(arm_id),
+                prices=prices,
+                remaining_usd_cap=usd_cap - spent,
+            )
+            row = {
+                "schema_version": probe_results.RESULT_SCHEMA_VERSION,
+                "benchmark": probe_results.BENCHMARK,
+                "cell_id": probe_results.cell_id(identity),
+                "identity": identity,
+                "expected_arm_ids": sorted(expected),
+                "scheduled_blocks_per_condition": scheduled_per_condition,
+                "arm_role": arm.route_kind,
+                "baseline": arm.baseline,
+                "model_match": experiment.model_match,
+                **result,
+            }
+            serialized = json.dumps(row, sort_keys=True)
+            for forbidden in (
+                cases_by_id[block.case_id].prompt,
+                probe_http.nonce(experiment.digest, block, "primer"),
+                probe_http.nonce(experiment.digest, block, "measured"),
+                secrets.value_for(arm_id),
+            ):
+                if forbidden and forbidden in serialized:
+                    raise GatewayProbeRunError(
+                        "private probe payload leaked into result row"
+                    )
+            probe_results.append_row(path, row)
+            appended += 1
+            spent += probe_results.charged_cost(result)
+            if (
+                result.get("billing", {}).get("stop_required") is True
+                or spent >= usd_cap
+            ):
+                stop_for_budget = True
+                block_completed = False
+                break
+        if not block_completed:
+            break
+        completed += 1
+    return RunSummary(path, appended, completed, replaced, skipped)

--- a/obench/gateway_probe_spec.py
+++ b/obench/gateway_probe_spec.py
@@ -1,0 +1,268 @@
+"""Immutable request-level Gateway Probe experiment schema."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import re
+import tomllib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from . import gateway_spec
+
+
+SCHEMA_VERSION = 1
+TRACK = "request_probe"
+CONDITIONS = ("cold", "warm")
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+_ROOT_FIELDS = {
+    "schema_version", "experiment_id", "track", "model_match",
+    "repetitions", "schedule_seed", "allow_private_endpoint",
+    "private_host_allowlist", "private_cidr_allowlist", "budget",
+    "cases", "arms",
+}
+_BUDGET_FIELDS = {"timeout_s", "max_output_tokens", "usd_cap"}
+_CASE_FIELDS = {"case_id", "prompt"}
+
+
+class GatewayProbeSpecError(ValueError):
+    """Raised when a Gateway Probe experiment is malformed or unsafe."""
+
+
+def _table(value: Any, path: str, fields: set[str]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GatewayProbeSpecError(f"{path} must be a table")
+    unknown = sorted(set(value) - fields)
+    if unknown:
+        raise GatewayProbeSpecError(f"{path} has unknown field: {unknown[0]}")
+    return value
+
+
+def _required(value: Mapping[str, Any], key: str, path: str) -> Any:
+    if key not in value:
+        raise GatewayProbeSpecError(f"{path} is missing {key}")
+    return value[key]
+
+
+def _string(value: Any, path: str, pattern: re.Pattern[str] | None = None) -> str:
+    if not isinstance(value, str) or not value:
+        raise GatewayProbeSpecError(f"{path} must be a non-empty string")
+    if pattern is not None and not pattern.fullmatch(value):
+        raise GatewayProbeSpecError(f"{path} has invalid characters")
+    return value
+
+
+def _integer(value: Any, path: str, minimum: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise GatewayProbeSpecError(f"{path} must be an integer >= {minimum}")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeBudget:
+    timeout_s: int
+    max_output_tokens: int
+    usd_cap: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeCase:
+    case_id: str
+    prompt: str
+
+    @property
+    def prompt_digest(self) -> str:
+        return gateway_spec.canonical_digest({"prompt": self.prompt})
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "case_id": self.case_id,
+            "prompt": self.prompt,
+            "prompt_digest": self.prompt_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayProbeExperiment:
+    schema_version: int
+    experiment_id: str
+    track: str
+    model_match: str
+    repetitions: int
+    schedule_seed: int
+    allow_private_endpoint: bool
+    private_host_allowlist: tuple[str, ...]
+    private_cidr_allowlist: tuple[str, ...]
+    budget: ProbeBudget
+    cases: tuple[ProbeCase, ...]
+    arms: tuple[gateway_spec.Arm, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "experiment_id": self.experiment_id,
+            "track": self.track,
+            "model_match": self.model_match,
+            "repetitions": self.repetitions,
+            "schedule_seed": self.schedule_seed,
+            "allow_private_endpoint": self.allow_private_endpoint,
+            "private_host_allowlist": list(self.private_host_allowlist),
+            "private_cidr_allowlist": list(self.private_cidr_allowlist),
+            "budget": self.budget.to_dict(),
+            "cases": [case.to_dict() for case in self.cases],
+            "arms": [arm.to_dict() for arm in self.arms],
+        }
+
+    @property
+    def digest(self) -> str:
+        return gateway_spec.canonical_digest(self.to_dict())
+
+
+def _parse_budget(value: Any) -> ProbeBudget:
+    table = _table(value, "budget", _BUDGET_FIELDS)
+    raw_cap = _required(table, "usd_cap", "budget")
+    if isinstance(raw_cap, bool) or not isinstance(raw_cap, (str, int, float)):
+        raise GatewayProbeSpecError("budget.usd_cap must be a positive decimal")
+    try:
+        cap = Decimal(str(raw_cap))
+    except InvalidOperation as exc:
+        raise GatewayProbeSpecError("budget.usd_cap must be a positive decimal") from exc
+    if not cap.is_finite() or cap <= 0:
+        raise GatewayProbeSpecError("budget.usd_cap must be a positive decimal")
+    return ProbeBudget(
+        timeout_s=_integer(_required(table, "timeout_s", "budget"), "budget.timeout_s", 1),
+        max_output_tokens=_integer(
+            _required(table, "max_output_tokens", "budget"),
+            "budget.max_output_tokens",
+            1,
+        ),
+        usd_cap=str(cap),
+    )
+
+
+def _parse_cases(value: Any) -> tuple[ProbeCase, ...]:
+    if not isinstance(value, list) or not value:
+        raise GatewayProbeSpecError("cases must contain at least one case table")
+    cases = []
+    for index, raw in enumerate(value):
+        path = f"cases[{index}]"
+        table = _table(raw, path, _CASE_FIELDS)
+        cases.append(ProbeCase(
+            case_id=_string(_required(table, "case_id", path), f"{path}.case_id", _ID_RE),
+            prompt=_string(_required(table, "prompt", path), f"{path}.prompt"),
+        ))
+    if len({case.case_id for case in cases}) != len(cases):
+        raise GatewayProbeSpecError("cases must have unique case_id values")
+    return tuple(cases)
+
+
+def parse_experiment(data: Mapping[str, Any]) -> GatewayProbeExperiment:
+    table = _table(dict(data), "experiment", _ROOT_FIELDS)
+    version = _integer(
+        _required(table, "schema_version", "experiment"), "schema_version", 1
+    )
+    if version != SCHEMA_VERSION:
+        raise GatewayProbeSpecError(f"schema_version must be {SCHEMA_VERSION}")
+    track = _string(_required(table, "track", "experiment"), "track")
+    if track != TRACK:
+        raise GatewayProbeSpecError(f"track must be {TRACK!r}")
+    model_match = _string(table.get("model_match", "exact_revision"), "model_match")
+    if model_match not in gateway_spec.MODEL_MATCHES:
+        raise GatewayProbeSpecError("model_match is unsupported")
+    allow_private = table.get("allow_private_endpoint", False)
+    if not isinstance(allow_private, bool):
+        raise GatewayProbeSpecError("allow_private_endpoint must be a boolean")
+    try:
+        hosts, cidrs = gateway_spec.parse_endpoint_allowlists(table, allow_private)
+        raw_arms = _required(table, "arms", "experiment")
+        if not isinstance(raw_arms, list) or len(raw_arms) < 2:
+            raise GatewayProbeSpecError("arms must contain at least two arm tables")
+        arms = tuple(
+            gateway_spec.parse_route_arm(
+                raw,
+                index,
+                allow_private_endpoint=allow_private,
+                private_host_allowlist=hosts,
+                private_cidr_allowlist=cidrs,
+            )
+            for index, raw in enumerate(raw_arms)
+        )
+        gateway_spec.validate_fixed_route_arms(arms)
+    except gateway_spec.GatewaySpecError as exc:
+        raise GatewayProbeSpecError(str(exc)) from exc
+    protocols = {arm.protocol for arm in arms}
+    if len(protocols) != 1:
+        raise GatewayProbeSpecError("all arms must use the same protocol")
+    return GatewayProbeExperiment(
+        schema_version=version,
+        experiment_id=_string(
+            _required(table, "experiment_id", "experiment"), "experiment_id", _ID_RE
+        ),
+        track=track,
+        model_match=model_match,
+        repetitions=_integer(
+            _required(table, "repetitions", "experiment"), "repetitions", 1
+        ),
+        schedule_seed=_integer(
+            _required(table, "schedule_seed", "experiment"), "schedule_seed", 0
+        ),
+        allow_private_endpoint=allow_private,
+        private_host_allowlist=hosts,
+        private_cidr_allowlist=cidrs,
+        budget=_parse_budget(_required(table, "budget", "experiment")),
+        cases=_parse_cases(_required(table, "cases", "experiment")),
+        arms=arms,
+    )
+
+
+def parse_experiment_toml(text: str, *, source: str = "<string>") -> GatewayProbeExperiment:
+    try:
+        raw = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise GatewayProbeSpecError(f"invalid Gateway Probe TOML in {source}: {exc}") from exc
+    try:
+        return parse_experiment(raw)
+    except GatewayProbeSpecError as exc:
+        raise GatewayProbeSpecError(f"invalid Gateway Probe experiment in {source}: {exc}") from exc
+
+
+def load_experiment(path: str | os.PathLike[str]) -> GatewayProbeExperiment:
+    source = Path(path)
+    try:
+        text = source.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise GatewayProbeSpecError(f"cannot read Gateway Probe experiment {source}: {exc}") from exc
+    return parse_experiment_toml(text, source=str(source))
+
+
+def compile_route_plans(
+    experiment: GatewayProbeExperiment,
+    *,
+    environ: Mapping[str, str],
+    admitted_auth_envs: set[str] | frozenset[str],
+) -> tuple[tuple[gateway_spec.RoutePlan, ...], gateway_spec.SecretPlan]:
+    if not isinstance(experiment, GatewayProbeExperiment):
+        raise TypeError("experiment must be a GatewayProbeExperiment")
+    source = experiment.to_dict()
+    for case in source["cases"]:
+        case.pop("prompt_digest")
+    experiment = parse_experiment(source)
+    return gateway_spec.compile_fixed_route_plans(
+        arms=experiment.arms,
+        experiment_digest=experiment.digest,
+        track=TRACK,
+        model_match=experiment.model_match,
+        provider_prompt_mode="provider_default",
+        allow_private_endpoint=experiment.allow_private_endpoint,
+        private_host_allowlist=experiment.private_host_allowlist,
+        private_cidr_allowlist=experiment.private_cidr_allowlist,
+        environ=environ,
+        admitted_auth_envs=admitted_auth_envs,
+    )

--- a/obench/gateway_profiles.py
+++ b/obench/gateway_profiles.py
@@ -25,11 +25,7 @@ _CLOUDFLARE_REST_ENDPOINT_RE = re.compile(
     r"(?P<account_id>[0-9a-fA-F]{32})/ai/v1/"
     r"(?P<operation>chat/completions|responses)"
 )
-_CLOUDFLARE_COMPAT_ENDPOINT_RE = re.compile(
-    r"https://gateway\.ai\.cloudflare\.com/v1/"
-    r"(?P<account_id>[0-9a-fA-F]{32})/"
-    r"(?P<gateway_id>[A-Za-z0-9][A-Za-z0-9_-]*)/compat/chat/completions"
-)
+_GATEWAY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _CACHE_KEYS = frozenset({
     "cache",
     "cache_control",
@@ -122,6 +118,7 @@ def validate_arm(
     *,
     route_kind: str,
     gateway: str | None,
+    gateway_id: str | None = None,
     endpoint: str,
     protocol: str,
     requested_model: str,
@@ -132,12 +129,24 @@ def validate_arm(
     if route_kind == "direct":
         if gateway is not None:
             raise GatewayProfileError("direct arm must not declare gateway")
+        if gateway_id is not None:
+            raise GatewayProfileError("direct arm must not declare gateway_id")
         return
     if gateway is None:
         raise GatewayProfileError("gateway arm requires gateway")
     if gateway not in GATEWAYS:
         raise GatewayProfileError(
             f"gateway must be one of: {', '.join(sorted(GATEWAYS))}"
+        )
+    if gateway != "cloudflare" and gateway_id is not None:
+        raise GatewayProfileError(
+            "gateway_id is supported only for cloudflare managed gateway arms"
+        )
+    if gateway == "cloudflare" and (
+        gateway_id is None or _GATEWAY_ID_RE.fullmatch(gateway_id) is None
+    ):
+        raise GatewayProfileError(
+            "cloudflare managed gateway arm requires a valid gateway_id"
         )
     if gateway == "concentrate":
         if (
@@ -151,6 +160,25 @@ def validate_arm(
         if _model_provider(requested_model) != requested_provider.casefold():
             raise GatewayProfileError(
                 "concentrate requested_model must be provider-qualified with "
+                "requested_provider"
+            )
+    if gateway == "cloudflare":
+        rest_match = _CLOUDFLARE_REST_ENDPOINT_RE.fullmatch(endpoint)
+        expected_operation = (
+            "responses" if protocol == "openai_responses" else "chat/completions"
+        )
+        if rest_match is None or rest_match.group("operation") != expected_operation:
+            raise GatewayProfileError(
+                "cloudflare managed endpoint must be "
+                "https://api.cloudflare.com/client/v4/accounts/"
+                "{32-hex-account-id}/ai/v1/{chat/completions|responses}"
+            )
+        if (
+            _model_provider(requested_model) is None
+            or not model_provider_matches(requested_model, requested_provider)
+        ):
+            raise GatewayProfileError(
+                "cloudflare requested_model must be provider-qualified with "
                 "requested_provider"
             )
 
@@ -169,34 +197,6 @@ def validate_arm(
             raise GatewayProfileError(
                 "vercel requested_model must be a provider-qualified model ID"
             )
-    if gateway == "cloudflare":
-        rest_match = _CLOUDFLARE_REST_ENDPOINT_RE.fullmatch(endpoint)
-        compat_match = _CLOUDFLARE_COMPAT_ENDPOINT_RE.fullmatch(endpoint)
-        expected_operation = (
-            "responses" if protocol == "openai_responses" else "chat/completions"
-        )
-        if (
-            (rest_match is None or rest_match.group("operation") != expected_operation)
-            and (compat_match is None or protocol != "openai_chat")
-        ):
-            raise GatewayProfileError(
-                "cloudflare endpoint must be either "
-                "https://api.cloudflare.com/client/v4/accounts/"
-                "{32-hex-account-id}/ai/v1/{chat/completions|responses} or "
-                "https://gateway.ai.cloudflare.com/v1/"
-                "{32-hex-account-id}/{gateway-id}/compat/chat/completions; metadata-only "
-                "Logs API verification is required for other Cloudflare routes"
-            )
-        if (
-            _model_provider(requested_model) is None
-            or not model_provider_matches(requested_model, requested_provider)
-        ):
-            raise GatewayProfileError(
-                "cloudflare requested_model must be provider-qualified with "
-                "requested_provider"
-            )
-
-
 def _strip_cache_controls(value: Any) -> None:
     if isinstance(value, dict):
         for key in list(value):
@@ -269,6 +269,7 @@ def request_headers(
     *,
     gateway: str | None,
     secret: str,
+    gateway_id: str | None = None,
 ) -> dict[str, str]:
     """Return authoritative auth and gateway control headers."""
     headers = {"Authorization": f"Bearer {secret}"}
@@ -280,7 +281,12 @@ def request_headers(
             "X-OpenRouter-Cache": "false",
         })
     elif gateway == "cloudflare":
+        if gateway_id is None or _GATEWAY_ID_RE.fullmatch(gateway_id) is None:
+            raise GatewayProfileError(
+                "cloudflare managed requests require a valid gateway_id"
+            )
         headers.update({
+            "cf-aig-gateway-id": gateway_id,
             "cf-aig-skip-cache": "true",
             "cf-aig-max-attempts": "1",
             "cf-aig-collect-log-payload": "false",

--- a/obench/gateway_publish.py
+++ b/obench/gateway_publish.py
@@ -338,6 +338,7 @@ _EXPERIMENT_ARM_SCHEMA = {
     "arm_digest": _SCALAR,
     "route_kind": _SCALAR,
     "gateway": _SCALAR,
+    "gateway_id": _SCALAR,
     "protocol": _SCALAR,
     "baseline": _SCALAR,
     "canonical_model": _SCALAR,
@@ -564,6 +565,8 @@ def _experiment_dto(source: Mapping[str, Any], source_digest: str) -> dict[str, 
         }
         if "gateway" in arm:
             public_arm["gateway"] = arm["gateway"]
+        if "gateway_id" in arm:
+            public_arm["gateway_id"] = arm["gateway_id"]
         arms.append(public_arm)
     return {
         "kind": "experiment",

--- a/obench/gateway_run.py
+++ b/obench/gateway_run.py
@@ -742,6 +742,21 @@ def _cache_accounting(metrics: Mapping[str, Any]) -> dict[str, int | None]:
     }
 
 
+def price_call(
+    metrics: Mapping[str, Any],
+    prices: Mapping[str, Price],
+    plan: gateway_spec.RoutePlan,
+    observed_at: Any,
+) -> tuple[dict[str, Any], Decimal | None]:
+    """Public request-level accounting wrapper shared by gateway tracks."""
+    return _price_call(metrics, prices, plan, observed_at)
+
+
+def cache_accounting(metrics: Mapping[str, Any]) -> dict[str, int | None]:
+    """Return normalized cache token counts from privacy-safe metrics."""
+    return _cache_accounting(metrics)
+
+
 def _token_accounting(metrics: Mapping[str, Any]) -> dict[str, int | None]:
     usage = metrics.get("usage")
     usage = usage if isinstance(usage, Mapping) else {}

--- a/obench/gateway_spec.py
+++ b/obench/gateway_spec.py
@@ -137,6 +137,7 @@ class Arm:
     sampling: Sampling
     direct_control_arm_id: str | None = None
     gateway: str | None = None
+    gateway_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         result = {
@@ -159,6 +160,8 @@ class Arm:
         }
         if self.gateway is not None:
             result["gateway"] = self.gateway
+        if self.gateway_id is not None:
+            result["gateway_id"] = self.gateway_id
         return result
 
     @property
@@ -241,6 +244,7 @@ class RoutePlan:
     # Proxy-only controls. They are bound by arm_digest but intentionally
     # omitted from the adapter-facing route-plan JSON.
     gateway: str | None = None
+    gateway_id: str | None = None
     track: str = TRACK
     model_match: str = "exact_revision"
     provider_prompt_mode: str = "provider_default"
@@ -322,7 +326,7 @@ _ARM_FIELDS = {
     "arm_id", "route_kind", "endpoint", "protocol", "baseline",
     "canonical_model", "requested_model", "requested_provider", "allowed_models",
     "allowed_providers", "fallback_enabled", "retry_count", "cache_enabled",
-    "auth_env", "sampling", "direct_control_arm_id", "gateway",
+    "auth_env", "sampling", "direct_control_arm_id", "gateway", "gateway_id",
 }
 
 
@@ -566,6 +570,9 @@ def _parse_arm(
     gateway = table.get("gateway")
     if gateway is not None:
         gateway = _string(gateway, f"{path}.gateway")
+    gateway_id = table.get("gateway_id")
+    if gateway_id is not None:
+        gateway_id = _string(gateway_id, f"{path}.gateway_id", _ID_RE)
     arm = Arm(
         arm_id=_string(_required(table, "arm_id", path), f"{path}.arm_id", _ID_RE),
         route_kind=route_kind,
@@ -592,6 +599,7 @@ def _parse_arm(
         sampling=_parse_sampling(_required(table, "sampling", path), f"{path}.sampling"),
         direct_control_arm_id=direct_control,
         gateway=gateway,
+        gateway_id=gateway_id,
     )
     if arm.requested_model not in arm.allowed_models:
         raise GatewaySpecError(f"{path}.allowed_models must contain requested_model")
@@ -610,10 +618,13 @@ def _parse_arm(
         raise GatewaySpecError(f"{path}: gateway arm requires direct_control_arm_id")
     if arm.route_kind == "direct" and "gateway" in table:
         raise GatewaySpecError(f"{path}: direct arm must not declare gateway")
+    if arm.route_kind == "direct" and "gateway_id" in table:
+        raise GatewaySpecError(f"{path}: direct arm must not declare gateway_id")
     try:
         gateway_profiles.validate_arm(
             route_kind=arm.route_kind,
             gateway=arm.gateway,
+            gateway_id=arm.gateway_id,
             endpoint=arm.endpoint,
             protocol=arm.protocol,
             requested_model=arm.requested_model,
@@ -949,6 +960,7 @@ def compile_fixed_route_plans(
             private_host_allowlist=hosts,
             private_cidr_allowlist=cidrs,
             gateway=arm.gateway,
+            gateway_id=arm.gateway_id,
         ))
         secrets.append(_ArmSecret(arm.arm_id, arm.auth_env, value))
     return tuple(plans), SecretPlan(tuple(secrets))

--- a/obench/gateway_spec.py
+++ b/obench/gateway_spec.py
@@ -238,8 +238,8 @@ class RoutePlan:
     allow_private_endpoint: bool
     private_host_allowlist: tuple[str, ...]
     private_cidr_allowlist: tuple[str, ...]
-    # Proxy-only controls. They are bound by the experiment or arm digest but
-    # intentionally omitted from the adapter-facing route-plan JSON.
+    # Proxy-only controls. They are bound by arm_digest but intentionally
+    # omitted from the adapter-facing route-plan JSON.
     gateway: str | None = None
     track: str = TRACK
     model_match: str = "exact_revision"
@@ -691,6 +691,14 @@ def _parse_allowlists(table: Mapping[str, Any], allow_private_endpoint: bool) ->
     return hosts, tuple(cidrs)
 
 
+def parse_endpoint_allowlists(
+    data: Mapping[str, Any],
+    allow_private_endpoint: bool,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Validate endpoint allowlists for another gateway experiment surface."""
+    return _parse_allowlists(data, allow_private_endpoint)
+
+
 def _normalize_hostname(value: str, path: str, *, allow_ip: bool = False) -> str:
     hostname = value.strip().rstrip(".").lower()
     try:
@@ -706,6 +714,29 @@ def _normalize_hostname(value: str, path: str, *, allow_ip: bool = False) -> str
             or any(not _HOST_LABEL_RE.fullmatch(label) for label in labels)):
         raise GatewaySpecError(f"{path} must be a bare DNS hostname")
     return hostname
+
+
+def parse_route_arm(
+    value: Any,
+    index: int,
+    *,
+    allow_private_endpoint: bool,
+    private_host_allowlist: tuple[str, ...],
+    private_cidr_allowlist: tuple[str, ...],
+) -> Arm:
+    """Parse one route arm without imposing a benchmark scheduling contract."""
+    return _parse_arm(
+        value,
+        index,
+        allow_private_endpoint,
+        private_host_allowlist,
+        private_cidr_allowlist,
+    )
+
+
+def validate_fixed_route_arms(arms: tuple[Arm, ...]) -> None:
+    """Require the fixed direct-control comparison used by gateway tracks."""
+    _validate_gateway_controls(arms)
 
 
 def parse_experiment(data: Mapping[str, Any]) -> GatewayExperiment:
@@ -825,22 +856,57 @@ def load_experiment(path: str | os.PathLike[str]) -> GatewayExperiment:
     return parse_experiment_toml(text, source=str(resolved))
 
 
-def compile_route_plans(
-    experiment: GatewayExperiment,
+def compile_fixed_route_plans(
     *,
+    arms: tuple[Arm, ...],
+    experiment_digest: str,
+    track: str,
+    model_match: str,
+    provider_prompt_mode: str,
+    allow_private_endpoint: bool,
+    private_host_allowlist: tuple[str, ...],
+    private_cidr_allowlist: tuple[str, ...],
     environ: Mapping[str, str],
     admitted_auth_envs: set[str] | frozenset[str],
 ) -> tuple[tuple[RoutePlan, ...], SecretPlan]:
-    """Compile sanitized route plans and admitted in-memory credentials."""
-    if not isinstance(experiment, GatewayExperiment):
-        raise TypeError("experiment must be a GatewayExperiment")
-    # Public dataclasses are convenient value types, but parsing remains the
-    # validation boundary. Reparse here so hand-built instances cannot bypass it.
-    experiment = parse_experiment(experiment.to_dict())
+    """Compile one validated direct-control route set for any gateway track."""
+    if not isinstance(experiment_digest, str) or not re.fullmatch(
+        r"[0-9a-f]{64}", experiment_digest
+    ):
+        raise GatewaySpecError("experiment_digest must be a lowercase SHA-256 digest")
+    if not isinstance(track, str) or not track:
+        raise GatewaySpecError("track must be a non-empty string")
+    if model_match not in MODEL_MATCHES:
+        raise GatewaySpecError("model_match is unsupported")
+    if provider_prompt_mode not in PROVIDER_PROMPT_MODES:
+        raise GatewaySpecError("provider_prompt_mode is unsupported")
+    if not isinstance(allow_private_endpoint, bool):
+        raise GatewaySpecError("allow_private_endpoint must be a boolean")
+    if (
+        not isinstance(private_host_allowlist, tuple)
+        or any(not isinstance(item, str) for item in private_host_allowlist)
+        or not isinstance(private_cidr_allowlist, tuple)
+        or any(not isinstance(item, str) for item in private_cidr_allowlist)
+    ):
+        raise GatewaySpecError("private endpoint allowlists must be tuples of strings")
+    policy = {
+        "private_host_allowlist": list(private_host_allowlist),
+        "private_cidr_allowlist": list(private_cidr_allowlist),
+    }
+    hosts, cidrs = _parse_allowlists(policy, allow_private_endpoint)
+    if not isinstance(arms, tuple) or not arms or any(
+        not isinstance(arm, Arm) for arm in arms
+    ):
+        raise GatewaySpecError("arms must be a non-empty tuple of Arm values")
+    validated_arms = tuple(
+        _parse_arm(arm.to_dict(), index, allow_private_endpoint, hosts, cidrs)
+        for index, arm in enumerate(arms)
+    )
+    _validate_gateway_controls(validated_arms)
     admitted = frozenset(admitted_auth_envs)
     if any(not isinstance(name, str) for name in admitted):
         raise GatewaySpecError("admitted_auth_envs must contain environment variable names")
-    declared = frozenset(arm.auth_env for arm in experiment.arms)
+    declared = frozenset(arm.auth_env for arm in validated_arms)
     unexpected = sorted(admitted - declared)
     if unexpected:
         raise GatewaySpecError(
@@ -848,7 +914,7 @@ def compile_route_plans(
         )
     plans: list[RoutePlan] = []
     secrets: list[_ArmSecret] = []
-    for arm in experiment.arms:
+    for arm in validated_arms:
         if arm.auth_env not in admitted:
             raise GatewaySpecError(
                 f"auth environment variable {arm.auth_env!r} is not explicitly admitted"
@@ -860,10 +926,10 @@ def compile_route_plans(
             )
         plans.append(RoutePlan(
             schema_version=SCHEMA_VERSION,
-            experiment_digest=experiment.digest,
-            track=experiment.track,
-            model_match=experiment.model_match,
-            provider_prompt_mode=experiment.provider_prompt_mode,
+            experiment_digest=experiment_digest,
+            track=track,
+            model_match=model_match,
+            provider_prompt_mode=provider_prompt_mode,
             arm_digest=arm.digest,
             arm_id=arm.arm_id,
             route_kind=arm.route_kind,
@@ -879,13 +945,39 @@ def compile_route_plans(
             cache_enabled=arm.cache_enabled,
             auth_env=arm.auth_env,
             sampling=arm.sampling,
-            allow_private_endpoint=experiment.allow_private_endpoint,
-            private_host_allowlist=experiment.private_host_allowlist,
-            private_cidr_allowlist=experiment.private_cidr_allowlist,
+            allow_private_endpoint=allow_private_endpoint,
+            private_host_allowlist=hosts,
+            private_cidr_allowlist=cidrs,
             gateway=arm.gateway,
         ))
         secrets.append(_ArmSecret(arm.arm_id, arm.auth_env, value))
     return tuple(plans), SecretPlan(tuple(secrets))
+
+
+def compile_route_plans(
+    experiment: GatewayExperiment,
+    *,
+    environ: Mapping[str, str],
+    admitted_auth_envs: set[str] | frozenset[str],
+) -> tuple[tuple[RoutePlan, ...], SecretPlan]:
+    """Compile sanitized route plans and admitted in-memory credentials."""
+    if not isinstance(experiment, GatewayExperiment):
+        raise TypeError("experiment must be a GatewayExperiment")
+    # Public dataclasses are convenient value types, but parsing remains the
+    # validation boundary. Reparse here so hand-built instances cannot bypass it.
+    experiment = parse_experiment(experiment.to_dict())
+    return compile_fixed_route_plans(
+        arms=experiment.arms,
+        experiment_digest=experiment.digest,
+        track=experiment.track,
+        model_match=experiment.model_match,
+        provider_prompt_mode=experiment.provider_prompt_mode,
+        allow_private_endpoint=experiment.allow_private_endpoint,
+        private_host_allowlist=experiment.private_host_allowlist,
+        private_cidr_allowlist=experiment.private_cidr_allowlist,
+        environ=environ,
+        admitted_auth_envs=admitted_auth_envs,
+    )
 
 
 # Explicit aliases make call sites readable while retaining one parser contract.

--- a/obench/proxy.py
+++ b/obench/proxy.py
@@ -705,6 +705,7 @@ class CountingProxyHandler(BaseHTTPRequestHandler):
         }
         headers.update(gateway_profiles.request_headers(
             gateway=route.gateway_route.plan.gateway,
+            gateway_id=route.gateway_route.plan.gateway_id,
             secret=route.gateway_route.secret,
         ))
         headers["Content-Length"] = str(body_length)
@@ -906,6 +907,7 @@ class CountingProxyServer(ThreadingHTTPServer):
             gateway_profiles.validate_arm(
                 route_kind=plan.route_kind,
                 gateway=plan.gateway,
+                gateway_id=plan.gateway_id,
                 endpoint=plan.endpoint,
                 protocol=plan.protocol,
                 requested_model=plan.requested_model,

--- a/obench/tests/test_gateway_probe_cli.py
+++ b/obench/tests/test_gateway_probe_cli.py
@@ -1,12 +1,19 @@
 import contextlib
 import io
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
-from obench import gateway_cli, gateway_probe_cli, gateway_probe_run
+from obench import (
+    gateway_cli,
+    gateway_probe_cli,
+    gateway_probe_results,
+    gateway_probe_run,
+    gateway_probe_spec,
+)
 from obench.gateway_probe_models import RunSummary
 from obench.tests.test_gateway_probe_report import row
 from obench.tests.test_gateway_probe_spec import manifest
@@ -119,7 +126,237 @@ class GatewayProbeCliTests(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("Gateway Probe (exploratory)", stdout.getvalue())
         self.assertIn("| Arm | Condition |", stdout.getvalue())
-        self.assertIn("| Gateway | Condition | Median delta TTFT |", stdout.getvalue())
+        self.assertIn("| Gateway | Condition | Phase metric |", stdout.getvalue())
+
+    def test_benchmark_writes_self_contained_resumable_bundle(self):
+        prices = json.dumps({
+            "openai/gpt-4o-mini": {
+                "input_per_million": "1",
+                "output_per_million": "2",
+                "effective_at": "2026-07-25T00:00:00Z",
+            }
+        })
+        environ = {
+            "OPENAI_API_KEY": "direct-secret",
+            "OPENROUTER_API_KEY": "gateway-secret",
+            gateway_probe_run.FROZEN_PRICES_ENV: prices,
+        }
+
+        def fake_run(_experiment, *, results_path, **_kwargs):
+            experiment = gateway_probe_spec.load_experiment(_experiment)
+            arms = {arm.arm_id: arm for arm in experiment.arms}
+            rows = [
+                row("direct", "cold", 1, baseline=True),
+                row("gateway", "cold", 1),
+                row("direct", "warm", 1, baseline=True),
+                row("gateway", "warm", 1),
+            ]
+            for item in rows:
+                item["scheduled_blocks_per_condition"] = 1
+                item["identity"]["experiment"] = {
+                    "id": experiment.experiment_id,
+                    "digest": experiment.digest,
+                }
+                arm_id = item["identity"]["arm"]["id"]
+                item["identity"]["arm"]["digest"] = arms[arm_id].digest
+                item["model_match"] = experiment.model_match
+                item["cell_id"] = gateway_probe_results.cell_id(
+                    item["identity"]
+                )
+            path = Path(results_path)
+            path.write_text(
+                "".join(json.dumps(item, sort_keys=True) + "\n" for item in rows),
+                encoding="utf-8",
+            )
+            return RunSummary(path, 4, 2, 0, 0)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp, "probe.toml")
+            output = Path(tmp, "bundle")
+            source = manifest()
+            spec.write_text(source, encoding="utf-8")
+            with mock.patch.object(
+                gateway_probe_run,
+                "run_experiment",
+                side_effect=fake_run,
+            ) as run:
+                with mock.patch.dict(os.environ, environ, clear=True):
+                    code = gateway_probe_cli.main([
+                        "benchmark",
+                        str(spec),
+                        "--output-dir",
+                        str(output),
+                    ])
+                resume_environ = {
+                    "OPENAI_API_KEY": "direct-secret",
+                    "OPENROUTER_API_KEY": "gateway-secret",
+                }
+                with mock.patch.dict(
+                    os.environ,
+                    resume_environ,
+                    clear=True,
+                ):
+                    resumed_code = gateway_probe_cli.main([
+                        "benchmark",
+                        str(spec),
+                        "--output-dir",
+                        str(output),
+                    ])
+            self.assertEqual(code, 0)
+            self.assertEqual(resumed_code, 0)
+            self.assertEqual(
+                {path.name for path in output.iterdir()},
+                {
+                    "experiment.toml",
+                    "prices.json",
+                    "results.jsonl",
+                    "report.md",
+                    "report.json",
+                    "manifest.json",
+                },
+            )
+            self.assertEqual((output / "experiment.toml").read_text(), source)
+            bundle_text = "\n".join(
+                path.read_text(encoding="utf-8")
+                for path in output.iterdir()
+            )
+            self.assertNotIn("direct-secret", bundle_text)
+            self.assertNotIn("gateway-secret", bundle_text)
+            self.assertIn(
+                "Request to response headers",
+                (output / "report.md").read_text(),
+            )
+            manifest_data = json.loads((output / "manifest.json").read_text())
+            self.assertEqual(manifest_data["result_schema_version"], 3)
+            self.assertEqual(set(manifest_data["files"]), {
+                "experiment.toml",
+                "prices.json",
+                "results.jsonl",
+                "report.md",
+                "report.json",
+            })
+            self.assertTrue(
+                Path(run.call_args.args[0]).samefile(
+                    output / "experiment.toml"
+                )
+            )
+            self.assertEqual(run.call_count, 2)
+            self.assertIn(
+                gateway_probe_run.FROZEN_PRICES_ENV,
+                run.call_args.kwargs["environ"],
+            )
+            stderr = io.StringIO()
+            with (
+                mock.patch.dict(os.environ, environ, clear=True),
+                mock.patch.object(
+                    gateway_probe_run,
+                    "run_experiment",
+                    side_effect=OSError("simulated run failure"),
+                ),
+                contextlib.redirect_stderr(stderr),
+            ):
+                failed_code = gateway_probe_cli.main([
+                    "benchmark",
+                    str(spec),
+                    "--output-dir",
+                    str(output),
+                ])
+            self.assertEqual(failed_code, 2)
+            self.assertTrue((output / "results.jsonl").exists())
+            self.assertTrue((output / "experiment.toml").exists())
+            self.assertTrue((output / "prices.json").exists())
+            self.assertFalse((output / "report.md").exists())
+            self.assertFalse((output / "report.json").exists())
+            self.assertFalse((output / "manifest.json").exists())
+
+    def test_benchmark_doctor_failure_creates_no_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp, "probe.toml")
+            output = Path(tmp, "bundle")
+            spec.write_text(manifest(), encoding="utf-8")
+            stderr = io.StringIO()
+            with (
+                mock.patch.dict(os.environ, {}, clear=True),
+                contextlib.redirect_stderr(stderr),
+            ):
+                code = gateway_probe_cli.main([
+                    "benchmark",
+                    str(spec),
+                    "--output-dir",
+                    str(output),
+                ])
+            self.assertEqual(code, 2)
+            self.assertFalse(output.exists())
+            self.assertIn("doctor failed", stderr.getvalue())
+
+    def test_benchmark_reports_a_valid_first_block_partial_stop(self):
+        environ = {
+            "OPENAI_API_KEY": "direct-secret",
+            "OPENROUTER_API_KEY": "gateway-secret",
+            gateway_probe_run.FROZEN_PRICES_ENV: json.dumps({
+                "openai/gpt-4o-mini": {
+                    "input_per_million": "1",
+                    "output_per_million": "2",
+                    "effective_at": "2026-07-25T00:00:00Z",
+                }
+            }),
+        }
+
+        def partial_run(experiment_path, *, results_path, **_kwargs):
+            experiment = gateway_probe_spec.load_experiment(experiment_path)
+            direct = next(
+                arm for arm in experiment.arms if arm.arm_id == "direct"
+            )
+            item = row("direct", "cold", 1, baseline=True)
+            item["identity"]["experiment"] = {
+                "id": experiment.experiment_id,
+                "digest": experiment.digest,
+            }
+            item["identity"]["arm"]["digest"] = direct.digest
+            item["model_match"] = experiment.model_match
+            item["billing"]["stop_required"] = True
+            item["outcome"]["budget_exhausted_reason"] = "usd_cap_reached"
+            item["cell_id"] = gateway_probe_results.cell_id(item["identity"])
+            path = Path(results_path)
+            path.write_text(
+                json.dumps(item, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            return RunSummary(path, 1, 0, 0, 0)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp, "probe.toml")
+            output = Path(tmp, "bundle")
+            spec.write_text(manifest(), encoding="utf-8")
+            with (
+                mock.patch.dict(os.environ, environ, clear=True),
+                mock.patch.object(
+                    gateway_probe_run,
+                    "run_experiment",
+                    side_effect=partial_run,
+                ),
+            ):
+                code = gateway_probe_cli.main([
+                    "benchmark",
+                    str(spec),
+                    "--output-dir",
+                    str(output),
+                ])
+            self.assertEqual(code, 0)
+            report = json.loads((output / "report.json").read_text())
+            self.assertEqual(
+                report["arms"]["gateway"]["conditions"]["cold"][
+                    "denominators"
+                ]["attempted"],
+                0,
+            )
+            self.assertEqual(
+                report["paired_contrasts"]["gateway"]["cold"][
+                    "request_stream_total_s"
+                ]["coverage"],
+                {"covered": 0, "ratio": 0.0, "total": 0},
+            )
+            self.assertTrue((output / "manifest.json").exists())
 
 
 if __name__ == "__main__":

--- a/obench/tests/test_gateway_probe_cli.py
+++ b/obench/tests/test_gateway_probe_cli.py
@@ -1,0 +1,126 @@
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from obench import gateway_cli, gateway_probe_cli, gateway_probe_run
+from obench.gateway_probe_models import RunSummary
+from obench.tests.test_gateway_probe_report import row
+from obench.tests.test_gateway_probe_spec import manifest
+
+
+class GatewayProbeCliTests(unittest.TestCase):
+    def test_checked_in_minimal_and_four_way_examples_validate_through_cli(self):
+        examples = Path(__file__).parents[1] / "examples"
+        cases = (
+            ("gateway-probe-responses.toml", "arms=2"),
+            ("gateway-probe-four-way-responses.toml", "arms=4"),
+        )
+        for filename, expected in cases:
+            with self.subTest(filename=filename):
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    code = gateway_probe_cli.main([
+                        "validate",
+                        str(examples / filename),
+                    ])
+                self.assertEqual(code, 0)
+                self.assertIn(expected, stdout.getvalue())
+
+    def test_gateway_dispatches_nested_probe_validate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp, "probe.toml")
+            spec.write_text(manifest(), encoding="utf-8")
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = gateway_cli.main(["probe", "validate", str(spec)])
+        self.assertEqual(code, 0)
+        self.assertIn("valid probe=probe-test", stdout.getvalue())
+
+    def test_doctor_is_offline_and_fails_closed_for_missing_inputs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp, "probe.toml")
+            spec.write_text(manifest(), encoding="utf-8")
+            with mock.patch.dict("os.environ", {}, clear=True):
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    code = gateway_probe_cli.main(["doctor", str(spec)])
+        self.assertEqual(code, 2)
+        self.assertIn('"live_requests": false', stdout.getvalue())
+        self.assertIn("OPENAI_API_KEY", stdout.getvalue())
+
+    def test_run_dispatches_without_live_request_when_runner_is_mocked(self):
+        summary = RunSummary(Path("out.jsonl"), 4, 2, 0, 0)
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp, "probe.toml")
+            spec.write_text(manifest(), encoding="utf-8")
+            with mock.patch.object(
+                gateway_probe_run, "run_experiment", return_value=summary
+            ) as run:
+                code = gateway_probe_cli.main(["run", str(spec), "--results", "out.jsonl"])
+        self.assertEqual(code, 0)
+        run.assert_called_once()
+
+    def test_malformed_prices_and_missing_credentials_exit_two_without_traceback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = Path(tmp, "probe.toml")
+            spec.write_text(manifest(), encoding="utf-8")
+            cases = [
+                (
+                    ["doctor", str(spec)],
+                    {gateway_probe_run.FROZEN_PRICES_ENV: "{bad-json"},
+                    "not valid JSON",
+                ),
+                (
+                    ["run", str(spec), "--results", str(Path(tmp, "out.jsonl"))],
+                    {
+                        gateway_probe_run.FROZEN_PRICES_ENV: json.dumps({
+                            "openai/gpt-4o-mini": {
+                                "input_per_million": "1",
+                                "output_per_million": "2",
+                                "effective_at": "2026-07-25T00:00:00Z",
+                            }
+                        })
+                    },
+                    "missing or empty",
+                ),
+            ]
+            for argv, environ, expected in cases:
+                with self.subTest(command=argv[0]):
+                    stderr = io.StringIO()
+                    with mock.patch.dict("os.environ", environ, clear=True):
+                        with contextlib.redirect_stderr(stderr):
+                            code = gateway_probe_cli.main(argv)
+                    self.assertEqual(code, 2)
+                    self.assertIn(expected, stderr.getvalue())
+                    self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_report_cli_renders_publishable_tables(self):
+        rows = [
+            row("direct", "cold", 1, baseline=True),
+            row("gateway", "cold", 1, total=1.5),
+            row("direct", "warm", 1, baseline=True),
+            row("gateway", "warm", 1, total=1.5),
+        ]
+        for item in rows:
+            item["scheduled_blocks_per_condition"] = 1
+        with tempfile.TemporaryDirectory() as tmp:
+            results = Path(tmp, "probe.jsonl")
+            results.write_text(
+                "".join(json.dumps(item, sort_keys=True) + "\n" for item in rows),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = gateway_probe_cli.main(["report", str(results)])
+        self.assertEqual(code, 0)
+        self.assertIn("Gateway Probe (exploratory)", stdout.getvalue())
+        self.assertIn("| Arm | Condition |", stdout.getvalue())
+        self.assertIn("| Gateway | Condition | Median delta TTFT |", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_gateway_probe_cli.py
+++ b/obench/tests/test_gateway_probe_cli.py
@@ -20,11 +20,11 @@ from obench.tests.test_gateway_probe_spec import manifest
 
 
 class GatewayProbeCliTests(unittest.TestCase):
-    def test_checked_in_minimal_and_four_way_examples_validate_through_cli(self):
+    def test_checked_in_minimal_and_five_way_examples_validate_through_cli(self):
         examples = Path(__file__).parents[1] / "examples"
         cases = (
             ("gateway-probe-responses.toml", "arms=2"),
-            ("gateway-probe-four-way-responses.toml", "arms=4"),
+            ("gateway-probe-five-way-responses.toml", "arms=5"),
         )
         for filename, expected in cases:
             with self.subTest(filename=filename):

--- a/obench/tests/test_gateway_probe_http.py
+++ b/obench/tests/test_gateway_probe_http.py
@@ -1,7 +1,9 @@
 import dataclasses
 import http.client
 import json
+import socket
 import threading
+import time
 import unittest
 from decimal import Decimal
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -247,6 +249,104 @@ class GatewayProbeHttpTests(unittest.TestCase):
         )
         self.assertTrue(result["reuse_evidence"]["socket_reused"])
         self.assertTrue(result["outcome"]["success"])
+
+    def test_slow_dns_is_bounded_by_one_request_deadline(self):
+        exp = experiment(self.endpoint)
+        exp = dataclasses.replace(
+            exp,
+            budget=dataclasses.replace(exp.budget, timeout_s=0.1),
+        )
+        block = ProbeBlock(
+            "case", exp.cases[0].prompt_digest, "cold", 1, ("direct",)
+        )
+        original_getaddrinfo = socket.getaddrinfo
+
+        def slow_dns(*args, **kwargs):
+            time.sleep(0.35)
+            return original_getaddrinfo(*args, **kwargs)
+
+        started = time.monotonic()
+        with mock.patch.object(
+            gateway_probe_http.socket,
+            "getaddrinfo",
+            side_effect=slow_dns,
+        ):
+            result = gateway_probe_http.execute_request(
+                experiment=exp,
+                case=exp.cases[0],
+                block=block,
+                plan=route_plan(exp, self.endpoint),
+                secret="test-secret",
+                prices=prices(),
+            )
+        elapsed = time.monotonic() - started
+        self.assertTrue(result["outcome"]["timed_out"], result)
+        self.assertGreaterEqual(elapsed, 0.08)
+        self.assertLess(elapsed, 0.25)
+        time.sleep(0.3)
+        self.assertEqual(_SSEHandler.requests, [])
+
+    def test_multiple_address_attempts_share_one_request_deadline(self):
+        exp = experiment(self.endpoint)
+        exp = dataclasses.replace(
+            exp,
+            budget=dataclasses.replace(exp.budget, timeout_s=0.2),
+        )
+        block = ProbeBlock(
+            "case", exp.cases[0].prompt_digest, "cold", 1, ("direct",)
+        )
+        sockets = []
+
+        class SlowFailingSocket:
+            def __init__(self, *_args):
+                self.index = len(sockets)
+                self.timeout = None
+                sockets.append(self)
+
+            def settimeout(self, value):
+                self.timeout = value
+
+            def connect(self, _sockaddr):
+                if self.index == 0:
+                    time.sleep(0.08)
+                    raise ConnectionRefusedError
+                time.sleep(self.timeout)
+                raise socket.timeout
+
+            def close(self):
+                return None
+
+        addresses = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 1)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 2)),
+        ]
+        started = time.monotonic()
+        with (
+            mock.patch.object(
+                gateway_probe_http.socket,
+                "getaddrinfo",
+                return_value=addresses,
+            ),
+            mock.patch.object(
+                gateway_probe_http.socket,
+                "socket",
+                SlowFailingSocket,
+            ),
+        ):
+            result = gateway_probe_http.execute_request(
+                experiment=exp,
+                case=exp.cases[0],
+                block=block,
+                plan=route_plan(exp, self.endpoint),
+                secret="test-secret",
+                prices=prices(),
+            )
+        elapsed = time.monotonic() - started
+        self.assertTrue(result["outcome"]["timed_out"], result)
+        self.assertEqual(len(sockets), 2)
+        self.assertLess(sockets[1].timeout, sockets[0].timeout)
+        self.assertGreaterEqual(elapsed, 0.16)
+        self.assertLess(elapsed, 0.26)
 
     def test_gateway_body_shaping_is_authoritative(self):
         plan = gateway_spec.RoutePlan(

--- a/obench/tests/test_gateway_probe_http.py
+++ b/obench/tests/test_gateway_probe_http.py
@@ -1,0 +1,303 @@
+import dataclasses
+import http.client
+import json
+import threading
+import unittest
+from decimal import Decimal
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest import mock
+
+from obench import (
+    gateway_probe_http,
+    gateway_probe_spec,
+    gateway_run,
+    gateway_spec,
+)
+from obench.gateway_probe_models import ProbeBlock
+
+
+PRIVATE_PROMPT = "PRIVATE_PROBE_PROMPT_MUST_NOT_PERSIST"
+PRIVATE_OUTPUT = "PRIVATE_MODEL_OUTPUT_MUST_NOT_PERSIST"
+
+
+class _SSEHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    requests = []
+    fail_first = False
+
+    def log_message(self, _format, *_args):
+        return
+
+    def do_POST(self):
+        size = int(self.headers["content-length"])
+        payload = json.loads(self.rfile.read(size))
+        type(self).requests.append({
+            "connection": id(self.connection),
+            "payload": payload,
+        })
+        terminal = (
+            "failed"
+            if self.fail_first and len(self.requests) == 1
+            else "completed"
+        )
+        body = (
+            'data: {"type":"response.output_text.delta","delta":"'
+            + PRIVATE_OUTPUT
+            + '"}\n\n'
+            f'data: {{"type":"response.{terminal}","response":'
+            f'{{"status":"{terminal}","model":"gpt-test","provider":"openai",'
+            '"usage":{"input_tokens":5,"output_tokens":3,"total_tokens":8}}}\n\n'
+        ).encode()
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(body)))
+        self.send_header("connection", "keep-alive")
+        self.end_headers()
+        self.wfile.write(body)
+        self.wfile.flush()
+
+
+def experiment(endpoint):
+    arm = gateway_spec.Arm(
+        arm_id="direct",
+        route_kind="direct",
+        endpoint=endpoint,
+        protocol="openai_responses",
+        baseline=True,
+        canonical_model="openai/gpt-test",
+        requested_model="gpt-test",
+        requested_provider="openai",
+        allowed_models=("gpt-test",),
+        allowed_providers=("openai",),
+        fallback_enabled=False,
+        retry_count=0,
+        cache_enabled=False,
+        auth_env="TEST_KEY",
+        sampling=gateway_spec.Sampling(0.0, 1.0, 7),
+    )
+    return gateway_probe_spec.GatewayProbeExperiment(
+        schema_version=1,
+        experiment_id="local",
+        track="request_probe",
+        model_match="exact_revision",
+        repetitions=1,
+        schedule_seed=9,
+        allow_private_endpoint=True,
+        private_host_allowlist=(),
+        private_cidr_allowlist=("127.0.0.1/32",),
+        budget=gateway_probe_spec.ProbeBudget(5, 16, "1"),
+        cases=(gateway_probe_spec.ProbeCase("case", PRIVATE_PROMPT),),
+        arms=(arm,),
+    )
+
+
+def route_plan(exp, endpoint):
+    return gateway_spec.RoutePlan(
+        schema_version=1,
+        experiment_digest=exp.digest,
+        arm_digest=exp.arms[0].digest,
+        arm_id="direct",
+        route_kind="direct",
+        endpoint=endpoint,
+        protocol="openai_responses",
+        canonical_model="openai/gpt-test",
+        requested_model="gpt-test",
+        requested_provider="openai",
+        allowed_models=("gpt-test",),
+        allowed_providers=("openai",),
+        fallback_enabled=False,
+        retry_count=0,
+        cache_enabled=False,
+        auth_env="TEST_KEY",
+        sampling=exp.arms[0].sampling,
+        allow_private_endpoint=True,
+        private_host_allowlist=(),
+        private_cidr_allowlist=("127.0.0.1/32",),
+        track="request_probe",
+    )
+
+
+def prices():
+    return {
+        "openai/gpt-test": gateway_run.Price(
+            Decimal("1"),
+            Decimal("2"),
+            "2026-07-25T00:00:00Z",
+        )
+    }
+
+
+class GatewayProbeHttpTests(unittest.TestCase):
+    def setUp(self):
+        _SSEHandler.requests = []
+        _SSEHandler.fail_first = False
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), _SSEHandler)
+        self.thread = threading.Thread(
+            target=self.server.serve_forever, daemon=True
+        )
+        self.thread.start()
+        self.endpoint = (
+            f"http://127.0.0.1:{self.server.server_port}/responses"
+        )
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+    def test_warm_primer_and_measurement_use_same_socket_without_leaking_payloads(self):
+        exp = experiment(self.endpoint)
+        block = ProbeBlock(
+            "case", exp.cases[0].prompt_digest, "warm", 1, ("direct",)
+        )
+        result = gateway_probe_http.execute_request(
+            experiment=exp,
+            case=exp.cases[0],
+            block=block,
+            plan=route_plan(exp, self.endpoint),
+            secret="test-secret",
+            prices=prices(),
+        )
+        self.assertTrue(result["reuse_evidence"]["socket_reused"])
+        self.assertTrue(result["outcome"]["success"])
+        self.assertEqual(result["route_integrity"]["status"], "verified")
+        self.assertEqual(len(_SSEHandler.requests), 2)
+        self.assertFalse(_SSEHandler.requests[0]["payload"]["store"])
+        self.assertFalse(_SSEHandler.requests[1]["payload"]["store"])
+        self.assertEqual(
+            _SSEHandler.requests[0]["connection"],
+            _SSEHandler.requests[1]["connection"],
+        )
+        primer_input = _SSEHandler.requests[0]["payload"]["input"]
+        measured_input = _SSEHandler.requests[1]["payload"]["input"]
+        self.assertNotEqual(primer_input, measured_input)
+        self.assertTrue(primer_input.startswith("[openbench_probe_nonce:"))
+        self.assertNotEqual(
+            primer_input.split("\n", 1)[0],
+            measured_input.split("\n", 1)[0],
+        )
+        self.assertIn(PRIVATE_PROMPT, primer_input)
+        self.assertIn(PRIVATE_PROMPT, measured_input)
+        serialized = json.dumps(result, sort_keys=True)
+        for private in (PRIVATE_PROMPT, PRIVATE_OUTPUT, "test-secret"):
+            self.assertNotIn(private, serialized)
+        self.assertNotEqual(
+            result["reuse_evidence"]["primer_nonce_sha256"],
+            result["reuse_evidence"]["measured_nonce_sha256"],
+        )
+        self.assertIsNotNone(
+            result["reuse_evidence"]["connection"]["dns_s"]
+        )
+        self.assertEqual(
+            result["request_metrics"]["connection"],
+            {"dns_s": None, "tcp_s": None, "tls_s": None},
+        )
+        self.assertGreater(
+            Decimal(result["billing"]["primer_cost_usd"]), 0
+        )
+        self.assertGreater(
+            Decimal(result["billing"]["charged_cost_usd"]),
+            Decimal(result["billing"]["measured_cost_usd"]),
+        )
+
+    def test_warm_measurement_requires_a_successful_verified_primer(self):
+        _SSEHandler.fail_first = True
+        exp = experiment(self.endpoint)
+        block = ProbeBlock(
+            "case", exp.cases[0].prompt_digest, "warm", 1, ("direct",)
+        )
+        result = gateway_probe_http.execute_request(
+            experiment=exp,
+            case=exp.cases[0],
+            block=block,
+            plan=route_plan(exp, self.endpoint),
+            secret="test-secret",
+            prices=prices(),
+        )
+        self.assertEqual(len(_SSEHandler.requests), 1)
+        self.assertFalse(result["outcome"]["attempted"])
+        self.assertEqual(result["outcome"]["error_class"], "primer")
+        self.assertFalse(result["reuse_evidence"]["completed"])
+        self.assertGreater(
+            Decimal(result["billing"]["primer_cost_usd"]), 0
+        )
+
+    def test_gateway_body_shaping_is_authoritative(self):
+        plan = gateway_spec.RoutePlan(
+            schema_version=1,
+            experiment_digest="e" * 64,
+            arm_digest="a" * 64,
+            arm_id="gateway",
+            route_kind="gateway",
+            endpoint="https://openrouter.ai/api/v1/chat/completions",
+            protocol="openai_chat",
+            canonical_model="openai/gpt-test",
+            requested_model="openai/gpt-test",
+            requested_provider="openai",
+            allowed_models=("openai/gpt-test",),
+            allowed_providers=("openai",),
+            fallback_enabled=False,
+            retry_count=0,
+            cache_enabled=False,
+            auth_env="KEY",
+            sampling=gateway_spec.Sampling(0.0, 1.0, 9),
+            allow_private_endpoint=False,
+            private_host_allowlist=(),
+            private_cidr_allowlist=(),
+            gateway="openrouter",
+            track="request_probe",
+        )
+        body = json.loads(
+            gateway_probe_http.request_body("prompt", "nonce", plan, 32)
+        )
+        self.assertEqual(body["model"], "openai/gpt-test")
+        self.assertEqual(
+            body["provider"], {"only": ["openai"], "allow_fallbacks": False}
+        )
+        self.assertTrue(body["stream"])
+        self.assertEqual(body["max_completion_tokens"], 32)
+        responses_plan = dataclasses.replace(
+            plan,
+            endpoint="https://openrouter.ai/api/v1/responses",
+            protocol="openai_responses",
+        )
+        responses_body = json.loads(
+            gateway_probe_http.request_body(
+                "prompt", "nonce", responses_plan, 32
+            )
+        )
+        self.assertIs(responses_body["store"], False)
+        self.assertEqual(
+            responses_body["provider"],
+            {"only": ["openai"], "allow_fallbacks": False},
+        )
+
+    def test_bad_status_line_never_persists_server_or_exception_text(self):
+        exp = experiment(self.endpoint)
+        block = ProbeBlock(
+            "case", exp.cases[0].prompt_digest, "cold", 1, ("direct",)
+        )
+        private_server_bytes = "PRIVATE_BAD_STATUS_SERVER_BYTES"
+        with mock.patch.object(
+            gateway_probe_http,
+            "_consume",
+            side_effect=http.client.BadStatusLine(private_server_bytes),
+        ):
+            result = gateway_probe_http.execute_request(
+                experiment=exp,
+                case=exp.cases[0],
+                block=block,
+                plan=route_plan(exp, self.endpoint),
+                secret="test-secret",
+                prices={},
+            )
+        serialized = json.dumps(result, sort_keys=True)
+        self.assertEqual(result["outcome"]["error_class"], "transport")
+        self.assertEqual(
+            result["outcome"]["error_detail"], "bad_status_line"
+        )
+        self.assertNotIn(private_server_bytes, serialized)
+        self.assertNotIn("test-secret", serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_gateway_probe_http.py
+++ b/obench/tests/test_gateway_probe_http.py
@@ -298,6 +298,104 @@ class GatewayProbeHttpTests(unittest.TestCase):
             {"only": ["openai"], "allow_fallbacks": False},
         )
 
+    def test_route_reason_taxonomy_is_explicit_and_fail_closed(self):
+        expected = {
+            "missing_stream_metrics": "unverifiable",
+            "missing_route_evidence": "unverifiable",
+            "missing_requested_model": "unverifiable",
+            "missing_served_model": "unverifiable",
+            "stream_not_done": "unverifiable",
+            "missing_gateway_profile": "unverifiable",
+            "missing_cloudflare_metadata": "unverifiable",
+            "missing_concentrate_metadata": "unverifiable",
+            "missing_openrouter_metadata": "unverifiable",
+            "missing_vercel_metadata": "unverifiable",
+            "missing_provider": "unverifiable",
+            "unqualified_served_model": "unverifiable",
+            "missing_metadata_requested_model": "unverifiable",
+            "missing_attempt_count": "unverifiable",
+            "missing_model_attempts": "unverifiable",
+            "missing_successful_attempt": "unverifiable",
+            "missing_attempt_evidence": "unverifiable",
+            "missing_attempt_provider": "unverifiable",
+            "missing_attempt_model": "unverifiable",
+            "missing_attempt_status": "unverifiable",
+            "malformed_route_evidence": "failed",
+            "malformed_events": "failed",
+            "fallback_enabled": "failed",
+            "served_model_conflict": "failed",
+            "provider_conflict": "failed",
+            "multiple_attempts": "failed",
+            "served_model_not_allowed": "failed",
+            "provider_not_allowed": "failed",
+            "requested_model_conflict": "failed",
+            "malformed_attempts": "failed",
+            "fallback_attempt": "failed",
+            "attempt_provider_not_allowed": "failed",
+            "unsuccessful_attempt": "failed",
+        }
+        self.assertEqual(
+            gateway_probe_http._ROUTE_REASON_STATUS,
+            expected,
+        )
+        for reason, expected_status in expected.items():
+            with self.subTest(reason=reason):
+                status, reasons = gateway_probe_http._route_status({
+                    "route_evidence": {
+                        "pass": False,
+                        "reasons": [reason],
+                    }
+                })
+                self.assertEqual(status, expected_status)
+                self.assertEqual(reasons, [reason])
+
+        for reasons in (
+            ["unknown_route_reason"],
+            ["missing_provider", "provider_not_allowed"],
+            [],
+        ):
+            with self.subTest(reasons=reasons):
+                status, _normalized = gateway_probe_http._route_status({
+                    "route_evidence": {
+                        "pass": False,
+                        "reasons": reasons,
+                    }
+                })
+                self.assertEqual(status, "failed")
+
+        self.assertEqual(
+            gateway_probe_http._route_status({
+                "route_evidence": {
+                    "pass": True,
+                    "reasons": ["provider_not_allowed"],
+                }
+            }),
+            ("failed", ["provider_not_allowed"]),
+        )
+        self.assertEqual(
+            gateway_probe_http._route_status({
+                "route_evidence": {
+                    "pass": True,
+                    "reasons": [],
+                }
+            }),
+            ("verified", []),
+        )
+        self.assertEqual(
+            gateway_probe_http._route_status(None),
+            ("unverifiable", ["missing_stream_metrics"]),
+        )
+        self.assertEqual(
+            gateway_probe_http._route_status({}),
+            ("unverifiable", ["missing_route_evidence"]),
+        )
+        self.assertEqual(
+            gateway_probe_http._route_status({
+                "route_evidence": {"pass": False, "reasons": "not-a-list"}
+            }),
+            ("failed", ["malformed_route_evidence"]),
+        )
+
     def test_bad_status_line_never_persists_server_or_exception_text(self):
         exp = experiment(self.endpoint)
         block = ProbeBlock(

--- a/obench/tests/test_gateway_probe_http.py
+++ b/obench/tests/test_gateway_probe_http.py
@@ -24,6 +24,7 @@ class _SSEHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
     requests = []
     fail_first = False
+    close_measured = False
 
     def log_message(self, _format, *_args):
         return
@@ -51,7 +52,10 @@ class _SSEHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("content-type", "text/event-stream")
         self.send_header("content-length", str(len(body)))
-        self.send_header("connection", "keep-alive")
+        close_response = self.close_measured and len(self.requests) == 2
+        self.send_header(
+            "connection", "close" if close_response else "keep-alive"
+        )
         self.end_headers()
         self.wfile.write(body)
         self.wfile.flush()
@@ -131,6 +135,7 @@ class GatewayProbeHttpTests(unittest.TestCase):
     def setUp(self):
         _SSEHandler.requests = []
         _SSEHandler.fail_first = False
+        _SSEHandler.close_measured = False
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), _SSEHandler)
         self.thread = threading.Thread(
             target=self.server.serve_forever, daemon=True
@@ -220,6 +225,28 @@ class GatewayProbeHttpTests(unittest.TestCase):
         self.assertGreater(
             Decimal(result["billing"]["primer_cost_usd"]), 0
         )
+
+    def test_warm_reuse_survives_measured_response_closing_same_socket(self):
+        _SSEHandler.close_measured = True
+        exp = experiment(self.endpoint)
+        block = ProbeBlock(
+            "case", exp.cases[0].prompt_digest, "warm", 1, ("direct",)
+        )
+        result = gateway_probe_http.execute_request(
+            experiment=exp,
+            case=exp.cases[0],
+            block=block,
+            plan=route_plan(exp, self.endpoint),
+            secret="test-secret",
+            prices=prices(),
+        )
+        self.assertEqual(len(_SSEHandler.requests), 2)
+        self.assertEqual(
+            _SSEHandler.requests[0]["connection"],
+            _SSEHandler.requests[1]["connection"],
+        )
+        self.assertTrue(result["reuse_evidence"]["socket_reused"])
+        self.assertTrue(result["outcome"]["success"])
 
     def test_gateway_body_shaping_is_authoritative(self):
         plan = gateway_spec.RoutePlan(

--- a/obench/tests/test_gateway_probe_http.py
+++ b/obench/tests/test_gateway_probe_http.py
@@ -37,6 +37,9 @@ class _SSEHandler(BaseHTTPRequestHandler):
         type(self).requests.append({
             "connection": id(self.connection),
             "payload": payload,
+            "headers": {
+                key.lower(): value for key, value in self.headers.items()
+            },
         })
         terminal = (
             "failed"
@@ -228,6 +231,44 @@ class GatewayProbeHttpTests(unittest.TestCase):
             Decimal(result["billing"]["charged_cost_usd"]),
             Decimal(result["billing"]["measured_cost_usd"]),
         )
+
+    def test_cloudflare_managed_probe_sends_bound_gateway_controls(self):
+        exp = experiment(self.endpoint)
+        plan = dataclasses.replace(
+            route_plan(exp, self.endpoint),
+            arm_id="cloudflare-managed",
+            route_kind="gateway",
+            requested_model="openai/gpt-test",
+            allowed_models=("openai/gpt-test",),
+            gateway="cloudflare",
+            gateway_id="openbench-gateway-bench",
+        )
+        block = ProbeBlock(
+            "case", exp.cases[0].prompt_digest, "cold", 1, (plan.arm_id,)
+        )
+
+        result = gateway_probe_http.execute_request(
+            experiment=exp,
+            case=exp.cases[0],
+            block=block,
+            plan=plan,
+            secret="cloudflare-managed-secret",
+            prices=prices(),
+        )
+
+        self.assertTrue(result["outcome"]["success"])
+        headers = _SSEHandler.requests[-1]["headers"]
+        self.assertEqual(
+            headers["authorization"],
+            "Bearer cloudflare-managed-secret",
+        )
+        self.assertEqual(
+            headers["cf-aig-gateway-id"],
+            "openbench-gateway-bench",
+        )
+        self.assertEqual(headers["cf-aig-skip-cache"], "true")
+        self.assertEqual(headers["cf-aig-max-attempts"], "1")
+        self.assertNotIn("cloudflare-managed-secret", json.dumps(result))
 
     def test_warm_measurement_requires_a_successful_verified_primer(self):
         _SSEHandler.fail_first = True

--- a/obench/tests/test_gateway_probe_http.py
+++ b/obench/tests/test_gateway_probe_http.py
@@ -54,6 +54,8 @@ class _SSEHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("content-type", "text/event-stream")
         self.send_header("content-length", str(len(body)))
+        self.send_header("x-request-id", "receipt-123")
+        self.send_header("x-internal-debug", "must-not-persist")
         close_response = self.close_measured and len(self.requests) == 2
         self.send_header(
             "connection", "close" if close_response else "keep-alive"
@@ -192,11 +194,32 @@ class GatewayProbeHttpTests(unittest.TestCase):
             result["reuse_evidence"]["measured_nonce_sha256"],
         )
         self.assertIsNotNone(
-            result["reuse_evidence"]["connection"]["dns_s"]
+            result["reuse_evidence"]["setup"]["dns_s"]
+        )
+        self.assertIsNone(result["request_metrics"]["setup"])
+        timing = result["request_metrics"]["timing"]
+        self.assertIsNotNone(timing["request_to_response_headers_s"])
+        self.assertIsNotNone(timing["request_to_first_body_byte_s"])
+        self.assertIsNotNone(timing["request_to_semantic_ttft_s"])
+        self.assertIsNotNone(timing["request_stream_total_s"])
+        self.assertTrue(
+            all(
+                timing[name] is None
+                for name in (
+                    "cold_end_to_end_response_headers_s",
+                    "cold_end_to_end_first_body_byte_s",
+                    "cold_end_to_end_semantic_ttft_s",
+                    "cold_end_to_end_stream_total_s",
+                )
+            )
         )
         self.assertEqual(
-            result["request_metrics"]["connection"],
-            {"dns_s": None, "tcp_s": None, "tls_s": None},
+            result["request_metrics"]["receipt_headers"],
+            {"x-request-id": "receipt-123"},
+        )
+        self.assertEqual(
+            result["reuse_evidence"]["receipt_headers"],
+            {"x-request-id": "receipt-123"},
         )
         self.assertGreater(
             Decimal(result["billing"]["primer_cost_usd"]), 0
@@ -227,6 +250,151 @@ class GatewayProbeHttpTests(unittest.TestCase):
         self.assertGreater(
             Decimal(result["billing"]["primer_cost_usd"]), 0
         )
+
+    def test_cold_phase_boundaries_include_setup_exactly_once(self):
+        exp = experiment(self.endpoint)
+        block = ProbeBlock(
+            "case", exp.cases[0].prompt_digest, "cold", 1, ("direct",)
+        )
+        result = gateway_probe_http.execute_request(
+            experiment=exp,
+            case=exp.cases[0],
+            block=block,
+            plan=route_plan(exp, self.endpoint),
+            secret="test-secret",
+            prices=prices(),
+        )
+        setup = result["request_metrics"]["setup"]
+        timing = result["request_metrics"]["timing"]
+        self.assertIsNotNone(setup["dns_s"])
+        self.assertIsNotNone(setup["tcp_s"])
+        self.assertIsNone(setup["tls_s"])
+        pairs = (
+            (
+                "cold_end_to_end_response_headers_s",
+                "request_to_response_headers_s",
+            ),
+            (
+                "cold_end_to_end_first_body_byte_s",
+                "request_to_first_body_byte_s",
+            ),
+            (
+                "cold_end_to_end_semantic_ttft_s",
+                "request_to_semantic_ttft_s",
+            ),
+            (
+                "cold_end_to_end_stream_total_s",
+                "request_stream_total_s",
+            ),
+        )
+        for end_to_end, request_only in pairs:
+            self.assertGreaterEqual(timing[end_to_end], timing[request_only])
+        self.assertLessEqual(
+            timing["request_to_response_headers_s"],
+            timing["request_to_first_body_byte_s"],
+        )
+        self.assertLessEqual(
+            timing["request_to_first_body_byte_s"],
+            timing["request_to_semantic_ttft_s"],
+        )
+
+    def test_consume_uses_post_send_and_pre_dns_clock_boundaries(self):
+        class FakeSocket:
+            def settimeout(self, _value):
+                return None
+
+        class FakeResponse:
+            status = 200
+            will_close = False
+
+            def __init__(self):
+                self.chunks = [b"data", b""]
+
+            def getheaders(self):
+                return [("content-type", "text/event-stream")]
+
+            def read1(self, _size):
+                return self.chunks.pop(0)
+
+        class FakeConnection:
+            timeout = 30
+            sock = FakeSocket()
+
+            def set_request_deadline(self, deadline):
+                self.deadline = deadline
+
+            def request(self, *_args, **_kwargs):
+                return None
+
+            def _remaining_timeout(self):
+                return 20
+
+            def getresponse(self):
+                return FakeResponse()
+
+        class FakeParser:
+            def feed(self, _chunk, received_at):
+                self.received_at = received_at
+
+            def finalize(self, completed_at):
+                self.completed_at = completed_at
+                return {
+                    "timing": {
+                        "ttfb_s": 6.0,
+                        "semantic_ttft_s": 7.0,
+                    }
+                }
+
+        exp = experiment(self.endpoint)
+        parser = FakeParser()
+        with (
+            mock.patch.object(
+                gateway_probe_http.time,
+                "monotonic",
+                side_effect=[10.0, 12.0, 15.0, 16.0, 18.0, 19.0, 20.0],
+            ),
+            mock.patch.object(
+                gateway_probe_http.gateway_metrics,
+                "sse_parser",
+                return_value=parser,
+            ) as parser_factory,
+        ):
+            _status, _metrics, _closed, evidence = gateway_probe_http._consume(
+                FakeConnection(),
+                "/responses",
+                b"{}",
+                {},
+                route_plan(exp, self.endpoint),
+                capture_metrics=True,
+                cold_started_at=9.0,
+            )
+        self.assertEqual(parser_factory.call_args.kwargs["started_at"], 12.0)
+        self.assertEqual(evidence["timing"], {
+            "request_to_response_headers_s": 3.0,
+            "request_to_first_body_byte_s": 6.0,
+            "request_to_semantic_ttft_s": 7.0,
+            "request_stream_total_s": 8.0,
+            "cold_end_to_end_response_headers_s": 6.0,
+            "cold_end_to_end_first_body_byte_s": 9.0,
+            "cold_end_to_end_semantic_ttft_s": 10.0,
+            "cold_end_to_end_stream_total_s": 11.0,
+        })
+
+    def test_receipt_headers_use_strict_allowlist_and_value_sanitation(self):
+        receipts = gateway_probe_http._receipt_headers([
+            ("X-Request-ID", " safe-id "),
+            ("Authorization", "secret"),
+            ("CF-Ray", "bad\nvalue"),
+            ("X-Vercel-ID", "x" * 257),
+            ("Request-ID", "first"),
+            ("Request-ID", "second"),
+            ("OpenAI-Request-ID", "openai-id"),
+            ("Anthropic-Request-ID", "private output words"),
+        ])
+        self.assertEqual(receipts, {
+            "x-request-id": "safe-id",
+            "openai-request-id": "openai-id",
+        })
 
     def test_warm_reuse_survives_measured_response_closing_same_socket(self):
         _SSEHandler.close_measured = True

--- a/obench/tests/test_gateway_probe_report.py
+++ b/obench/tests/test_gateway_probe_report.py
@@ -19,7 +19,7 @@ def row(arm, condition, repetition, *, baseline=False, total=1.0, route="verifie
         },
     }
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "benchmark": "gateway_probe",
         "cell_id": gateway_probe_results.cell_id(identity),
         "identity": identity,
@@ -28,15 +28,41 @@ def row(arm, condition, repetition, *, baseline=False, total=1.0, route="verifie
         "arm_role": "direct" if baseline else "gateway",
         "baseline": baseline,
         "model_match": "exact_revision",
-        "outcome": {"attempted": True, "success": True},
+        "outcome": {
+            "attempted": True,
+            "success": True,
+            "available": True,
+            "http_status": 200,
+            "timed_out": False,
+            "error_class": None,
+            "error_detail": None,
+            "budget_exhausted_reason": None,
+        },
         "route_integrity": {"status": route, "pass": route == "verified", "reasons": []},
         "request_metrics": {
-            "connection": {"dns_s": 0.01, "tcp_s": 0.02, "tls_s": 0.03},
+            "setup": (
+                {"dns_s": 0.01, "tcp_s": 0.02, "tls_s": 0.03}
+                if condition == "cold" else None
+            ),
             "timing": {
-                "ttfb_s": total / 4,
-                "semantic_ttft_s": total / 2,
-                "total_s": total,
+                "request_to_response_headers_s": total / 4,
+                "request_to_first_body_byte_s": total / 3,
+                "request_to_semantic_ttft_s": total / 2,
+                "request_stream_total_s": total,
+                "cold_end_to_end_response_headers_s": (
+                    total / 4 + 0.1 if condition == "cold" else None
+                ),
+                "cold_end_to_end_first_body_byte_s": (
+                    total / 3 + 0.1 if condition == "cold" else None
+                ),
+                "cold_end_to_end_semantic_ttft_s": (
+                    total / 2 + 0.1 if condition == "cold" else None
+                ),
+                "cold_end_to_end_stream_total_s": (
+                    total + 0.1 if condition == "cold" else None
+                ),
             },
+            "receipt_headers": {"x-request-id": f"receipt-{arm}-{repetition}"},
             "generation": {"tokens_per_second": 10.0},
             "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
             "cache": {"cached_input_tokens": None, "cache_write_input_tokens": None},
@@ -47,6 +73,36 @@ def row(arm, condition, repetition, *, baseline=False, total=1.0, route="verifie
                     "effective_at": "2026-07-25T00:00:00Z",
                 }
             },
+            "route": {"served_model": "gpt-test", "provider": "openai"},
+            "stream": {
+                "done": True,
+                "terminal_status": "completed",
+                "finalized": True,
+            },
+            "coverage": {},
+        },
+        "reuse_evidence": {
+            "required": condition == "warm",
+            "completed": condition == "warm",
+            "http_status": 200 if condition == "warm" else None,
+            "socket_reused": True if condition == "warm" else None,
+            "primer_nonce_sha256": "1" * 64,
+            "measured_nonce_sha256": "2" * 64,
+            "setup": {"dns_s": 0.01, "tcp_s": 0.02, "tls_s": 0.03},
+            "receipt_headers": {},
+            "route_integrity": (
+                {"status": "verified", "pass": True, "reasons": []}
+                if condition == "warm" else None
+            ),
+            "usage": None,
+            "cache": None,
+            "costs": {},
+        },
+        "billing": {
+            "primer_cost_usd": "0" if condition == "warm" else None,
+            "measured_cost_usd": "0.001",
+            "charged_cost_usd": "0.001",
+            "stop_required": False,
         },
     }
 
@@ -70,7 +126,7 @@ class GatewayProbeReportTests(unittest.TestCase):
             "route_unverifiable": 0,
             "route_failed": 0,
         })
-        self.assertEqual(cold["metrics"]["total_s"]["p50"], 2.0)
+        self.assertEqual(cold["metrics"]["request_stream_total_s"]["p50"], 2.0)
         availability = cold["availability"]
         self.assertEqual(availability["successes"], 2)
         self.assertEqual(availability["attempted"], 2)
@@ -81,24 +137,51 @@ class GatewayProbeReportTests(unittest.TestCase):
         self.assertEqual(
             cold["metrics"]["cached_input_tokens"]["coverage"]["covered"], 0
         )
-        contrast = report["paired_contrasts"]["gateway"]["cold"]["total_s"]
+        contrast = report["paired_contrasts"]["gateway"]["cold"][
+            "request_stream_total_s"
+        ]
         self.assertEqual(contrast["median_gateway_minus_direct"], 0.5)
         self.assertEqual(contrast["coverage"]["covered"], 2)
         self.assertIsNotNone(contrast["interval"])
+        warm_metrics = report["arms"]["gateway"]["conditions"]["warm"]["metrics"]
+        self.assertNotIn("setup_dns_s", warm_metrics)
+        self.assertNotIn("cold_end_to_end_stream_total_s", warm_metrics)
+        self.assertNotIn(
+            "setup_dns_s",
+            report["paired_contrasts"]["gateway"]["warm"],
+        )
         text = gateway_probe_report.render_text(report)
         self.assertIn("Gateway Probe (exploratory)", text)
         self.assertIn("| Arm | Condition | Success / availability |", text)
-        self.assertIn("Semantic TTFT p50 / p95", text)
+        self.assertIn("Request to semantic TTFT p50 / p95", text)
+        self.assertIn("Cold setup DNS p50", text)
+        self.assertIn("Cold end-to-end response headers p50", text)
+        self.assertIn("Total tokens p50 (coverage)", text)
+        self.assertIn("Cached input p50 (coverage)", text)
         self.assertIn("Measured cost p50 (coverage)", text)
         self.assertIn("| gateway | cold |", text)
+        self.assertIn("8.0 (2/2)", text)
+        self.assertIn("n/a (0/2)", text)
         self.assertIn("$0.001000 (2/2)", text)
-        self.assertIn("| Gateway | Condition | Median delta TTFT |", text)
-        self.assertIn("| gateway | cold | +0.250s | +0.125s | +0.500s | 2/2 |", text)
+        self.assertIn("| Gateway | Condition | Phase metric |", text)
+        self.assertIn(
+            "| gateway | cold | Request to semantic TTFT | +0.250s | 2/2 |",
+            text,
+        )
 
     def test_missing_metrics_are_not_imputed_and_unverified_rows_do_not_pair(self):
         direct = row("direct", "cold", 1, baseline=True)
         gateway = row("gateway", "cold", 1, route="unverifiable")
-        gateway["request_metrics"]["timing"]["semantic_ttft_s"] = None
+        gateway["request_metrics"]["timing"]["request_to_semantic_ttft_s"] = None
+        gateway["request_metrics"]["timing"][
+            "cold_end_to_end_semantic_ttft_s"
+        ] = None
+        gateway["outcome"].update({
+            "success": False,
+            "available": False,
+            "error_class": "stream",
+            "error_detail": "stream_no_semantic_output",
+        })
         warm_direct = row("direct", "warm", 1, baseline=True)
         warm_gateway = row("gateway", "warm", 1)
         rows = [direct, gateway, warm_direct, warm_gateway]
@@ -108,11 +191,11 @@ class GatewayProbeReportTests(unittest.TestCase):
         cold = report["arms"]["gateway"]["conditions"]["cold"]
         self.assertEqual(cold["denominators"]["route_unverifiable"], 1)
         self.assertEqual(
-            cold["metrics"]["semantic_ttft_s"]["coverage"],
-            {"covered": 0, "total": 1, "ratio": 0.0},
+            cold["metrics"]["request_to_semantic_ttft_s"]["coverage"],
+            {"covered": 0, "total": 0, "ratio": 0.0},
         )
         self.assertIsNone(
-            report["paired_contrasts"]["gateway"]["cold"]["total_s"][
+            report["paired_contrasts"]["gateway"]["cold"]["request_stream_total_s"][
                 "median_gateway_minus_direct"
             ]
         )
@@ -133,10 +216,10 @@ class GatewayProbeReportTests(unittest.TestCase):
         self.assertEqual(cold["denominators"]["success"], 1)
         self.assertEqual(cold["availability"]["rate"], 1.0)
         self.assertEqual(
-            cold["metrics"]["total_s"]["coverage"],
+            cold["metrics"]["request_stream_total_s"]["coverage"],
             {"covered": 0, "total": 1, "ratio": 0.0},
         )
-        self.assertIsNone(cold["metrics"]["total_s"]["p50"])
+        self.assertIsNone(cold["metrics"]["request_stream_total_s"]["p50"])
         self.assertEqual(
             cold["metrics"]["total_tokens"]["coverage"],
             {"covered": 0, "total": 1, "ratio": 0.0},

--- a/obench/tests/test_gateway_probe_report.py
+++ b/obench/tests/test_gateway_probe_report.py
@@ -1,0 +1,187 @@
+import copy
+import unittest
+
+from obench import gateway_probe_report, gateway_probe_results
+
+
+def row(arm, condition, repetition, *, baseline=False, total=1.0, route="verified"):
+    identity = {
+        "benchmark": {"name": "gateway_probe", "track": "request_probe"},
+        "experiment": {"id": "exp", "digest": "e" * 64},
+        "arm": {"id": arm, "digest": ("a" if baseline else "b") * 64},
+        "case": {"id": "case", "prompt_digest": "c" * 64},
+        "comparison": {"schedule_digest": "s" * 64, "price_digest": "p" * 64},
+        "schedule": {
+            "condition": condition,
+            "repetition": repetition,
+            "block_id": f"{condition}-{repetition}",
+            "block_attempt": 0,
+        },
+    }
+    return {
+        "schema_version": 2,
+        "benchmark": "gateway_probe",
+        "cell_id": gateway_probe_results.cell_id(identity),
+        "identity": identity,
+        "expected_arm_ids": ["direct", "gateway"],
+        "scheduled_blocks_per_condition": 2,
+        "arm_role": "direct" if baseline else "gateway",
+        "baseline": baseline,
+        "model_match": "exact_revision",
+        "outcome": {"attempted": True, "success": True},
+        "route_integrity": {"status": route, "pass": route == "verified", "reasons": []},
+        "request_metrics": {
+            "connection": {"dns_s": 0.01, "tcp_s": 0.02, "tls_s": 0.03},
+            "timing": {
+                "ttfb_s": total / 4,
+                "semantic_ttft_s": total / 2,
+                "total_s": total,
+            },
+            "generation": {"tokens_per_second": 10.0},
+            "usage": {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+            "cache": {"cached_input_tokens": None, "cache_write_input_tokens": None},
+            "costs": {
+                "frozen_list_estimate": {
+                    "amount_usd": 0.001,
+                    "currency": "USD",
+                    "effective_at": "2026-07-25T00:00:00Z",
+                }
+            },
+        },
+    }
+
+
+class GatewayProbeReportTests(unittest.TestCase):
+    def test_reports_denominators_percentiles_coverage_and_paired_medians(self):
+        rows = []
+        for condition in ("cold", "warm"):
+            for repetition, direct_total in ((1, 1.0), (2, 2.0)):
+                rows.append(row("direct", condition, repetition, baseline=True, total=direct_total))
+                rows.append(row("gateway", condition, repetition, total=direct_total + 0.5))
+        report = gateway_probe_report.aggregate(rows, bootstrap_replicates=100)
+        self.assertEqual(report["label"], "exploratory")
+        cold = report["arms"]["gateway"]["conditions"]["cold"]
+        self.assertEqual(cold["denominators"], {
+            "scheduled": 2,
+            "attempted": 2,
+            "success": 2,
+            "request_failed": 0,
+            "route_verified": 2,
+            "route_unverifiable": 0,
+            "route_failed": 0,
+        })
+        self.assertEqual(cold["metrics"]["total_s"]["p50"], 2.0)
+        availability = cold["availability"]
+        self.assertEqual(availability["successes"], 2)
+        self.assertEqual(availability["attempted"], 2)
+        self.assertEqual(availability["rate"], 1.0)
+        self.assertEqual(availability["wilson95"]["confidence"], 0.95)
+        self.assertAlmostEqual(availability["wilson95"]["low"], 0.34237195288961925)
+        self.assertEqual(availability["wilson95"]["high"], 1.0)
+        self.assertEqual(
+            cold["metrics"]["cached_input_tokens"]["coverage"]["covered"], 0
+        )
+        contrast = report["paired_contrasts"]["gateway"]["cold"]["total_s"]
+        self.assertEqual(contrast["median_gateway_minus_direct"], 0.5)
+        self.assertEqual(contrast["coverage"]["covered"], 2)
+        self.assertIsNotNone(contrast["interval"])
+        text = gateway_probe_report.render_text(report)
+        self.assertIn("Gateway Probe (exploratory)", text)
+        self.assertIn("| Arm | Condition | Success / availability |", text)
+        self.assertIn("Semantic TTFT p50 / p95", text)
+        self.assertIn("Measured cost p50 (coverage)", text)
+        self.assertIn("| gateway | cold |", text)
+        self.assertIn("$0.001000 (2/2)", text)
+        self.assertIn("| Gateway | Condition | Median delta TTFT |", text)
+        self.assertIn("| gateway | cold | +0.250s | +0.125s | +0.500s | 2/2 |", text)
+
+    def test_missing_metrics_are_not_imputed_and_unverified_rows_do_not_pair(self):
+        direct = row("direct", "cold", 1, baseline=True)
+        gateway = row("gateway", "cold", 1, route="unverifiable")
+        gateway["request_metrics"]["timing"]["semantic_ttft_s"] = None
+        warm_direct = row("direct", "warm", 1, baseline=True)
+        warm_gateway = row("gateway", "warm", 1)
+        rows = [direct, gateway, warm_direct, warm_gateway]
+        for item in rows:
+            item["scheduled_blocks_per_condition"] = 1
+        report = gateway_probe_report.aggregate(rows, bootstrap_replicates=20)
+        cold = report["arms"]["gateway"]["conditions"]["cold"]
+        self.assertEqual(cold["denominators"]["route_unverifiable"], 1)
+        self.assertEqual(
+            cold["metrics"]["semantic_ttft_s"]["coverage"],
+            {"covered": 0, "total": 1, "ratio": 0.0},
+        )
+        self.assertIsNone(
+            report["paired_contrasts"]["gateway"]["cold"]["total_s"][
+                "median_gateway_minus_direct"
+            ]
+        )
+        text = gateway_probe_report.render_text(report)
+        self.assertIn("n/a", text)
+
+    def test_rejects_mixed_comparison_duplicate_logical_and_provenance_drift(self):
+        direct = row("direct", "cold", 1, baseline=True)
+        gateway = row("gateway", "cold", 1)
+        warm_direct = row("direct", "warm", 1, baseline=True)
+        warm_gateway = row("gateway", "warm", 1)
+        base = [direct, gateway, warm_direct, warm_gateway]
+        for item in base:
+            item["scheduled_blocks_per_condition"] = 1
+
+        mixed_price = copy.deepcopy(base)
+        mixed_price[-1]["identity"]["comparison"]["price_digest"] = "x" * 64
+        mixed_price[-1]["cell_id"] = gateway_probe_results.cell_id(
+            mixed_price[-1]["identity"]
+        )
+        with self.assertRaisesRegex(
+            gateway_probe_report.GatewayProbeReportError,
+            "schedule or price digests",
+        ):
+            gateway_probe_report.aggregate(mixed_price)
+
+        duplicate = copy.deepcopy(base)
+        duplicate_row = copy.deepcopy(duplicate[0])
+        duplicate.append(duplicate_row)
+        with self.assertRaisesRegex(
+            gateway_probe_report.GatewayProbeReportError,
+            "duplicate logical arm row",
+        ):
+            gateway_probe_report.aggregate(duplicate)
+
+        metadata_drift = copy.deepcopy(base)
+        metadata_drift[2]["identity"]["arm"]["digest"] = "z" * 64
+        metadata_drift[2]["cell_id"] = gateway_probe_results.cell_id(
+            metadata_drift[2]["identity"]
+        )
+        with self.assertRaisesRegex(
+            gateway_probe_report.GatewayProbeReportError,
+            "inconsistent arm provenance",
+        ):
+            gateway_probe_report.aggregate(metadata_drift)
+
+        model_drift = copy.deepcopy(base)
+        model_drift[2]["model_match"] = "rolling_alias"
+        with self.assertRaisesRegex(
+            gateway_probe_report.GatewayProbeReportError,
+            "inconsistent arm provenance",
+        ):
+            gateway_probe_report.aggregate(model_drift)
+
+        tampered_cell = copy.deepcopy(base)
+        tampered_cell[0]["cell_id"] = "forged"
+        with self.assertRaisesRegex(
+            gateway_probe_report.GatewayProbeReportError,
+            "cell_id does not match",
+        ):
+            gateway_probe_report.aggregate(tampered_cell)
+
+        missing_arm = copy.deepcopy(base[:1])
+        with self.assertRaisesRegex(
+            gateway_probe_report.GatewayProbeReportError,
+            "omit metadata for expected arms",
+        ):
+            gateway_probe_report.aggregate(missing_arm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_gateway_probe_report.py
+++ b/obench/tests/test_gateway_probe_report.py
@@ -119,6 +119,33 @@ class GatewayProbeReportTests(unittest.TestCase):
         text = gateway_probe_report.render_text(report)
         self.assertIn("n/a", text)
 
+    def test_unverified_success_counts_as_available_but_not_as_fixed_route_metric(self):
+        rows = [
+            row("direct", "cold", 1, baseline=True),
+            row("gateway", "cold", 1, route="unverifiable"),
+            row("direct", "warm", 1, baseline=True),
+            row("gateway", "warm", 1),
+        ]
+        for item in rows:
+            item["scheduled_blocks_per_condition"] = 1
+        report = gateway_probe_report.aggregate(rows, bootstrap_replicates=20)
+        cold = report["arms"]["gateway"]["conditions"]["cold"]
+        self.assertEqual(cold["denominators"]["success"], 1)
+        self.assertEqual(cold["availability"]["rate"], 1.0)
+        self.assertEqual(
+            cold["metrics"]["total_s"]["coverage"],
+            {"covered": 0, "total": 1, "ratio": 0.0},
+        )
+        self.assertIsNone(cold["metrics"]["total_s"]["p50"])
+        self.assertEqual(
+            cold["metrics"]["total_tokens"]["coverage"],
+            {"covered": 0, "total": 1, "ratio": 0.0},
+        )
+        self.assertEqual(
+            cold["metrics"]["measured_cost_usd"]["coverage"],
+            {"covered": 0, "total": 1, "ratio": 0.0},
+        )
+
     def test_rejects_mixed_comparison_duplicate_logical_and_provenance_drift(self):
         direct = row("direct", "cold", 1, baseline=True)
         gateway = row("gateway", "cold", 1)

--- a/obench/tests/test_gateway_probe_results.py
+++ b/obench/tests/test_gateway_probe_results.py
@@ -1,0 +1,173 @@
+import copy
+import dataclasses
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from obench import (
+    gateway_probe_results,
+    gateway_probe_run,
+    gateway_probe_spec,
+    gateway_run,
+    gateway_spec,
+)
+from obench.gateway_probe_models import GatewayProbeRunError
+from obench.tests.test_gateway_probe_spec import manifest
+
+
+def bound_row(experiment, block, schedule_digest, price_digest):
+    arm = next(
+        item for item in experiment.arms if item.arm_id == block.arm_ids[0]
+    )
+    identity = gateway_probe_results.make_identity(
+        experiment, arm, block, 0, schedule_digest, price_digest
+    )
+    return {
+        "schema_version": gateway_probe_results.RESULT_SCHEMA_VERSION,
+        "benchmark": gateway_probe_results.BENCHMARK,
+        "cell_id": gateway_probe_results.cell_id(identity),
+        "identity": identity,
+        "expected_arm_ids": sorted(item.arm_id for item in experiment.arms),
+        "scheduled_blocks_per_condition": (
+            len(experiment.cases) * experiment.repetitions
+        ),
+        "arm_role": arm.route_kind,
+        "baseline": arm.baseline,
+        "model_match": experiment.model_match,
+        "outcome": {
+            "attempted": True,
+            "success": True,
+            "available": True,
+            "http_status": 200,
+            "timed_out": False,
+            "error_class": None,
+            "error_detail": None,
+            "budget_exhausted_reason": None,
+        },
+        "route_integrity": {
+            "status": "verified",
+            "pass": True,
+            "reasons": [],
+        },
+        "request_metrics": {
+            "connection": {},
+            "timing": {},
+            "usage": None,
+            "generation": None,
+            "cache": {},
+            "route": None,
+            "costs": {},
+            "stream": None,
+            "coverage": None,
+        },
+        "reuse_evidence": {
+            "required": False,
+            "completed": False,
+            "http_status": None,
+            "socket_reused": None,
+            "primer_nonce_sha256": "1" * 64,
+            "measured_nonce_sha256": "2" * 64,
+            "connection": {},
+            "route_integrity": None,
+            "usage": None,
+            "cache": None,
+            "costs": {},
+        },
+        "billing": {
+            "primer_cost_usd": None,
+            "measured_cost_usd": "0",
+            "charged_cost_usd": "0",
+            "stop_required": True,
+        },
+    }
+
+
+class GatewayProbeResultsTests(unittest.TestCase):
+    def test_resume_rows_are_fully_bound(self):
+        env = {
+            gateway_run.FROZEN_PRICES_ENV: json.dumps({
+                "openai/gpt-4o-mini": {
+                    "input_per_million": "1",
+                    "output_per_million": "2",
+                    "effective_at": "2026-07-25T00:00:00Z",
+                }
+            }),
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            spec_path = Path(tmp, "probe.toml")
+            spec_path.write_text(manifest(), encoding="utf-8")
+            experiment = gateway_probe_spec.load_experiment(spec_path)
+            schedule = gateway_probe_run.build_schedule(experiment)
+            schedule_digest = gateway_spec.canonical_digest(
+                [dataclasses.asdict(block) for block in schedule]
+            )
+            _prices, price_snapshot = gateway_run.load_frozen_prices(env)
+            price_digest = gateway_spec.canonical_digest(price_snapshot)
+            base = bound_row(
+                experiment, schedule[0], schedule_digest, price_digest
+            )
+            variants = {}
+            variants["schema"] = copy.deepcopy(base)
+            variants["schema"]["schema_version"] = 999
+            variants["cell_id"] = copy.deepcopy(base)
+            variants["cell_id"]["cell_id"] = "forged"
+            variants["block_id"] = copy.deepcopy(base)
+            variants["block_id"]["identity"]["schedule"]["block_id"] = "forged"
+            variants["arm_digest"] = copy.deepcopy(base)
+            variants["arm_digest"]["identity"]["arm"]["digest"] = "f" * 64
+            variants["prompt_digest"] = copy.deepcopy(base)
+            variants["prompt_digest"]["identity"]["case"][
+                "prompt_digest"
+            ] = "f" * 64
+            variants["expected_arms"] = copy.deepcopy(base)
+            variants["expected_arms"]["expected_arm_ids"] = [
+                base["identity"]["arm"]["id"]
+            ]
+            variants["membership"] = copy.deepcopy(base)
+            variants["membership"]["identity"]["schedule"]["repetition"] = 999
+            variants["comparison"] = copy.deepcopy(base)
+            variants["comparison"]["identity"]["comparison"][
+                "price_digest"
+            ] = "f" * 64
+            variants["provenance"] = copy.deepcopy(base)
+            variants["provenance"]["arm_role"] = (
+                "gateway" if base["arm_role"] == "direct" else "direct"
+            )
+            for name, candidate in variants.items():
+                if name not in {
+                    "schema", "cell_id", "expected_arms", "provenance"
+                }:
+                    candidate["cell_id"] = gateway_probe_results.cell_id(
+                        candidate["identity"]
+                    )
+                with self.subTest(name=name):
+                    with self.assertRaises(GatewayProbeRunError):
+                        gateway_probe_results.validate_resume_rows(
+                            [candidate],
+                            experiment=experiment,
+                            schedule=schedule,
+                            schedule_digest=schedule_digest,
+                            price_digest=price_digest,
+                        )
+
+    def test_jsonl_rejects_duplicate_cell_and_unterminated_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "results.jsonl")
+            row = {
+                "benchmark": gateway_probe_results.BENCHMARK,
+                "cell_id": "cell",
+            }
+            path.write_text(json.dumps(row), encoding="utf-8")
+            with self.assertRaises(GatewayProbeRunError):
+                gateway_probe_results.load_results(path)
+            path.write_text(
+                json.dumps(row) + "\n" + json.dumps(row) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(GatewayProbeRunError):
+                gateway_probe_results.load_results(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_gateway_probe_results.py
+++ b/obench/tests/test_gateway_probe_results.py
@@ -23,6 +23,7 @@ def bound_row(experiment, block, schedule_digest, price_digest):
     identity = gateway_probe_results.make_identity(
         experiment, arm, block, 0, schedule_digest, price_digest
     )
+    cold = block.condition == "cold"
     return {
         "schema_version": gateway_probe_results.RESULT_SCHEMA_VERSION,
         "benchmark": gateway_probe_results.BENCHMARK,
@@ -51,25 +52,49 @@ def bound_row(experiment, block, schedule_digest, price_digest):
             "reasons": [],
         },
         "request_metrics": {
-            "connection": {},
-            "timing": {},
+            "setup": (
+                {"dns_s": 0.01, "tcp_s": 0.02, "tls_s": 0.03}
+                if cold else None
+            ),
+            "timing": {
+                "request_to_response_headers_s": 0.1,
+                "request_to_first_body_byte_s": 0.15,
+                "request_to_semantic_ttft_s": 0.2,
+                "request_stream_total_s": 0.3,
+                "cold_end_to_end_response_headers_s": 0.16 if cold else None,
+                "cold_end_to_end_first_body_byte_s": 0.21 if cold else None,
+                "cold_end_to_end_semantic_ttft_s": 0.26 if cold else None,
+                "cold_end_to_end_stream_total_s": 0.36 if cold else None,
+            },
+            "receipt_headers": {},
             "usage": None,
             "generation": None,
-            "cache": {},
+            "cache": {
+                "cached_input_tokens": None,
+                "cache_write_input_tokens": None,
+            },
             "route": None,
             "costs": {},
-            "stream": None,
+            "stream": {
+                "done": True,
+                "terminal_status": "completed",
+                "finalized": True,
+            },
             "coverage": None,
         },
         "reuse_evidence": {
-            "required": False,
-            "completed": False,
-            "http_status": None,
-            "socket_reused": None,
+            "required": not cold,
+            "completed": not cold,
+            "http_status": 200 if not cold else None,
+            "socket_reused": True if not cold else None,
             "primer_nonce_sha256": "1" * 64,
             "measured_nonce_sha256": "2" * 64,
-            "connection": {},
-            "route_integrity": None,
+            "setup": {"dns_s": 0.01, "tcp_s": 0.02, "tls_s": 0.03},
+            "receipt_headers": {},
+            "route_integrity": (
+                {"status": "verified", "pass": True, "reasons": []}
+                if not cold else None
+            ),
             "usage": None,
             "cache": None,
             "costs": {},
@@ -107,9 +132,15 @@ class GatewayProbeResultsTests(unittest.TestCase):
             base = bound_row(
                 experiment, schedule[0], schedule_digest, price_digest
             )
+            warm_base = bound_row(
+                experiment,
+                next(block for block in schedule if block.condition == "warm"),
+                schedule_digest,
+                price_digest,
+            )
             variants = {}
             variants["schema"] = copy.deepcopy(base)
-            variants["schema"]["schema_version"] = 999
+            variants["schema"]["schema_version"] = 2
             variants["cell_id"] = copy.deepcopy(base)
             variants["cell_id"]["cell_id"] = "forged"
             variants["block_id"] = copy.deepcopy(base)
@@ -134,6 +165,44 @@ class GatewayProbeResultsTests(unittest.TestCase):
             variants["provenance"]["arm_role"] = (
                 "gateway" if base["arm_role"] == "direct" else "direct"
             )
+            variants["unsafe_receipt"] = copy.deepcopy(base)
+            variants["unsafe_receipt"]["request_metrics"]["receipt_headers"] = {
+                "authorization": "secret"
+            }
+            variants["timing_schema"] = copy.deepcopy(base)
+            variants["timing_schema"]["request_metrics"]["timing"]["ttfb_s"] = 1.0
+            variants["timing_order"] = copy.deepcopy(base)
+            variants["timing_order"]["request_metrics"]["timing"][
+                "request_to_response_headers_s"
+            ] = 0.25
+            variants["timing_offset"] = copy.deepcopy(base)
+            variants["timing_offset"]["request_metrics"]["timing"][
+                "cold_end_to_end_semantic_ttft_s"
+            ] = 0.4
+            variants["success_timeout"] = copy.deepcopy(base)
+            variants["success_timeout"]["outcome"].update({
+                "timed_out": True,
+                "error_class": "timeout",
+                "error_detail": "timeout",
+            })
+            variants["success_without_stream"] = copy.deepcopy(base)
+            variants["success_without_stream"]["request_metrics"]["stream"] = None
+            variants["numeric_socket_reuse"] = copy.deepcopy(base)
+            variants["numeric_socket_reuse"]["reuse_evidence"][
+                "socket_reused"
+            ] = 1
+            variants["warm_without_reuse"] = copy.deepcopy(warm_base)
+            variants["warm_without_reuse"]["reuse_evidence"][
+                "socket_reused"
+            ] = False
+            variants["nested_private_field"] = copy.deepcopy(base)
+            variants["nested_private_field"]["request_metrics"]["route"] = {
+                "private_output": "must-not-persist"
+            }
+            variants["inconsistent_charged_cost"] = copy.deepcopy(base)
+            variants["inconsistent_charged_cost"]["billing"][
+                "charged_cost_usd"
+            ] = "1"
             for name, candidate in variants.items():
                 if name not in {
                     "schema", "cell_id", "expected_arms", "provenance"

--- a/obench/tests/test_gateway_probe_run.py
+++ b/obench/tests/test_gateway_probe_run.py
@@ -32,8 +32,8 @@ def environment():
     }
 
 
-def canned_result(*, stop_required=False):
-    return {
+def canned_result(*, stop_required=False, condition="cold"):
+    result = {
         "outcome": {
             "attempted": True,
             "success": True,
@@ -52,16 +52,22 @@ def canned_result(*, stop_required=False):
             "reasons": [],
         },
         "request_metrics": {
-            "connection": {
+            "setup": {
                 "dns_s": 0.01,
                 "tcp_s": 0.01,
                 "tls_s": 0.01,
             },
             "timing": {
-                "ttfb_s": 0.1,
-                "semantic_ttft_s": 0.2,
-                "total_s": 0.3,
+                "request_to_response_headers_s": 0.1,
+                "request_to_first_body_byte_s": 0.15,
+                "request_to_semantic_ttft_s": 0.2,
+                "request_stream_total_s": 0.3,
+                "cold_end_to_end_response_headers_s": 0.13,
+                "cold_end_to_end_first_body_byte_s": 0.18,
+                "cold_end_to_end_semantic_ttft_s": 0.23,
+                "cold_end_to_end_stream_total_s": 0.33,
             },
+            "receipt_headers": {},
             "usage": {
                 "input_tokens": 1,
                 "output_tokens": 1,
@@ -77,7 +83,11 @@ def canned_result(*, stop_required=False):
                 "provider": "openai",
             },
             "costs": {},
-            "stream": {"done": True, "terminal_status": "completed"},
+            "stream": {
+                "done": True,
+                "terminal_status": "completed",
+                "finalized": True,
+            },
             "coverage": {},
         },
         "reuse_evidence": {
@@ -87,7 +97,8 @@ def canned_result(*, stop_required=False):
             "socket_reused": None,
             "primer_nonce_sha256": "1" * 64,
             "measured_nonce_sha256": "2" * 64,
-            "connection": {},
+            "setup": {"dns_s": None, "tcp_s": None, "tls_s": None},
+            "receipt_headers": {},
             "route_integrity": None,
             "usage": None,
             "cache": None,
@@ -100,6 +111,34 @@ def canned_result(*, stop_required=False):
             "stop_required": stop_required,
         },
     }
+    if condition == "warm":
+        result["request_metrics"]["setup"] = None
+        for name in (
+            "cold_end_to_end_response_headers_s",
+            "cold_end_to_end_first_body_byte_s",
+            "cold_end_to_end_semantic_ttft_s",
+            "cold_end_to_end_stream_total_s",
+        ):
+            result["request_metrics"]["timing"][name] = None
+        result["reuse_evidence"]["required"] = True
+        result["reuse_evidence"]["completed"] = True
+        result["reuse_evidence"]["socket_reused"] = True
+        result["reuse_evidence"]["http_status"] = 200
+        result["reuse_evidence"]["route_integrity"] = {
+            "status": "verified",
+            "pass": True,
+            "reasons": [],
+        }
+    return result
+
+
+def canned_execute(*, stop_required=False):
+    def execute(**kwargs):
+        return canned_result(
+            stop_required=stop_required,
+            condition=kwargs["block"].condition,
+        )
+    return execute
 
 
 class GatewayProbeRunTests(unittest.TestCase):
@@ -164,7 +203,7 @@ class GatewayProbeRunTests(unittest.TestCase):
             with mock.patch.object(
                 gateway_probe_http,
                 "execute_request",
-                return_value=canned_result(stop_required=True),
+                side_effect=canned_execute(stop_required=True),
             ) as execute:
                 first = gateway_probe_run.run_experiment(
                     spec_path, results_path=results_path, environ=environment()
@@ -185,7 +224,7 @@ class GatewayProbeRunTests(unittest.TestCase):
             with mock.patch.object(
                 gateway_probe_http,
                 "execute_request",
-                return_value=canned_result(),
+                side_effect=canned_execute(),
             ):
                 first = gateway_probe_run.run_experiment(
                     spec_path, results_path=results_path, environ=environment()

--- a/obench/tests/test_gateway_probe_run.py
+++ b/obench/tests/test_gateway_probe_run.py
@@ -1,0 +1,213 @@
+import dataclasses
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from obench import (
+    gateway_probe_http,
+    gateway_probe_results,
+    gateway_probe_run,
+    gateway_probe_spec,
+    gateway_run,
+    gateway_spec,
+)
+from obench.gateway_probe_models import GatewayProbeRunError
+from obench.tests.test_gateway_probe_results import bound_row
+from obench.tests.test_gateway_probe_spec import manifest
+
+
+def environment():
+    return {
+        "OPENAI_API_KEY": "direct-secret",
+        "OPENROUTER_API_KEY": "gateway-secret",
+        gateway_run.FROZEN_PRICES_ENV: json.dumps({
+            "openai/gpt-4o-mini": {
+                "input_per_million": "1",
+                "output_per_million": "2",
+                "effective_at": "2026-07-25T00:00:00Z",
+            }
+        }),
+    }
+
+
+def canned_result(*, stop_required=False):
+    return {
+        "outcome": {
+            "attempted": True,
+            "success": True,
+            "available": True,
+            "http_status": 200,
+            "timed_out": False,
+            "error_class": None,
+            "error_detail": None,
+            "budget_exhausted_reason": (
+                "usd_cap_reached" if stop_required else None
+            ),
+        },
+        "route_integrity": {
+            "status": "verified",
+            "pass": True,
+            "reasons": [],
+        },
+        "request_metrics": {
+            "connection": {
+                "dns_s": 0.01,
+                "tcp_s": 0.01,
+                "tls_s": 0.01,
+            },
+            "timing": {
+                "ttfb_s": 0.1,
+                "semantic_ttft_s": 0.2,
+                "total_s": 0.3,
+            },
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "total_tokens": 2,
+            },
+            "generation": {"tokens_per_second": 10.0},
+            "cache": {
+                "cached_input_tokens": None,
+                "cache_write_input_tokens": None,
+            },
+            "route": {
+                "served_model": "gpt-4o-mini",
+                "provider": "openai",
+            },
+            "costs": {},
+            "stream": {"done": True, "terminal_status": "completed"},
+            "coverage": {},
+        },
+        "reuse_evidence": {
+            "required": False,
+            "completed": False,
+            "http_status": None,
+            "socket_reused": None,
+            "primer_nonce_sha256": "1" * 64,
+            "measured_nonce_sha256": "2" * 64,
+            "connection": {},
+            "route_integrity": None,
+            "usage": None,
+            "cache": None,
+            "costs": {},
+        },
+        "billing": {
+            "primer_cost_usd": None,
+            "measured_cost_usd": "1.00" if stop_required else "0",
+            "charged_cost_usd": "1.00" if stop_required else "0",
+            "stop_required": stop_required,
+        },
+    }
+
+
+class GatewayProbeRunTests(unittest.TestCase):
+    def test_schedule_is_deterministic_and_conditions_are_interleaved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spec_path = Path(tmp, "probe.toml")
+            spec_path.write_text(manifest(), encoding="utf-8")
+            base = gateway_probe_spec.load_experiment(spec_path)
+        expanded = dataclasses.replace(base, repetitions=4)
+        first = gateway_probe_run.build_schedule(expanded)
+        self.assertEqual(first, gateway_probe_run.build_schedule(expanded))
+        self.assertEqual(
+            [item.condition for item in first],
+            [
+                first[0].condition,
+                "warm" if first[0].condition == "cold" else "cold",
+            ]
+            * 4,
+        )
+
+    def test_resume_validation_precedes_budget_accounting(self):
+        env = environment()
+        with tempfile.TemporaryDirectory() as tmp:
+            spec_path = Path(tmp, "probe.toml")
+            results_path = Path(tmp, "probe.jsonl")
+            spec_path.write_text(manifest(), encoding="utf-8")
+            experiment = gateway_probe_spec.load_experiment(spec_path)
+            schedule = gateway_probe_run.build_schedule(experiment)
+            schedule_digest = gateway_spec.canonical_digest(
+                [dataclasses.asdict(block) for block in schedule]
+            )
+            _prices, price_snapshot = gateway_run.load_frozen_prices(env)
+            price_digest = gateway_spec.canonical_digest(
+                price_snapshot
+            )
+            row = bound_row(
+                experiment, schedule[0], schedule_digest, price_digest
+            )
+            row["cell_id"] = "forged"
+            results_path.write_text(
+                json.dumps(row, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            with mock.patch.object(
+                gateway_probe_results,
+                "charged_cost",
+                side_effect=AssertionError(
+                    "budget read before identity validation"
+                ),
+            ):
+                with self.assertRaises(GatewayProbeRunError):
+                    gateway_probe_run.run_experiment(
+                        spec_path,
+                        results_path=results_path,
+                        environ=env,
+                    )
+
+    def test_cumulative_cap_stops_after_paid_partial_block_and_on_resume(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spec_path = Path(tmp, "probe.toml")
+            results_path = Path(tmp, "probe.jsonl")
+            spec_path.write_text(manifest(), encoding="utf-8")
+            with mock.patch.object(
+                gateway_probe_http,
+                "execute_request",
+                return_value=canned_result(stop_required=True),
+            ) as execute:
+                first = gateway_probe_run.run_experiment(
+                    spec_path, results_path=results_path, environ=environment()
+                )
+                second = gateway_probe_run.run_experiment(
+                    spec_path, results_path=results_path, environ=environment()
+                )
+        self.assertEqual(execute.call_count, 1)
+        self.assertEqual(first.rows_appended, 1)
+        self.assertEqual(first.blocks_completed, 0)
+        self.assertEqual(second.rows_appended, 0)
+
+    def test_run_resumes_complete_blocks_and_replaces_partial_latest_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            spec_path = Path(tmp, "probe.toml")
+            results_path = Path(tmp, "probe.jsonl")
+            spec_path.write_text(manifest(), encoding="utf-8")
+            with mock.patch.object(
+                gateway_probe_http,
+                "execute_request",
+                return_value=canned_result(),
+            ):
+                first = gateway_probe_run.run_experiment(
+                    spec_path, results_path=results_path, environ=environment()
+                )
+                second = gateway_probe_run.run_experiment(
+                    spec_path, results_path=results_path, environ=environment()
+                )
+                lines = results_path.read_text(
+                    encoding="utf-8"
+                ).splitlines()
+                results_path.write_text(
+                    "\n".join(lines[:-1]) + "\n", encoding="utf-8"
+                )
+                repaired = gateway_probe_run.run_experiment(
+                    spec_path, results_path=results_path, environ=environment()
+                )
+        self.assertEqual(first.rows_appended, 8)
+        self.assertEqual(second.rows_appended, 0)
+        self.assertEqual(second.blocks_skipped, 4)
+        self.assertEqual(repaired.rows_appended, 2)
+        self.assertEqual(repaired.blocks_replaced, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_gateway_probe_spec.py
+++ b/obench/tests/test_gateway_probe_spec.py
@@ -1,0 +1,133 @@
+import dataclasses
+import unittest
+
+from obench import gateway_probe_spec
+
+
+def manifest(prompt="Return the word probe."):
+    return f"""
+schema_version = 1
+experiment_id = "probe-test"
+track = "request_probe"
+model_match = "exact_revision"
+repetitions = 2
+schedule_seed = 17
+allow_private_endpoint = false
+
+[budget]
+timeout_s = 30
+max_output_tokens = 64
+usd_cap = 0.05
+
+[[cases]]
+case_id = "short"
+prompt = {prompt!r}
+
+[[arms]]
+arm_id = "direct"
+route_kind = "direct"
+endpoint = "https://api.openai.com/v1/responses"
+protocol = "openai_responses"
+baseline = true
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENAI_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 17
+
+[[arms]]
+arm_id = "gateway"
+route_kind = "gateway"
+gateway = "openrouter"
+direct_control_arm_id = "direct"
+endpoint = "https://openrouter.ai/api/v1/responses"
+protocol = "openai_responses"
+baseline = false
+canonical_model = "openai/gpt-4o-mini"
+requested_model = "openai/gpt-4o-mini"
+requested_provider = "openai"
+allowed_models = ["openai/gpt-4o-mini"]
+allowed_providers = ["openai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENROUTER_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 17
+"""
+
+
+class GatewayProbeSpecTests(unittest.TestCase):
+    def test_parses_and_digest_binds_fixed_prompt(self):
+        first = gateway_probe_spec.parse_experiment_toml(manifest())
+        second = gateway_probe_spec.parse_experiment_toml(manifest("Different prompt."))
+        self.assertEqual(first.track, "request_probe")
+        self.assertNotEqual(first.digest, second.digest)
+        self.assertNotEqual(first.cases[0].prompt_digest, second.cases[0].prompt_digest)
+        self.assertEqual({arm.protocol for arm in first.arms}, {"openai_responses"})
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            first.repetitions = 3
+
+    def test_rejects_agent_fields_and_route_policy_drift(self):
+        with self.assertRaisesRegex(
+            gateway_probe_spec.GatewayProbeSpecError, "unknown field: harness"
+        ):
+            gateway_probe_spec.parse_experiment_toml(
+                manifest().replace('track = "request_probe"', 'track = "request_probe"\nharness = "pi"')
+            )
+        with self.assertRaisesRegex(
+            gateway_probe_spec.GatewayProbeSpecError, "retry_count"
+        ):
+            gateway_probe_spec.parse_experiment_toml(
+                manifest().replace("retry_count = 0", "retry_count = 1", 1)
+            )
+
+    def test_compile_reuses_secret_isolation_and_rebinds_probe_track(self):
+        experiment = gateway_probe_spec.parse_experiment_toml(manifest())
+        plans, secrets = gateway_probe_spec.compile_route_plans(
+            experiment,
+            environ={"OPENAI_API_KEY": "direct-secret", "OPENROUTER_API_KEY": "gateway-secret"},
+            admitted_auth_envs={"OPENAI_API_KEY", "OPENROUTER_API_KEY"},
+        )
+        self.assertEqual({plan.track for plan in plans}, {"request_probe"})
+        self.assertTrue(all(plan.experiment_digest == experiment.digest for plan in plans))
+        persisted = gateway_probe_spec.gateway_spec.canonical_json(
+            [plan.to_dict() for plan in plans]
+        )
+        self.assertNotIn("direct-secret", persisted)
+        self.assertNotIn("gateway-secret", persisted)
+        self.assertEqual(secrets.value_for("direct"), "direct-secret")
+
+    def test_compile_revalidates_manually_constructed_probe(self):
+        experiment = gateway_probe_spec.parse_experiment_toml(manifest())
+        invalid_arm = dataclasses.replace(experiment.arms[0], retry_count=1)
+        invalid = dataclasses.replace(
+            experiment, arms=(invalid_arm, experiment.arms[1])
+        )
+        with self.assertRaisesRegex(
+            gateway_probe_spec.GatewayProbeSpecError, "retry_count"
+        ):
+            gateway_probe_spec.compile_route_plans(
+                invalid,
+                environ={
+                    "OPENAI_API_KEY": "direct-secret",
+                    "OPENROUTER_API_KEY": "gateway-secret",
+                },
+                admitted_auth_envs={
+                    "OPENAI_API_KEY", "OPENROUTER_API_KEY"
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obench/tests/test_gateway_profiles.py
+++ b/obench/tests/test_gateway_profiles.py
@@ -98,16 +98,15 @@ class GatewayRequestProfileTests(unittest.TestCase):
             "0123456789abcdef0123456789abcdef/"
             "openbench-gateway-bench/compat/chat/completions"
         )
-        for endpoint in (rest_endpoint, compat_endpoint):
-            with self.subTest(endpoint=endpoint):
-                gateway_profiles.validate_arm(
-                    route_kind="gateway",
-                    gateway="cloudflare",
-                    endpoint=endpoint,
-                    protocol="openai_chat",
-                    requested_model="openai/gpt-4o-mini",
-                    requested_provider="openai",
-                )
+        gateway_profiles.validate_arm(
+            route_kind="gateway",
+            gateway="cloudflare",
+            gateway_id="openbench-gateway-bench",
+            endpoint=rest_endpoint,
+            protocol="openai_chat",
+            requested_model="openai/gpt-4o-mini",
+            requested_provider="openai",
+        )
 
         invalid_endpoints = (
             rest_endpoint.replace(
@@ -118,17 +117,18 @@ class GatewayRequestProfileTests(unittest.TestCase):
             ),
             rest_endpoint + "?gateway=other",
             compat_endpoint.replace("openbench-gateway-bench", "{gateway_id}"),
-            compat_endpoint.replace("/compat/chat/completions", "/openai"),
+            compat_endpoint,
         )
         for invalid in invalid_endpoints:
             with self.subTest(endpoint=invalid):
                 with self.assertRaisesRegex(
                     gateway_profiles.GatewayProfileError,
-                    "cloudflare endpoint must be",
+                    "cloudflare managed endpoint must be",
                 ):
                     gateway_profiles.validate_arm(
                         route_kind="gateway",
                         gateway="cloudflare",
+                        gateway_id="openbench-gateway-bench",
                         endpoint=invalid,
                         protocol="openai_chat",
                         requested_model="openai/gpt-4o-mini",
@@ -142,6 +142,7 @@ class GatewayRequestProfileTests(unittest.TestCase):
             gateway_profiles.validate_arm(
                 route_kind="gateway",
                 gateway="cloudflare",
+                gateway_id="openbench-gateway-bench",
                 endpoint=rest_endpoint,
                 protocol="openai_chat",
                 requested_model="anthropic/gpt-4o-mini",
@@ -153,6 +154,7 @@ class GatewayRequestProfileTests(unittest.TestCase):
         gateway_profiles.validate_arm(
             route_kind="gateway",
             gateway="cloudflare",
+            gateway_id="openbench-gateway-bench",
             endpoint=responses_endpoint,
             protocol="openai_responses",
             requested_model="openai/gpt-4o-mini",
@@ -160,17 +162,44 @@ class GatewayRequestProfileTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             gateway_profiles.GatewayProfileError,
-            "cloudflare endpoint must be",
+            "cloudflare managed endpoint must be",
         ):
             gateway_profiles.validate_arm(
                 route_kind="gateway",
                 gateway="cloudflare",
+                gateway_id="openbench-gateway-bench",
                 endpoint=responses_endpoint,
                 protocol="openai_chat",
                 requested_model="openai/gpt-4o-mini",
                 requested_provider="openai",
             )
 
+        with self.assertRaisesRegex(
+            gateway_profiles.GatewayProfileError,
+            "requires a valid gateway_id",
+        ):
+            gateway_profiles.validate_arm(
+                route_kind="gateway",
+                gateway="cloudflare",
+                endpoint=responses_endpoint,
+                protocol="openai_responses",
+                requested_model="openai/gpt-4o-mini",
+                requested_provider="openai",
+            )
+        with self.assertRaisesRegex(
+            gateway_profiles.GatewayProfileError,
+            "cloudflare managed endpoint must be",
+        ):
+            gateway_profiles.validate_arm(
+                route_kind="gateway",
+                gateway="cloudflare",
+                gateway_id="openbench-gateway-bench",
+                endpoint=compat_endpoint,
+                protocol="openai_chat",
+                requested_model="openai/gpt-4o-mini",
+                requested_provider="openai",
+                allow_private_endpoint=True,
+            )
     def test_cloudflare_overwrites_headers_and_strips_body_controls(self):
         body = self.base_body()
         body.update({
@@ -194,10 +223,13 @@ class GatewayRequestProfileTests(unittest.TestCase):
         self.assertNotIn("cache_control", body["messages"][0])
         self.assertEqual(
             gateway_profiles.request_headers(
-                gateway="cloudflare", secret="secret"
+                gateway="cloudflare",
+                gateway_id="openbench-gateway-bench",
+                secret="secret",
             ),
             {
                 "Authorization": "Bearer secret",
+                "cf-aig-gateway-id": "openbench-gateway-bench",
                 "cf-aig-skip-cache": "true",
                 "cf-aig-max-attempts": "1",
                 "cf-aig-collect-log-payload": "false",

--- a/obench/tests/test_gateway_publish.py
+++ b/obench/tests/test_gateway_publish.py
@@ -120,6 +120,7 @@ class GatewayPublishTests(unittest.TestCase):
                 "endpoint": "https://router.example.test/private/model",
             }],
         }
+
         self.prices = {
             "schema_version": 1,
             "price_id": "prices-1",
@@ -211,6 +212,34 @@ class GatewayPublishTests(unittest.TestCase):
             "transcript_path": "/Users/private/transcript.txt",
         }
         self._write_ledger()
+
+    def test_public_experiment_retains_cloudflare_managed_gateway_id(self):
+        source = experiment().to_dict()
+        gateway = source["arms"][1]
+        gateway.update({
+            "gateway": "cloudflare",
+            "gateway_id": "openbench-gateway-bench",
+            "endpoint": (
+                "https://api.cloudflare.com/client/v4/accounts/"
+                "0123456789abcdef0123456789abcdef/ai/v1/chat/completions"
+            ),
+            "auth_env": "CLOUDFLARE_API_TOKEN",
+        })
+        managed = gateway_spec.parse_experiment(source)
+
+        public = gateway_publish._experiment_dto(
+            managed.to_dict(),
+            managed.digest,
+        )
+
+        self.assertEqual(
+            public["arms"][1]["gateway_id"],
+            "openbench-gateway-bench",
+        )
+        self.assertEqual(
+            public["arms"][1]["arm_digest"],
+            managed.arms[1].digest,
+        )
 
     def test_provider_prompt_mode_is_bound_across_publication_artifacts(self):
         gateway_publish._require_provider_prompt_mode_binding(  # noqa: SLF001

--- a/obench/tests/test_gateway_route.py
+++ b/obench/tests/test_gateway_route.py
@@ -119,6 +119,7 @@ def route_plan(
     arm_id,
     arm_digest,
     gateway=None,
+    gateway_id=None,
     protocol="openai_chat",
     provider_prompt_mode="provider_default",
 ):
@@ -144,6 +145,7 @@ def route_plan(
         private_host_allowlist=("127.0.0.1",),
         private_cidr_allowlist=(),
         gateway=gateway or ("openrouter" if route_kind == "gateway" else None),
+        gateway_id=gateway_id,
         provider_prompt_mode=provider_prompt_mode,
     )
 
@@ -425,6 +427,44 @@ class GatewayRouteTests(unittest.TestCase):
         self.assertEqual(rows[0]["serving_arm"]["arm_digest"], plan.arm_digest)
         for secret in (HOST_SECRET, CLIENT_SECRET, PRIVATE_PROMPT):
             self.assertNotIn(secret, ledger)
+
+    def test_cloudflare_managed_route_overwrites_gateway_controls(self):
+        token = "cloudflare-managed-cell"
+        plan = route_plan(
+            endpoint=self.upstream_base + "/gateway",
+            route_kind="gateway",
+            arm_id="cloudflare-managed",
+            arm_digest="c" * 64,
+            gateway="cloudflare",
+            gateway_id="openbench-gateway-bench",
+        )
+        self.server.register_cell(token)
+        with mock.patch.object(proxy.gateway_profiles, "validate_arm"):
+            self.server.register_route(token, plan, secret_plan(plan.arm_id))
+
+        status, _ = self._post(
+            token,
+            plan.arm_digest,
+            headers={
+                "authorization": f"Bearer {CLIENT_SECRET}",
+                "cf-aig-gateway-id": "attacker-gateway",
+                "cf-aig-skip-cache": "false",
+                "cf-aig-max-attempts": "99",
+            },
+        )
+
+        self.assertEqual(status, 200)
+        headers = self.upstream.requests[-1]["headers"]
+        self.assertEqual(headers["authorization"], f"Bearer {HOST_SECRET}")
+        self.assertEqual(
+            headers["cf-aig-gateway-id"],
+            "openbench-gateway-bench",
+        )
+        self.assertEqual(headers["cf-aig-skip-cache"], "true")
+        self.assertEqual(headers["cf-aig-max-attempts"], "1")
+        ledger = self.server.seal_cell(token).path.read_text(encoding="utf-8")
+        for private in (HOST_SECRET, CLIENT_SECRET, "attacker-gateway"):
+            self.assertNotIn(private, ledger)
 
     def test_direct_openai_forces_model_and_sampling_without_gateway_metadata(self):
         token = "direct-cell"

--- a/obench/tests/test_gateway_spec.py
+++ b/obench/tests/test_gateway_spec.py
@@ -309,7 +309,7 @@ class GatewayExperimentTests(unittest.TestCase):
             manifest(budget=manifest_budget() + "\nextra = 1"),
             manifest(gateway_extra='direct_control_arm_id = "direct-openai"\nextra = 1'),
             manifest(gateway_extra=(
-                'gateway_id = "strict-tax"\n'
+                'other_gateway_id = "strict-tax"\n'
                 'direct_control_arm_id = "direct-openai"'
             )),
             manifest(windows=manifest_windows().replace(
@@ -449,7 +449,7 @@ class GatewayExperimentTests(unittest.TestCase):
                 with self.assertRaisesRegex(GatewaySpecError, message):
                     parse_experiment_toml(text)
 
-    def test_vercel_is_admitted_and_cloudflare_requires_logs_verification(self):
+    def test_vercel_and_named_cloudflare_managed_gateway_are_admitted(self):
         vercel = manifest(
             gateway_auth='auth_env = "AI_GATEWAY_API_KEY"',
             gateway_extra=(
@@ -476,17 +476,68 @@ class GatewayExperimentTests(unittest.TestCase):
         ).join(vercel)
         self.assertEqual(parse_experiment_toml(vercel).arms[1].gateway, "vercel")
 
-        with self.assertRaisesRegex(
-            GatewaySpecError,
-            "metadata-only Logs API verification is required",
-        ):
-            parse_experiment_toml(manifest(
-                gateway_auth='auth_env = "CLOUDFLARE_API_TOKEN"',
-                gateway_extra=(
-                    'gateway = "cloudflare"\n'
-                    'direct_control_arm_id = "direct-openai"'
-                ),
-            ))
+        cloudflare = manifest(
+            gateway_auth='auth_env = "CLOUDFLARE_API_TOKEN"',
+            gateway_extra=(
+                'gateway = "cloudflare"\n'
+                'gateway_id = "openbench-gateway-bench"\n'
+                'direct_control_arm_id = "direct-openai"'
+            ),
+        ).replace(
+            "https://openrouter.ai/api/v1/chat/completions",
+            "https://api.cloudflare.com/client/v4/accounts/"
+            "0123456789abcdef0123456789abcdef/ai/v1/chat/completions",
+        )
+        cloudflare = cloudflare.rsplit(
+            'requested_model = "gpt-test-2026-07-01"',
+            1,
+        )
+        cloudflare = (
+            'requested_model = "openai/gpt-test-2026-07-01"'
+        ).join(cloudflare)
+        cloudflare = cloudflare.rsplit(
+            'allowed_models = ["gpt-test-2026-07-01"]',
+            1,
+        )
+        cloudflare = (
+            'allowed_models = ["openai/gpt-test-2026-07-01"]'
+        ).join(cloudflare)
+        parsed = parse_experiment_toml(cloudflare)
+        self.assertEqual(
+            parsed.arms[1].gateway_id,
+            "openbench-gateway-bench",
+        )
+        changed = parse_experiment_toml(
+            cloudflare.replace(
+                'gateway_id = "openbench-gateway-bench"',
+                'gateway_id = "openbench-gateway-bench-alt"',
+            )
+        )
+        self.assertNotEqual(parsed.arms[1].digest, changed.arms[1].digest)
+        self.assertNotEqual(parsed.digest, changed.digest)
+        with self.assertRaisesRegex(GatewaySpecError, "requires a valid gateway_id"):
+            parse_experiment_toml(
+                cloudflare.replace(
+                    'gateway_id = "openbench-gateway-bench"\n',
+                    "",
+                )
+            )
+        with self.assertRaisesRegex(GatewaySpecError, "only for cloudflare"):
+            parse_experiment_toml(
+                manifest(
+                    gateway_extra=(
+                        'gateway = "openrouter"\n'
+                        'gateway_id = "not-cloudflare"\n'
+                        'direct_control_arm_id = "direct-openai"'
+                    )
+                )
+            )
+        with self.assertRaisesRegex(GatewaySpecError, "direct arm must not declare"):
+            parse_experiment_toml(
+                manifest(
+                    direct_extra='gateway_id = "not-direct"',
+                )
+            )
 
     def test_responses_protocol_requires_responses_endpoints(self):
         responses = manifest().replace(


### PR DESCRIPTION
## Summary
- add reproducible request-level Gateway Probe with cold/warm phase timing, matched reporting, route verification, cache/token/cost evidence, and resumable bundles
- make the canonical five-way cohort direct OpenAI, OpenRouter, Vercel, Concentrate, and Cloudflare Unified Billing
- bind Cloudflare `gateway_id` into immutable experiment identity and overwrite gateway/cache/retry headers in both Probe and Gateway Bench
- reject provider-native and compatibility/BYOK Cloudflare endpoints from the managed comparison

## Verification
- `python3 -m unittest discover -s obench/tests -v` (1095/1095)
- `obench validate` via `obench.cli:main` (40/40 task polarity checks)
- autoreview: clean, no P0/P1 findings

## Live verification gap
A paid Cloudflare canary was not run because the current Codex environment does not contain `CLOUDFLARE_API_TOKEN` or the frozen price table.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minghinmatthewlam/openbench/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->