### PR TITLE
Gateway: use task-weighted median latency

### DIFF
--- a/docs/gateway-bench.md
+++ b/docs/gateway-bench.md
@@ -92,7 +92,7 @@ single-attempt evidence where the gateway exposes it.
 Reports retain per-metric coverage and use equal task weighting.
 
 - checker solve rate and mean checker score;
-- availability and end-to-end cell latency;
+- availability and task-weighted median end-to-end cell latency;
 - time to first byte and semantic time to first token;
 - output throughput;
 - input, output, and total token usage;
@@ -103,6 +103,11 @@ Reports retain per-metric coverage and use equal task weighting.
 - route-integrity and infrastructure exclusion reasons;
 - per-arm cap-hit cells and cap-affected matched blocks;
 - paired gateway-minus-direct contrasts.
+
+Cell latency is summarized as the median across repetitions within each task,
+then the median across tasks. Its paired contrast applies the same aggregation
+to matched gateway-minus-direct differences. This keeps long agent trajectories
+from dominating the headline while preserving equal task weighting.
 
 Cost bases are never silently mixed:
 

--- a/obench/gateway_report.py
+++ b/obench/gateway_report.py
@@ -94,6 +94,13 @@ def _mean(values: Sequence[float]) -> float | None:
     return sum(values) / len(values) if values else None
 
 
