### PR TITLE
Gateway: terminate capped cells and publish cap incidence

### DIFF
--- a/docs/gateway-bench.md
+++ b/docs/gateway-bench.md
@@ -31,6 +31,13 @@ arms for one task and repetition. If infrastructure invalidates one cell, the
 whole block is excluded or replaced so every paired comparison uses the same
 task opportunity.
 
+Reaching `budget.max_calls` is a valid treatment outcome, not infrastructure
+failure: the cell remains in the denominator as unsolved with score zero.
+Never rerun only a cap-hit arm after observing its result. A different call
+budget is a separate experiment; any explicit replacement must rerun the
+complete all-arm block for a recorded infrastructure or route-integrity
+invalidation.
+
 Examples:
 
 - [`gateway-bench-responses.toml`](../obench/examples/gateway-bench-responses.toml):
@@ -94,6 +101,7 @@ Reports retain per-metric coverage and use equal task weighting.
 - cost using separately labeled evidence bases;
 - served-model/provider distribution;
 - route-integrity and infrastructure exclusion reasons;
+- per-arm cap-hit cells and cap-affected matched blocks;
 - paired gateway-minus-direct contrasts.
 
 Cost bases are never silently mixed:

--- a/obench/gateway_report.py
+++ b/obench/gateway_report.py
@@ -321,7 +321,8 @@ def _cell(row: Mapping[str, Any], row_number: int) -> dict[str, Any]:
         result.get("checker_score"),
         f"row {row_number} result.checker_score",
     )