+def _median(values: Sequence[float]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    return _percentile(ordered, 0.5)
+
+
 def _percentile(sorted_values: Sequence[float], probability: float) -> float:
     if len(sorted_values) == 1:
         return sorted_values[0]
@@ -111,6 +118,7 @@ def _interval(
     *,
     replicates: int,
     seed: int,
+    statistic: Any = _mean,
 ) -> dict[str, float] | None:
     if not task_values:
         return None
@@ -118,7 +126,9 @@ def _interval(
     rng = random.Random(seed)
     samples = []
     for _ in range(replicates):
-        samples.append(sum(rng.choice(ordered) for _ in ordered) / len(ordered))
+        sample = statistic([rng.choice(ordered) for _ in ordered])
+        if sample is not None:
+            samples.append(sample)
     samples.sort()
     return {
         "confidence": 0.95,
@@ -162,11 +172,19 @@ def _metric(
     cells_total: int,
     replicates: int,
     seed: int,
+    statistic: Any = _mean,
+    aggregation: str = "mean_of_task_means",
 ) -> dict[str, Any]:
     values = list(task_values.values())
     return {
-        "estimate": _mean(values),
-        "interval": _interval(task_values, replicates=replicates, seed=seed),
+        "estimate": statistic(values),
+        "aggregation": aggregation,
+        "interval": _interval(
+            task_values,
+            replicates=replicates,
+            seed=seed,
+            statistic=statistic,
+        ),
         "task_coverage": {
             "covered": len(task_values),
             "total": eligible_tasks,
@@ -538,6 +556,8 @@ def _cell_cost(cell: Mapping[str, Any], basis: str) -> float | None:
 def _task_values(
     cells_by_task: Mapping[str, Sequence[Mapping[str, Any]]],
     getter: Any,
+    *,
+    statistic: Any = _mean,
 ) -> tuple[dict[str, float], int]:
     values = {}
     covered_cells = 0
@@ -546,7 +566,7 @@ def _task_values(
         covered = [value for value in cell_values if value is not None]
         covered_cells += len(covered)
         if covered:
-            values[task] = sum(covered) / len(covered)
+            values[task] = statistic(covered)
     return values, covered_cells
 
 
@@ -824,7 +844,12 @@ def aggregate(
         }
         metrics = {}
         for name, getter in getters.items():
-            values, covered_cells = _task_values(cells_by_task, getter)
+            statistic = _median if name == "latency_s" else _mean
+            values, covered_cells = _task_values(
+                cells_by_task,
+                getter,
+                statistic=statistic,
+            )
             metrics[name] = _metric(
                 values,
                 eligible_tasks=eligible_tasks,
@@ -832,6 +857,12 @@ def aggregate(
                 cells_total=cells_total,
                 replicates=bootstrap_replicates,
                 seed=_seed(bootstrap_seed, f"arm:{arm_id}:{name}"),
+                statistic=statistic,
+                aggregation=(
+                    "median_of_task_medians"
+                    if name == "latency_s"
+                    else "mean_of_task_means"
+                ),
             )
             if name in _CALL_COVERAGE_FIELDS or name == "throughput_tokens_per_s":
                 call_total = sum(
@@ -1043,16 +1074,23 @@ def aggregate(
                 if treatment is not None and control is not None:
                     block_differences[block["task"]].append(treatment - control)
                     covered_blocks += 1
+            statistic = _median if name == "latency_s" else _mean
             paired = {
-                task: sum(values) / len(values)
+                task: statistic(values)
                 for task, values in sorted(block_differences.items())
             }
             metrics[name] = {
-                "estimate": _mean(list(paired.values())),
+                "estimate": statistic(list(paired.values())),
+                "aggregation": (
+                    "median_of_task_median_paired_differences"
+                    if name == "latency_s"
+                    else "mean_of_task_mean_paired_differences"
+                ),
                 "interval": _interval(
                     paired,
                     replicates=bootstrap_replicates,
                     seed=_seed(bootstrap_seed, f"contrast:{arm_id}:{name}"),
+                    statistic=statistic,
                 ),
                 "paired_task_coverage": {
                     "covered": len(paired),

--- a/obench/site.py
+++ b/obench/site.py
@@ -227,12 +227,18 @@ def _pick_cost(costs):
 
 def _metric_dto(metric):
     if not isinstance(metric, dict):
-        return {"estimate": None, "low": None, "high": None}
+        return {
+            "estimate": None,
+            "low": None,
+            "high": None,
+            "aggregation": None,
+        }
     interval = metric.get("interval") or {}
     return {
         "estimate": metric.get("estimate"),
         "low": interval.get("low"),
         "high": interval.get("high"),
+        "aggregation": metric.get("aggregation"),
     }
 
 
@@ -1514,7 +1520,7 @@ def _gateway_board(bundle):
              f"({_fmt_pct(a['max_calls']['ratio'])})"
          ),
          "key": lambda a: a["max_calls"]["ratio"]},
-        {"label": "Latency", "dir": "asc",
+        {"label": "Median latency", "dir": "asc",
          "cell": lambda a: _fmt_secs(a["latency_s"]["estimate"]),
          "key": lambda a: a["latency_s"]["estimate"]},
         {"label": "$/solve", "dir": "asc", "skip_if_empty": True,
@@ -1543,7 +1549,7 @@ def _gateway_board(bundle):
             delta_column("Δ solve rate", "solve_rate", _fmt_pct, True),
             delta_column("Δ mean score", "mean_checker_score", _fmt_score, True),
             delta_column("Δ availability", "availability", _fmt_pct, True),
-            delta_column("Δ latency", "latency_s",
+            delta_column("Δ median latency", "latency_s",
                          lambda v: f"{v:.2f}s", False, "asc"),
         ]
         legend = "".join(

--- a/obench/tests/test_gateway_report.py
+++ b/obench/tests/test_gateway_report.py
@@ -264,6 +264,53 @@ class GatewayReportTests(unittest.TestCase):
         rendered = gateway_report.render_text(report)
         self.assertIn("call cap 1/4 (25.0%)", rendered)
 
+    def test_latency_uses_task_weighted_medians(self):
+        rows = []
+        durations = {
+            "task_a": ([1, 1, 1], [2, 3, 100]),
+            "task_b": ([2, 2, 2], [4, 5, 6]),
+        }
+        for task, (direct, gateway) in durations.items():
+            for repetition, (direct_s, gateway_s) in enumerate(
+                zip(direct, gateway), start=1
+            ):
+                rows.append(
+                    make_row(
+                        task=task,
+                        arm_id="direct",
+                        role="direct",
+                        baseline=True,
+                        repetition=repetition,
+                        duration=direct_s,
+                        calls=[call()],
+                    )
+                )
+                rows.append(
+                    make_row(
+                        task=task,
+                        arm_id="gateway",
+                        role="gateway",
+                        baseline=False,
+                        repetition=repetition,
+                        duration=gateway_s,
+                        calls=[call()],
+                    )
+                )
+
+        report = gateway_report.aggregate(
+            rows, bootstrap_replicates=200, bootstrap_seed=7
+        )
+        latency = report["arms"]["gateway"]["metrics"]["latency_s"]
+        contrast = report["paired_contrasts"]["gateway"]["metrics"]["latency_s"]
+
+        self.assertEqual(latency["estimate"], 4.0)
+        self.assertEqual(latency["aggregation"], "median_of_task_medians")
+        self.assertEqual(contrast["estimate"], 2.5)
+        self.assertEqual(
+            contrast["aggregation"],
+            "median_of_task_median_paired_differences",
+        )
+
     def test_gateway_provider_failure_stays_in_attempted_denominator(self):
         rows = self.complete_rows()
         failed = rows[-1]

--- a/obench/tests/test_site.py
+++ b/obench/tests/test_site.py
@@ -122,6 +122,43 @@ class HarnessFamilyTests(_SiteFixture):
 
 
 class GatewayFamilyTests(_SiteFixture):
+    def test_gateway_board_labels_latency_as_median(self):
+        metric = {"estimate": 1.0, "low": 0.5, "high": 1.5}
+        bundle = {
+            "title": "Gateway fixture",
+            "track": "fixed_model_provider",
+            "blocks_included": 1,
+            "blocks_observed": 1,
+            "tasks_included": 1,
+            "blocks_excluded": {},
+            "blocks_max_calls_affected": 0,
+            "budget_max_calls": 20,
+            "arms": [{
+                "arm_id": "direct",
+                "role": "direct",
+                "requested_provider": "openai",
+                "solve_rate": metric,
+                "mean_checker_score": metric,
+                "availability": metric,
+                "latency_s": metric,
+                "max_calls": {"cells": 0, "total_cells": 1, "ratio": 0.0},
+                "cost": None,
+            }],
+            "contrasts": [{
+                "arm_id": "gateway",
+                "direct_arm": "direct",
+                "solve_rate": metric,
+                "mean_checker_score": metric,
+                "availability": metric,
+                "latency_s": metric,
+            }],
+        }
+
+        page = site._gateway_board(bundle)
+
+        self.assertIn("Median latency", page)
+        self.assertIn("Δ median latency", page)
+
     def test_missing_gateway_root_is_empty_not_an_error(self):
         doc = site.build_board(self.site_dir)
         self.assertEqual(doc["gateway"]["bundle_count"], 0)


### PR DESCRIPTION
## Summary
- aggregate Gateway Bench cell latency as median within task, then median across equally weighted tasks
- compute paired gateway-minus-direct latency with the same task-weighted median rule
- label latency and latency deltas explicitly as medians on the site

## Verification
- `python3 -m unittest obench.tests.test_gateway_report obench.tests.test_site -q` (67 tests)
- existing 1,106-test full suite passed immediately before this focused reporting-only change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minghinmatthewlam/openbench/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->