-    if result.get("budget_exhausted_reason") == "max_calls":
+    max_calls_exhausted = result.get("budget_exhausted_reason") == "max_calls"
+    if max_calls_exhausted:
         solved = False
         score = 0.0
     available = _bool(
@@ -472,6 +473,7 @@ def _cell(row: Mapping[str, Any], row_number: int) -> dict[str, Any]:
         "solved": 1.0 if solved else 0.0,
         "score": score,
         "availability": 1.0 if available else 0.0,
+        "max_calls_exhausted": max_calls_exhausted,
         "latency": (
             min(duration, timeout)
             if duration is not None
@@ -976,11 +978,21 @@ def aggregate(
                 },
             }
 
+        max_calls_cells = sum(
+            cell["max_calls_exhausted"]
+            for cells in cells_by_task.values()
+            for cell in cells
+        )
         report_arm = {
             "role": arm_metadata[arm_id][0],
             "baseline": arm_metadata[arm_id][1],
             "arm_digest": arm_metadata[arm_id][2],
             "attempted_cells": cells_total,
+            "max_calls": {
+                "cells": max_calls_cells,
+                "total_cells": cells_total,
+                "ratio": max_calls_cells / cells_total if cells_total else 0.0,
+            },
             "metrics": metrics,
             "costs": costs,
             "route_distribution": distribution,
@@ -1064,6 +1076,10 @@ def aggregate(
             "metrics": metrics,
         }
 
+    max_calls_affected_blocks = sum(
+        any(cell["max_calls_exhausted"] for cell in block["cells"].values())
+        for block in analyzed_blocks
+    )
     dto = {
         "schema_version": 1,
         "benchmark": results.GATEWAY_BENCHMARK,
@@ -1072,6 +1088,9 @@ def aggregate(
         "provider_prompt_mode": provider_prompt_mode,
         "experiment_id": next(iter(experiment_ids)),
         "experiment_digest": next(iter(experiment_digests)),
+        "budget": {
+            "max_calls": parsed[0]["identity"].budget_max_calls,
+        },
         "analysis": {
             "weighting": "calls_to_cell_complete_blocks_to_task_tasks_equal",
             "interval": "task_cluster_bootstrap_percentile",
@@ -1085,6 +1104,12 @@ def aggregate(
             "included": len(included_blocks),
             "excluded": len(blocks) - len(included_blocks),
             "excluded_by_reason": dict(sorted(exclusions.items())),
+            "max_calls_affected": max_calls_affected_blocks,
+            "max_calls_rate": (
+                max_calls_affected_blocks / len(included_blocks)
+                if included_blocks
+                else 0.0
+            ),
         },
         "tasks": {"included": eligible_tasks, "names": task_names},
         "baseline_arm": baseline_arm,
@@ -1122,7 +1147,9 @@ def render_text(report: Mapping[str, Any]) -> str:
         lines.append(
             f"{arm_id} ({role}): solve {_format_percent(solve)}, "
             f"score {_format_number(score)}, availability {_format_percent(availability)}, "
-            f"latency {_format_seconds(latency)}"
+            f"latency {_format_seconds(latency)}, "
+            f"call cap {arm['max_calls']['cells']}/{arm['max_calls']['total_cells']} "
+            f"({_format_percent(arm['max_calls']['ratio'])})"
         )
         for basis, cost in arm["costs"].items():
             attempted = cost["attempted_cost_usd"]["estimate"]

--- a/obench/gateway_run.py
+++ b/obench/gateway_run.py
@@ -20,7 +20,7 @@ import sys
 import tempfile
 import time
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
@@ -549,6 +549,16 @@ def _parse_entry_result(stdout: str) -> dict[str, Any]:
     raise GatewayRunError("routed entry emitted no result sentinel")
 
 
+def _kill_process_group(proc: subprocess.Popen[str]) -> None:
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except OSError:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
 def _invoke_local(
     *,
     plan_path: Path,
@@ -558,6 +568,7 @@ def _invoke_local(
     token: str,
     timeout_s: int,
     adapters_dir: Path,
+    max_calls_exceeded: Callable[[], bool] | None = None,
 ) -> dict[str, Any]:
     env = _sanitized_env(
         adapters_dir=adapters_dir,
@@ -582,17 +593,49 @@ def _invoke_local(
         text=True,
         start_new_session=True,
     )
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout_s + 10)
-    except subprocess.TimeoutExpired:
-        os.killpg(proc.pid, signal.SIGKILL)
-        stdout, stderr = proc.communicate()
+    deadline = time.monotonic() + timeout_s + 10
+
+    def max_calls_result(stdout: str, stderr: str) -> dict[str, Any]:
         return {
             "completed": False,
-            "error": f"entry timeout after {timeout_s}s",
+            "error": "entry stopped after max_calls budget exhaustion",
             "output_tail": (stdout + stderr)[-2000:],
-            "entry_timed_out": True,
+            "entry_timed_out": False,
+            "max_calls_exceeded": True,
         }
+
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _kill_process_group(proc)
+                stdout, stderr = proc.communicate()
+                return {
+                    "completed": False,
+                    "error": f"entry timeout after {timeout_s}s",
+                    "output_tail": (stdout + stderr)[-2000:],
+                    "entry_timed_out": True,
+                }
+            try:
+                stdout, stderr = proc.communicate(timeout=min(0.1, remaining))
+                # The session belongs to this cell. Clean up any background
+                # descendants even when the entry leader has already exited.
+                _kill_process_group(proc)
+                if max_calls_exceeded is not None and max_calls_exceeded():
+                    return max_calls_result(stdout, stderr)
+                break
+            except subprocess.TimeoutExpired:
+                if max_calls_exceeded is not None and max_calls_exceeded():
+                    _kill_process_group(proc)
+                    stdout, stderr = proc.communicate()
+                    return max_calls_result(stdout, stderr)
+    except BaseException:
+        _kill_process_group(proc)
+        try:
+            proc.communicate()
+        except BaseException:
+            pass
+        raise
     if proc.returncode != 0:
         raise GatewayRunError(
             f"routed entry exited {proc.returncode}: {(stderr or stdout)[-1000:]}"
@@ -1076,6 +1119,7 @@ def _run_cell(
         f"{results.make_gateway_cell_id(identity)}:{time.time_ns()}".encode()
     ).hexdigest()[:32]
     server.register_cell(token, max_calls=experiment.budget.max_calls)
+    max_calls_event = server.cell_max_calls_event(token)
     server.register_route(token, plan, secret_plan)
     started = time.monotonic()
     infrastructure_reason = None
@@ -1115,6 +1159,7 @@ def _run_cell(
                     token=token,
                     timeout_s=experiment.budget.timeout_s,
                     adapters_dir=adapters_dir,
+                    max_calls_exceeded=max_calls_event.is_set,
                 )
             except Exception as exc:  # noqa: BLE001 - row records infra failure
                 infrastructure_reason = "adapter_entry_failure"
@@ -1130,6 +1175,7 @@ def _run_cell(
             )
             if budget_reason == "max_calls_exceeded":
                 budget_exhausted_reason = "max_calls"
+                infrastructure_reason = None
             else:
                 infrastructure_reason = infrastructure_reason or budget_reason
         except Exception as exc:  # noqa: BLE001 - sealing is evidence-critical

--- a/obench/proxy.py
+++ b/obench/proxy.py
@@ -21,7 +21,7 @@ import sys
 import threading
 import time
 import zlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -92,6 +92,9 @@ class _CellLedger:
     max_calls: int | None = None
     admitted_calls: int = 0
     max_calls_exceeded: bool = False
+    max_calls_event: threading.Event = field(
+        default_factory=threading.Event, repr=False
+    )
     record_count: int = 0
     last_sequence: int = 0
     root_hash: str = EMPTY_LEDGER_HASH
@@ -957,6 +960,14 @@ class CountingProxyServer(ThreadingHTTPServer):
             return None
         return time.monotonic() - ts
 
+    def cell_max_calls_event(self, token: str) -> threading.Event:
+        """Return the cell-owned signal set by its terminal call-cap rejection."""
+        with self._ledger_condition:
+            ledger = self._cell_ledgers.get(token)
+            if ledger is None:
+                raise KeyError(f"cell is not registered: {token}")
+            return ledger.max_calls_event
+
     def admit_cell_request(self, token: str) -> bool:
         """Atomically admit a request, returning False for a legacy cell."""
         with self._ledger_condition:
@@ -971,6 +982,7 @@ class CountingProxyServer(ThreadingHTTPServer):
                     and ledger.write_error is None
                 )
                 ledger.max_calls_exceeded = True
+                ledger.max_calls_event.set()
                 if record:
                     ledger.in_flight += 1
                 raise MaxCallsExceeded(ledger.max_calls, record=record)

--- a/obench/site.py
+++ b/obench/site.py
@@ -280,6 +280,11 @@ def aggregate_gateway_bundle(bundle_dir, *, site_dir=None, manifest_entry=None):
             "mean_checker_score": _metric_dto(metrics.get("mean_checker_score")),
             "availability": _metric_dto(metrics.get("availability")),
             "latency_s": _metric_dto(metrics.get("latency_s")),
+            "max_calls": arm.get("max_calls") or {
+                "cells": 0,
+                "total_cells": arm.get("attempted_cells", 0),
+                "ratio": 0.0,
+            },
             "cost": _pick_cost(arm.get("costs")),
         })
     # Baseline first, then slowest-to-fastest is meaningless before sorting in
@@ -319,9 +324,11 @@ def aggregate_gateway_bundle(bundle_dir, *, site_dir=None, manifest_entry=None):
         "experiment_id": experiment.get("experiment_id"),
         "experiment_digest": report.get("experiment_digest"),
         "execution_lane": experiment.get("execution_lane"),
+        "budget_max_calls": (report.get("budget") or {}).get("max_calls"),
         "blocks_included": blocks.get("included"),
         "blocks_observed": blocks.get("observed"),
         "blocks_excluded": blocks.get("excluded_by_reason") or {},
+        "blocks_max_calls_affected": blocks.get("max_calls_affected", 0),
         "tasks_included": (report.get("tasks") or {}).get("included"),
         "arms": arms,
         "contrasts": contrasts,
@@ -1448,6 +1455,10 @@ def _gateway_board(bundle):
         _meta_field("harness", bundle["harness"]) if bundle.get("harness") else None,
         _meta_field("date", bundle["date"]) if bundle.get("date") else None,
         _meta_field("blocks", f"{bundle['blocks_included']}/{bundle['blocks_observed']}"),
+        _meta_field(
+            "cap-affected blocks",
+            f"{bundle.get('blocks_max_calls_affected', 0)}/{bundle['blocks_included']}",
+        ),
         _meta_field("tasks", bundle["tasks_included"]),
         _meta_field("lane", bundle["execution_lane"]) if bundle.get("execution_lane") else None,
         _meta_field("experiment", (bundle.get("experiment_digest") or "")[:12])
@@ -1493,6 +1504,16 @@ def _gateway_board(bundle):
         {"label": "Availability",
          "cell": lambda a: _fmt_pct(a["availability"]["estimate"]),
          "key": lambda a: a["availability"]["estimate"]},
+        {"label": (
+            f"{bundle['budget_max_calls']}-call cap"
+            if bundle.get("budget_max_calls") is not None
+            else "Call cap"
+         ),
+         "cell": lambda a: (
+             f"{a['max_calls']['cells']}/{a['max_calls']['total_cells']} "
+             f"({_fmt_pct(a['max_calls']['ratio'])})"
+         ),
+         "key": lambda a: a["max_calls"]["ratio"]},
         {"label": "Latency", "dir": "asc",
          "cell": lambda a: _fmt_secs(a["latency_s"]["estimate"]),
          "key": lambda a: a["latency_s"]["estimate"]},

--- a/obench/tests/test_gateway_proxy.py
+++ b/obench/tests/test_gateway_proxy.py
@@ -162,6 +162,8 @@ class GatewayProxyLedgerTests(unittest.TestCase):
         token = "capped-cell"
         max_calls = 8
         self.server.register_cell(token, max_calls=max_calls)
+        max_calls_event = self.server.cell_max_calls_event(token)
+        self.assertFalse(max_calls_event.is_set())
         self.upstream.request_count = 0
         self.upstream.release.set()
         start = threading.Barrier(25)
@@ -198,7 +200,12 @@ class GatewayProxyLedgerTests(unittest.TestCase):
         self.assertEqual([row["status"] for row in requests].count(429), 1)
         rejection = next(row for row in requests if row["status"] == 429)
         self.assertEqual(rejection["error"], "max_calls_exceeded")
+        self.assertTrue(max_calls_event.is_set())
         self.assertNotIn(SECRET, seal.path.read_text(encoding="utf-8"))
+
+    def test_max_calls_signal_requires_registered_cell(self):
+        with self.assertRaisesRegex(KeyError, "cell is not registered"):
+            self.server.cell_max_calls_event("missing")
 
     def test_exhausted_cell_returns_budget_error_while_draining_and_after_seal(self):
         token = "draining-capped-cell"

--- a/obench/tests/test_gateway_report.py
+++ b/obench/tests/test_gateway_report.py
@@ -43,6 +43,7 @@ def make_row(
     duration=10.0,
     calls=None,
     infrastructure_reason=None,
+    budget_exhausted_reason=None,
     route_pass=True,
     route_reasons=None,
     track="fixed_model_provider",
@@ -87,6 +88,7 @@ def make_row(
         "available": available,
         "duration_s": duration,
         "infrastructure_invalid_reason": infrastructure_reason,
+        "budget_exhausted_reason": budget_exhausted_reason,
     }
     row = {
         "schema_version": 2,
@@ -209,7 +211,10 @@ class GatewayReportTests(unittest.TestCase):
             "included": 4,
             "excluded": 0,
             "excluded_by_reason": {},
+            "max_calls_affected": 0,
+            "max_calls_rate": 0.0,
         })
+        self.assertEqual(report["budget"]["max_calls"], 4)
         self.assertEqual(report["tasks"]["included"], 2)
         self.assertEqual(direct["metrics"]["solve_rate"]["estimate"], 1.0)
         self.assertEqual(gateway["metrics"]["solve_rate"]["estimate"], 0.5)
@@ -228,6 +233,36 @@ class GatewayReportTests(unittest.TestCase):
         )
         self.assertFalse(report["analysis"]["wilson_intervals"])
         self.assertFalse(report["analysis"]["composite_score"])
+
+    def test_max_calls_incidence_keeps_cells_in_matched_denominator(self):
+        rows = self.complete_rows()
+        rows[1]["result"].update(
+            solved=True,
+            checker_score=1.0,
+            budget_exhausted_reason="max_calls",
+        )
+
+        report = gateway_report.aggregate(rows, bootstrap_replicates=20)
+
+        self.assertEqual(report["blocks"]["included"], 4)
+        self.assertEqual(report["blocks"]["max_calls_affected"], 1)
+        self.assertEqual(report["blocks"]["max_calls_rate"], 0.25)
+        self.assertEqual(report["arms"]["direct"]["max_calls"], {
+            "cells": 0,
+            "total_cells": 4,
+            "ratio": 0.0,
+        })
+        self.assertEqual(report["arms"]["gateway"]["max_calls"], {
+            "cells": 1,
+            "total_cells": 4,
+            "ratio": 0.25,
+        })
+        self.assertEqual(
+            report["arms"]["gateway"]["metrics"]["solve_rate"]["estimate"],
+            0.25,
+        )
+        rendered = gateway_report.render_text(report)
+        self.assertIn("call cap 1/4 (25.0%)", rendered)
 
     def test_gateway_provider_failure_stays_in_attempted_denominator(self):
         rows = self.complete_rows()

--- a/obench/tests/test_gateway_run.py
+++ b/obench/tests/test_gateway_run.py
@@ -371,6 +371,8 @@ direct_control_arm_id = "direct"
                 "excluded": 0,
                 "excluded_by_reason": {},
                 "included": 1,
+                "max_calls_affected": 0,
+                "max_calls_rate": 0.0,
                 "observed": 1,
             })
             self.assertEqual(report["arms"]["gateway"]["attempted_cells"], 1)
@@ -499,6 +501,8 @@ direct_control_arm_id = "direct"
             "excluded": 0,
             "excluded_by_reason": {},
             "included": 1,
+            "max_calls_affected": 1,
+            "max_calls_rate": 1.0,
             "observed": 1,
         })
         self.assertTrue(all(

--- a/obench/tests/test_gateway_run.py
+++ b/obench/tests/test_gateway_run.py
@@ -8,8 +8,11 @@ import http.client
 import io
 import json
 import os
+import subprocess
+import sys
 import tempfile
 import threading
+import time
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -439,7 +442,9 @@ direct_control_arm_id = "direct"
                 statuses.append(response.status)
                 response.read()
                 conn.close()
-            return {"completed": False, "error": "budget rejection"}
+            raise gateway_run.GatewayRunError(
+                "adapter exited after budget rejection"
+            )
 
         with self._runtime(), mock.patch.object(
             gateway_run, "_invoke_local", side_effect=invoke_many
@@ -507,6 +512,155 @@ direct_control_arm_id = "direct"
         )
         self.assertEqual(ledgers.count('"error":"max_calls_exceeded"'), len(rows))
         self.assertNotIn(SECRET, capped_results.read_text() + ledgers)
+
+    def test_invoke_local_stops_and_reaps_process_group_at_call_cap(self):
+        root = self.root / "invoke-cap"
+        root.mkdir()
+        plan = root / "plan.json"
+        instruction = root / "instruction.txt"
+        workspace = root / "workspace"
+        workspace.mkdir()
+        plan.write_text("{}")
+        instruction.write_text("test")
+        child_pid = root / "child.pid"
+        script = (
+            "import os, pathlib, subprocess, time\n"
+            f"p=subprocess.Popen(['sleep','60'])\n"
+            f"pathlib.Path({str(child_pid)!r}).write_text(str(p.pid))\n"
+            "time.sleep(60)\n"
+        )
+        real_popen = subprocess.Popen
+        with mock.patch.object(
+            gateway_run.subprocess,
+            "Popen",
+            side_effect=lambda *args, **kwargs: real_popen(
+                [sys.executable, "-c", script],
+                stdout=kwargs.get("stdout"),
+                stderr=kwargs.get("stderr"),
+                text=kwargs.get("text"),
+                start_new_session=kwargs.get("start_new_session"),
+            ),
+        ):
+            started = time.monotonic()
+            result = gateway_run._invoke_local(
+                plan_path=plan,
+                instruction_path=instruction,
+                workdir=workspace,
+                proxy_base_url="http://127.0.0.1:1",
+                token="cell",
+                timeout_s=10,
+                adapters_dir=self.adapters,
+                max_calls_exceeded=lambda: child_pid.exists(),
+            )
+        self.assertLess(time.monotonic() - started, 3)
+        self.assertTrue(result["max_calls_exceeded"])
+        pid = int(child_pid.read_text())
+        for _ in range(20):
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            self.fail("call-cap child process survived its process-group kill")
+
+    def test_invoke_local_preserves_call_cap_when_entry_exits_immediately(self):
+        root = self.root / "invoke-cap-exit"
+        root.mkdir()
+        plan = root / "plan.json"
+        instruction = root / "instruction.txt"
+        workspace = root / "workspace"
+        workspace.mkdir()
+        plan.write_text("{}")
+        instruction.write_text("test")
+        cap_signal = root / "cap.signal"
+        script = (
+            "import pathlib, sys\n"
+            f"pathlib.Path({str(cap_signal)!r}).touch()\n"
+            "sys.exit(1)\n"
+        )
+        real_popen = subprocess.Popen
+        with mock.patch.object(
+            gateway_run.subprocess,
+            "Popen",
+            side_effect=lambda *args, **kwargs: real_popen(
+                [sys.executable, "-c", script],
+                stdout=kwargs.get("stdout"),
+                stderr=kwargs.get("stderr"),
+                text=kwargs.get("text"),
+                start_new_session=kwargs.get("start_new_session"),
+            ),
+        ):
+            result = gateway_run._invoke_local(
+                plan_path=plan,
+                instruction_path=instruction,
+                workdir=workspace,
+                proxy_base_url="http://127.0.0.1:1",
+                token="cell",
+                timeout_s=10,
+                adapters_dir=self.adapters,
+                max_calls_exceeded=cap_signal.exists,
+            )
+        self.assertTrue(result["max_calls_exceeded"])
+        self.assertFalse(result["entry_timed_out"])
+
+    def test_invoke_local_reaps_process_group_on_interrupt(self):
+        root = self.root / "invoke-interrupt"
+        root.mkdir()
+        plan = root / "plan.json"
+        instruction = root / "instruction.txt"
+        workspace = root / "workspace"
+        workspace.mkdir()
+        plan.write_text("{}")
+        instruction.write_text("test")
+        child_pid = root / "child.pid"
+        script = (
+            "import pathlib, subprocess, time\n"
+            f"p=subprocess.Popen(['sleep','60'])\n"
+            f"pathlib.Path({str(child_pid)!r}).write_text(str(p.pid))\n"
+            "time.sleep(60)\n"
+        )
+        checks = 0
+
+        def interrupt():
+            nonlocal checks
+            checks += 1
+            if child_pid.exists() and checks > 1:
+                raise KeyboardInterrupt
+            return False
+
+        real_popen = subprocess.Popen
+        with mock.patch.object(
+            gateway_run.subprocess,
+            "Popen",
+            side_effect=lambda *args, **kwargs: real_popen(
+                [sys.executable, "-c", script],
+                stdout=kwargs.get("stdout"),
+                stderr=kwargs.get("stderr"),
+                text=kwargs.get("text"),
+                start_new_session=kwargs.get("start_new_session"),
+            ),
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                gateway_run._invoke_local(
+                    plan_path=plan,
+                    instruction_path=instruction,
+                    workdir=workspace,
+                    proxy_base_url="http://127.0.0.1:1",
+                    token="cell",
+                    timeout_s=10,
+                    adapters_dir=self.adapters,
+                    max_calls_exceeded=interrupt,
+                )
+        pid = int(child_pid.read_text())
+        for _ in range(20):
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            self.fail("interrupted child process survived its process-group kill")
 
     def test_proxy_evidence_honors_parser_integrity_verdict(self):
         experiment = gateway_run.gateway_spec.load_experiment(self.experiment)

--- a/obench/tests/test_site.py
+++ b/obench/tests/test_site.py
@@ -180,6 +180,38 @@ class CostBasisTests(unittest.TestCase):
 
 
 class RenderTests(_SiteFixture):
+    def test_gateway_board_renders_call_cap_denominators(self):
+        metric = {"estimate": 1.0, "low": 0.8, "high": 1.0}
+        bundle = {
+            "title": "Gateway run",
+            "track": "fixed_model_provider",
+            "harness": "pi",
+            "blocks_included": 5,
+            "blocks_observed": 5,
+            "blocks_excluded": {},
+            "blocks_max_calls_affected": 2,
+            "tasks_included": 1,
+            "budget_max_calls": 20,
+            "arms": [{
+                "arm_id": "direct",
+                "role": "direct",
+                "requested_provider": "openai",
+                "solve_rate": metric,
+                "mean_checker_score": metric,
+                "availability": metric,
+                "latency_s": metric,
+                "max_calls": {"cells": 2, "total_cells": 5, "ratio": 0.4},
+                "cost": None,
+            }],
+            "contrasts": [],
+        }
+
+        page = site._gateway_board(bundle)
+
+        self.assertIn("<b>cap-affected blocks </b>2/5", page)
+        self.assertIn("20-call cap", page)
+        self.assertIn("2/5 (40.0%)", page)
+
     def test_harness_token_columns_render_factual_split_semantics(self):
         page = site.render_board_html(site.build_board(self.site_dir))
         for label in (


### PR DESCRIPTION
## Summary
- terminate and reap Gateway Bench adapter process groups immediately after the fixed call budget is exhausted
- preserve capped cells as valid treatment outcomes even when adapter exit races the proxy ledger
- report per-route cap incidence and cap-affected matched blocks in CLI, JSON, and the site
- document that selective route-only backfill is prohibited

## Verification
- `python3 -m unittest discover -s obench/tests -q` (1106 tests)
- `python3 -c 'from obench.cli import main; main()' validate` (40/40 tasks)\n- focused Gateway proxy/runner/report/site tests\n- live five-route max_calls=1 lifecycle smoke\n- autoreview P1 threshold: pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minghinmatthewlam/openbench/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->