### PR TITLE
Add Kimi K3 five-way Gateway Bench support

### DIFF
--- a/docs/gateway-bench.md
+++ b/docs/gateway-bench.md
@@ -46,6 +46,11 @@ Examples:
   direct OpenAI, OpenRouter, Vercel, Concentrate, and Cloudflare.
 - [`gateway-bench-four-way.toml`](../obench/examples/gateway-bench-four-way.toml):
   Chat Completions variant without Concentrate.
+- [`gateway-bench-kimi-k3-five-way-chat.toml`](../obench/examples/gateway-bench-kimi-k3-five-way-chat.toml):
+  Kimi K3 over Chat Completions through Direct Moonshot, OpenRouter, Vercel,
+  Concentrate, and Cloudflare. Its 12,000-token budget is an aggregate
+  coding-agent cell cap; use the 128-token Gateway Probe example for the cheap
+  request-level smoke check.
 
 ## Route Locking
 
@@ -57,7 +62,8 @@ forwarding a request.
   `allow_fallbacks=false`.
 - Vercel: `providerOptions.gateway.only` contains one provider.
 - Concentrate: `routing.providers` contains one provider and no alternate
-  models.
+  models. The Kimi K3 profile translates the cross-route `moonshotai` identity
+  to Concentrate's `moonshot` provider slug.
 - Cloudflare Unified Billing: the named managed gateway is bound into the
   experiment and sent as `cf-aig-gateway-id`; cache is skipped, maximum
   attempts is one, and the requested model remains provider-qualified.
@@ -143,12 +149,12 @@ Gateway Bench supports:
 - `openai_chat` endpoints ending in `/chat/completions`;
 - `openai_responses` endpoints ending in `/responses`.
 
-Concentrate is admitted only through its Responses endpoint. Cloudflare is
-admitted only through its managed Unified Billing REST route for both
-protocols; provider-native and compatibility/BYOK routes belong in separate
-experiments. Public experiments require strict known endpoints; private test
-endpoints require `allow_private_endpoint=true` plus an explicit hostname or
-CIDR allowlist.
+Concentrate is admitted through its exact `/chat/completions` and `/responses`
+endpoints for the matching protocol. Cloudflare is admitted only through its
+managed Unified Billing REST route for both protocols; provider-native and
+compatibility/BYOK routes belong in separate experiments. Public experiments
+require strict known endpoints; private test endpoints require
+`allow_private_endpoint=true` plus an explicit hostname or CIDR allowlist.
 
 ## Run
 
@@ -162,6 +168,9 @@ export VERCEL_API_KEY=...
 export CONCENTRATE_API_KEY=...
 export CLOUDFLARE_API_TOKEN=...
 ```
+
+The Kimi K3 Chat Completions example uses the same gateway credentials and
+`MOONSHOT_API_KEY` for its direct control.
 
 Gateway Bench also requires a frozen price snapshot so the USD cap can be
 enforced before and during the run. Each canonical model used by an arm needs

--- a/docs/gateway-probe.md
+++ b/docs/gateway-probe.md
@@ -90,6 +90,12 @@ bound into the experiment and sent as `cf-aig-gateway-id`; its response cache
 is skipped and its maximum attempt count is one. Set the credentials declared
 by the selected experiment and a frozen price snapshot:
 
+For a Chat Completions smoke run of Kimi K3 across Direct Moonshot and the same
+four gateways, use
+[`gateway-probe-kimi-k3-five-way-chat.toml`](../obench/examples/gateway-probe-kimi-k3-five-way-chat.toml).
+It schedules five repetitions and caps each generated response at 128 tokens.
+Replace its illustrative 32-hex Cloudflare account ID before running.
+
 ```bash
 export OPENAI_API_KEY=...
 export OPENROUTER_API_KEY=...
@@ -104,6 +110,8 @@ export OPENBENCH_GATEWAY_FROZEN_PRICES_JSON='{
   }
 }'
 ```
+
+The Kimi K3 example uses `MOONSHOT_API_KEY` instead of `OPENAI_API_KEY`.
 
 The prices above illustrate the required shape; verify current prices before a
 real run.

--- a/obench/examples/gateway-bench-kimi-k3-five-way-chat.toml
+++ b/obench/examples/gateway-bench-kimi-k3-five-way-chat.toml
@@ -1,0 +1,135 @@
+schema_version = 2
+experiment_id = "kimi-k3-five-way-chat-gateway-bench"
+track = "fixed_model_provider"
+model_match = "rolling_alias"
+provider_prompt_mode = "provider_default"
+harness = "pi"
+tasks = ["make-it-run"]
+repetitions_per_window = 5
+schedule_seed = 20260727
+execution_lane = "local"
+allow_private_endpoint = false
+
+# Replace this illustrative future window with the UTC window for the run.
+[[windows]]
+window_id = "window-a"
+start = "2026-08-04T15:00:00Z"
+end = "2026-08-04T17:00:00Z"
+
+# 1 task x 5 repetitions x 5 arms = 25 cells. At 8 calls per cell, this
+# experiment permits at most 200 paid model calls.
+[budget]
+timeout_s = 600
+max_calls = 8
+max_output_tokens = 12000
+usd_cap = 1.00
+
+[[arms]]
+arm_id = "direct-moonshot"
+route_kind = "direct"
+endpoint = "https://api.moonshot.ai/v1/chat/completions"
+protocol = "openai_chat"
+baseline = true
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "MOONSHOT_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727
+
+[[arms]]
+arm_id = "openrouter-moonshot"
+route_kind = "gateway"
+gateway = "openrouter"
+direct_control_arm_id = "direct-moonshot"
+endpoint = "https://openrouter.ai/api/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "moonshotai/kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["moonshotai/kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENROUTER_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727
+
+[[arms]]
+arm_id = "vercel-moonshot"
+route_kind = "gateway"
+gateway = "vercel"
+direct_control_arm_id = "direct-moonshot"
+endpoint = "https://ai-gateway.vercel.sh/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "moonshotai/kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["moonshotai/kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "VERCEL_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727
+
+[[arms]]
+arm_id = "concentrate-moonshot"
+route_kind = "gateway"
+gateway = "concentrate"
+direct_control_arm_id = "direct-moonshot"
+endpoint = "https://api.concentrate.ai/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "moonshot/kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["moonshot/kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "CONCENTRATE_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727
+
+[[arms]]
+arm_id = "cloudflare-moonshot"
+route_kind = "gateway"
+gateway = "cloudflare"
+gateway_id = "openbench-router-bench"
+direct_control_arm_id = "direct-moonshot"
+# Replace this illustrative 32-hex account ID before running.
+endpoint = "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/ai/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "moonshotai/kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["moonshotai/kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "CLOUDFLARE_API_TOKEN"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727

--- a/obench/examples/gateway-bench-kimi-k3-five-way-chat.toml
+++ b/obench/examples/gateway-bench-kimi-k3-five-way-chat.toml
@@ -40,8 +40,8 @@ retry_count = 0
 cache_enabled = false
 auth_env = "MOONSHOT_API_KEY"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727
 
 [[arms]]
@@ -62,8 +62,8 @@ retry_count = 0
 cache_enabled = false
 auth_env = "OPENROUTER_API_KEY"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727
 
 [[arms]]
@@ -84,8 +84,8 @@ retry_count = 0
 cache_enabled = false
 auth_env = "VERCEL_API_KEY"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727
 
 [[arms]]
@@ -106,8 +106,8 @@ retry_count = 0
 cache_enabled = false
 auth_env = "CONCENTRATE_API_KEY"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727
 
 [[arms]]
@@ -130,6 +130,6 @@ retry_count = 0
 cache_enabled = false
 auth_env = "CLOUDFLARE_API_TOKEN"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727

--- a/obench/examples/gateway-probe-kimi-k3-five-way-chat.toml
+++ b/obench/examples/gateway-probe-kimi-k3-five-way-chat.toml
@@ -1,0 +1,126 @@
+schema_version = 1
+experiment_id = "kimi-k3-five-way-chat-probe"
+track = "request_probe"
+model_match = "rolling_alias"
+repetitions = 5
+schedule_seed = 20260727
+allow_private_endpoint = false
+
+[budget]
+timeout_s = 60
+max_output_tokens = 128
+usd_cap = 0.50
+
+[[cases]]
+case_id = "short-text"
+prompt = "Reply with one short sentence describing a blue circle."
+
+[[arms]]
+arm_id = "direct-moonshot"
+route_kind = "direct"
+endpoint = "https://api.moonshot.ai/v1/chat/completions"
+protocol = "openai_chat"
+baseline = true
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "MOONSHOT_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727
+
+[[arms]]
+arm_id = "openrouter-moonshot"
+route_kind = "gateway"
+gateway = "openrouter"
+direct_control_arm_id = "direct-moonshot"
+endpoint = "https://openrouter.ai/api/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "moonshotai/kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["moonshotai/kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "OPENROUTER_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727
+
+[[arms]]
+arm_id = "vercel-moonshot"
+route_kind = "gateway"
+gateway = "vercel"
+direct_control_arm_id = "direct-moonshot"
+endpoint = "https://ai-gateway.vercel.sh/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "moonshotai/kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["moonshotai/kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "VERCEL_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727
+
+[[arms]]
+arm_id = "concentrate-moonshot"
+route_kind = "gateway"
+gateway = "concentrate"
+direct_control_arm_id = "direct-moonshot"
+endpoint = "https://api.concentrate.ai/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "moonshot/kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["moonshot/kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "CONCENTRATE_API_KEY"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727
+
+[[arms]]
+arm_id = "cloudflare-moonshot"
+route_kind = "gateway"
+gateway = "cloudflare"
+gateway_id = "openbench-router-bench"
+direct_control_arm_id = "direct-moonshot"
+# Replace this illustrative 32-hex account ID before running.
+endpoint = "https://api.cloudflare.com/client/v4/accounts/0123456789abcdef0123456789abcdef/ai/v1/chat/completions"
+protocol = "openai_chat"
+baseline = false
+canonical_model = "moonshotai/kimi-k3"
+requested_model = "moonshotai/kimi-k3"
+requested_provider = "moonshotai"
+allowed_models = ["moonshotai/kimi-k3"]
+allowed_providers = ["moonshotai"]
+fallback_enabled = false
+retry_count = 0
+cache_enabled = false
+auth_env = "CLOUDFLARE_API_TOKEN"
+[arms.sampling]
+temperature = 0.0
+top_p = 1.0
+seed = 20260727

--- a/obench/examples/gateway-probe-kimi-k3-five-way-chat.toml
+++ b/obench/examples/gateway-probe-kimi-k3-five-way-chat.toml
@@ -31,8 +31,8 @@ retry_count = 0
 cache_enabled = false
 auth_env = "MOONSHOT_API_KEY"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727
 
 [[arms]]
@@ -53,8 +53,8 @@ retry_count = 0
 cache_enabled = false
 auth_env = "OPENROUTER_API_KEY"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727
 
 [[arms]]
@@ -75,8 +75,8 @@ retry_count = 0
 cache_enabled = false
 auth_env = "VERCEL_API_KEY"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727
 
 [[arms]]
@@ -97,8 +97,8 @@ retry_count = 0
 cache_enabled = false
 auth_env = "CONCENTRATE_API_KEY"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727
 
 [[arms]]
@@ -121,6 +121,6 @@ retry_count = 0
 cache_enabled = false
 auth_env = "CLOUDFLARE_API_TOKEN"
 [arms.sampling]
-temperature = 0.0
-top_p = 1.0
+temperature = 1.0
+top_p = 0.95
 seed = 20260727

--- a/obench/gateway_profiles.py
+++ b/obench/gateway_profiles.py
@@ -102,6 +102,11 @@ def _provider_identity(value: str) -> str:
     return _PROVIDER_IDENTITY_ALIASES.get(normalized, normalized)
 
 
+def _persisted_provider(value: str) -> str:
+    stripped = value.strip()
+    return _PROVIDER_IDENTITY_ALIASES.get(stripped.casefold(), stripped)
+
+
 def _providers_compatible(first: str, second: str) -> bool:
     first_provider = _model_provider(first)
     second_provider = _model_provider(second)
@@ -366,7 +371,7 @@ def _clean_openrouter_attempts(value: Any) -> tuple[list[dict[str, Any]], bool]:
         model = _identifier(item.get("model"))
         status = _integer(item.get("status"))
         if provider is not None:
-            attempt["provider"] = provider
+            attempt["provider"] = _persisted_provider(provider)
         if model is not None:
             attempt["model"] = model
         if status is not None:
@@ -448,7 +453,7 @@ class GatewayEvidence:
             and _provider_identity(self.provider) != _provider_identity(value)
         ):
             self.profile_reasons.append("provider_conflict")
-        self.provider = value
+        self.provider = _persisted_provider(value)
 
     def _set_model(self, value: str) -> None:
         self._record_model(value)
@@ -692,7 +697,7 @@ class GatewayEvidence:
                 successful_attempts += 1
             attempt = {}
             if provider is not None:
-                attempt["provider"] = provider
+                attempt["provider"] = _persisted_provider(provider)
             if model is not None:
                 attempt["model"] = model
                 self._record_model(model)

--- a/obench/gateway_profiles.py
+++ b/obench/gateway_profiles.py
@@ -19,7 +19,13 @@ _VERCEL_ENDPOINTS = {
     "openai_chat": "https://ai-gateway.vercel.sh/v1/chat/completions",
     "openai_responses": "https://ai-gateway.vercel.sh/v1/responses",
 }
-_CONCENTRATE_RESPONSES_ENDPOINT = "https://api.concentrate.ai/v1/responses"
+_CONCENTRATE_ENDPOINTS = {
+    "openai_chat": "https://api.concentrate.ai/v1/chat/completions",
+    "openai_responses": "https://api.concentrate.ai/v1/responses",
+}
+_CONCENTRATE_PROVIDER_SLUGS = {
+    "moonshotai": "moonshot",
+}
 _CLOUDFLARE_REST_ENDPOINT_RE = re.compile(
     r"https://api\.cloudflare\.com/client/v4/accounts/"
     r"(?P<account_id>[0-9a-fA-F]{32})/ai/v1/"
@@ -114,6 +120,11 @@ def _model_alias(value: str) -> str:
     return _DATED_REVISION_RE.sub("", _model_id(value))
 
 
+def _concentrate_provider_slug(value: str) -> str:
+    provider = value.casefold()
+    return _CONCENTRATE_PROVIDER_SLUGS.get(provider, provider)
+
+
 def validate_arm(
     *,
     route_kind: str,
@@ -149,18 +160,19 @@ def validate_arm(
             "cloudflare managed gateway arm requires a valid gateway_id"
         )
     if gateway == "concentrate":
+        expected_endpoint = _CONCENTRATE_ENDPOINTS.get(protocol)
+        if endpoint != expected_endpoint:
+            raise GatewayProfileError(
+                "concentrate endpoint must be "
+                f"{expected_endpoint} for protocol {protocol}"
+            )
         if (
-            endpoint != _CONCENTRATE_RESPONSES_ENDPOINT
-            or protocol != "openai_responses"
+            _model_provider(requested_model)
+            != _concentrate_provider_slug(requested_provider)
         ):
             raise GatewayProfileError(
-                "concentrate supports only "
-                f"{_CONCENTRATE_RESPONSES_ENDPOINT} with protocol openai_responses"
-            )
-        if _model_provider(requested_model) != requested_provider.casefold():
-            raise GatewayProfileError(
                 "concentrate requested_model must be provider-qualified with "
-                "requested_provider"
+                "the Concentrate provider slug for requested_provider"
             )
     if gateway == "cloudflare":
         rest_match = _CLOUDFLARE_REST_ENDPOINT_RE.fullmatch(endpoint)
@@ -258,7 +270,7 @@ def shape_body(
         ):
             payload.pop(key, None)
         payload["routing"] = {
-            "providers": [requested_provider],
+            "providers": [_concentrate_provider_slug(requested_provider)],
             "models": [],
         }
         return
@@ -700,10 +712,19 @@ class GatewayEvidence:
         if (
             self.provider
             and self.requested_provider
-            and self.provider.casefold() != self.requested_provider.casefold()
+            and not self._provider_matches(
+                self.provider, self.requested_provider
+            )
         ):
             reasons.append("provider_conflict")
-        allowed = {provider.casefold() for provider in self.allowed_providers}
+        allowed = {
+            (
+                _concentrate_provider_slug(provider)
+                if self.gateway == "concentrate"
+                else provider.casefold()
+            )
+            for provider in self.allowed_providers
+        }
         if self.provider and allowed and self.provider.casefold() not in allowed:
             reasons.append("provider_not_allowed")
         if self.gateway in {"openrouter", "vercel"}:
@@ -749,3 +770,11 @@ class GatewayEvidence:
             elif not 200 <= status < 300:
                 reasons.append("unsuccessful_attempt")
         return list(dict.fromkeys(reasons))
+
+    def _provider_matches(self, observed: str, expected: str) -> bool:
+        expected_slug = (
+            _concentrate_provider_slug(expected)
+            if self.gateway == "concentrate"
+            else expected.casefold()
+        )
+        return observed.casefold() == expected_slug

--- a/obench/gateway_profiles.py
+++ b/obench/gateway_profiles.py
@@ -26,6 +26,9 @@ _CONCENTRATE_ENDPOINTS = {
 _CONCENTRATE_PROVIDER_SLUGS = {
     "moonshotai": "moonshot",
 }
+_PROVIDER_IDENTITY_ALIASES = {
+    "moonshot ai": "moonshotai",
+}
 _CLOUDFLARE_REST_ENDPOINT_RE = re.compile(
     r"https://api\.cloudflare\.com/client/v4/accounts/"
     r"(?P<account_id>[0-9a-fA-F]{32})/ai/v1/"
@@ -48,7 +51,7 @@ _SCHEMA_KEYS = frozenset({
     "parameters",
     "schema",
 })
-_DATED_REVISION_RE = re.compile(r"-\d{4}-\d{2}-\d{2}$")
+_DATED_REVISION_RE = re.compile(r"-(?:\d{4}-\d{2}-\d{2}|\d{8})$")
 
 
 class GatewayProfileError(ValueError):
@@ -94,20 +97,29 @@ def _model_provider(value: str) -> str | None:
     return normalized.rsplit("/", 1)[0]
 
 
+def _provider_identity(value: str) -> str:
+    normalized = value.strip().casefold()
+    return _PROVIDER_IDENTITY_ALIASES.get(normalized, normalized)
+
+
 def _providers_compatible(first: str, second: str) -> bool:
     first_provider = _model_provider(first)
     second_provider = _model_provider(second)
     return (
         first_provider is None
         or second_provider is None
-        or first_provider == second_provider
+        or _provider_identity(first_provider)
+        == _provider_identity(second_provider)
     )
 
 
 def model_provider_matches(value: str, expected_provider: str) -> bool:
     """Allow an unqualified model ID, but reject a contradictory qualifier."""
     provider = _model_provider(value)
-    return provider is None or provider == expected_provider.casefold()
+    return (
+        provider is None
+        or _provider_identity(provider) == _provider_identity(expected_provider)
+    )
 
 
 def concrete_model_revision(value: str) -> str | None:
@@ -121,7 +133,7 @@ def _model_alias(value: str) -> str:
 
 
 def _concentrate_provider_slug(value: str) -> str:
-    provider = value.casefold()
+    provider = _provider_identity(value)
     return _CONCENTRATE_PROVIDER_SLUGS.get(provider, provider)
 
 
@@ -269,6 +281,9 @@ def shape_body(
             "router", "plugins", "routes", "fallback", "fallbacks",
         ):
             payload.pop(key, None)
+        seed = payload.get("seed")
+        if isinstance(seed, int) and not isinstance(seed, bool):
+            payload["seed"] = str(seed)
         payload["routing"] = {
             "providers": [_concentrate_provider_slug(requested_provider)],
             "models": [],
@@ -428,7 +443,10 @@ class GatewayEvidence:
         return True
 
     def _set_provider(self, value: str) -> None:
-        if self.provider is not None and self.provider.casefold() != value.casefold():
+        if (
+            self.provider is not None
+            and _provider_identity(self.provider) != _provider_identity(value)
+        ):
             self.profile_reasons.append("provider_conflict")
         self.provider = value
 
@@ -718,14 +736,18 @@ class GatewayEvidence:
         ):
             reasons.append("provider_conflict")
         allowed = {
-            (
+            _provider_identity(
                 _concentrate_provider_slug(provider)
                 if self.gateway == "concentrate"
-                else provider.casefold()
+                else provider
             )
             for provider in self.allowed_providers
         }
-        if self.provider and allowed and self.provider.casefold() not in allowed:
+        if (
+            self.provider
+            and allowed
+            and _provider_identity(self.provider) not in allowed
+        ):
             reasons.append("provider_not_allowed")
         if self.gateway in {"openrouter", "vercel"}:
             if not self.metadata_requested_model:
@@ -754,10 +776,11 @@ class GatewayEvidence:
                 reasons.append("missing_attempt_provider")
             elif (
                 self.provider
-                and provider.casefold() != self.provider.casefold()
+                and _provider_identity(provider)
+                != _provider_identity(self.provider)
             ):
                 reasons.append("fallback_attempt")
-            elif allowed and provider.casefold() not in allowed:
+            elif allowed and _provider_identity(provider) not in allowed:
                 reasons.append("attempt_provider_not_allowed")
             if model is None:
                 reasons.append("missing_attempt_model")
@@ -775,6 +798,6 @@ class GatewayEvidence:
         expected_slug = (
             _concentrate_provider_slug(expected)
             if self.gateway == "concentrate"
-            else expected.casefold()
+            else expected
         )
-        return observed.casefold() == expected_slug
+        return _provider_identity(observed) == _provider_identity(expected_slug)

--- a/obench/tests/test_gateway_probe_cli.py
+++ b/obench/tests/test_gateway_probe_cli.py
@@ -54,6 +54,7 @@ class GatewayProbeCliTests(unittest.TestCase):
         cases = (
             ("gateway-probe-responses.toml", "arms=2"),
             ("gateway-probe-five-way-responses.toml", "arms=5"),
+            ("gateway-probe-kimi-k3-five-way-chat.toml", "arms=5"),
         )
         for filename, expected in cases:
             with self.subTest(filename=filename):

--- a/obench/tests/test_gateway_probe_http.py
+++ b/obench/tests/test_gateway_probe_http.py
@@ -7,9 +7,11 @@ import time
 import unittest
 from decimal import Decimal
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from unittest import mock
 
 from obench import (
+    gateway_profiles,
     gateway_probe_http,
     gateway_probe_spec,
     gateway_run,
@@ -605,6 +607,102 @@ class GatewayProbeHttpTests(unittest.TestCase):
         self.assertEqual(
             responses_body["provider"],
             {"only": ["openai"], "allow_fallbacks": False},
+        )
+
+    def test_kimi_examples_compile_exact_five_way_chat_route_locks(self):
+        examples = Path(__file__).parents[1] / "examples"
+        experiment = gateway_probe_spec.load_experiment(
+            examples / "gateway-probe-kimi-k3-five-way-chat.toml"
+        )
+        auth_envs = {arm.auth_env for arm in experiment.arms}
+        plans, _secrets = gateway_probe_spec.compile_route_plans(
+            experiment,
+            environ={name: f"secret-for-{name}" for name in auth_envs},
+            admitted_auth_envs=auth_envs,
+        )
+        by_id = {plan.arm_id: plan for plan in plans}
+
+        self.assertEqual(experiment.repetitions, 5)
+        self.assertEqual(experiment.budget.max_output_tokens, 128)
+        self.assertEqual(len(plans), 5)
+        self.assertEqual({plan.protocol for plan in plans}, {"openai_chat"})
+        self.assertEqual(
+            {arm_id: plan.endpoint for arm_id, plan in by_id.items()},
+            {
+                "direct-moonshot":
+                    "https://api.moonshot.ai/v1/chat/completions",
+                "openrouter-moonshot":
+                    "https://openrouter.ai/api/v1/chat/completions",
+                "vercel-moonshot":
+                    "https://ai-gateway.vercel.sh/v1/chat/completions",
+                "concentrate-moonshot":
+                    "https://api.concentrate.ai/v1/chat/completions",
+                "cloudflare-moonshot":
+                    "https://api.cloudflare.com/client/v4/accounts/"
+                    "0123456789abcdef0123456789abcdef/ai/v1/chat/completions",
+            },
+        )
+        bodies = {
+            arm_id: json.loads(
+                gateway_probe_http.request_body("prompt", "nonce", plan, 128)
+            )
+            for arm_id, plan in by_id.items()
+        }
+        self.assertEqual(
+            bodies["openrouter-moonshot"]["provider"],
+            {"only": ["moonshotai"], "allow_fallbacks": False},
+        )
+        self.assertEqual(
+            bodies["vercel-moonshot"]["providerOptions"],
+            {"gateway": {"only": ["moonshotai"]}},
+        )
+        self.assertEqual(
+            bodies["concentrate-moonshot"]["routing"],
+            {"providers": ["moonshot"], "models": []},
+        )
+        self.assertEqual(
+            by_id["concentrate-moonshot"].requested_model,
+            "moonshot/kimi-k3",
+        )
+        self.assertEqual(
+            {
+                arm_id: body["model"]
+                for arm_id, body in bodies.items()
+            },
+            {
+                "direct-moonshot": "kimi-k3",
+                "openrouter-moonshot": "moonshotai/kimi-k3",
+                "vercel-moonshot": "moonshotai/kimi-k3",
+                "concentrate-moonshot": "moonshot/kimi-k3",
+                "cloudflare-moonshot": "moonshotai/kimi-k3",
+            },
+        )
+        cloudflare = by_id["cloudflare-moonshot"]
+        self.assertEqual(cloudflare.gateway_id, "openbench-router-bench")
+        self.assertNotIn("provider", bodies["cloudflare-moonshot"])
+        self.assertEqual(
+            gateway_profiles.request_headers(
+                gateway=cloudflare.gateway,
+                gateway_id=cloudflare.gateway_id,
+                secret="secret",
+            )["cf-aig-gateway-id"],
+            "openbench-router-bench",
+        )
+        self.assertTrue(
+            all(body["max_completion_tokens"] == 128 for body in bodies.values())
+        )
+
+        gateway_bench = gateway_spec.load_experiment(
+            examples / "gateway-bench-kimi-k3-five-way-chat.toml"
+        )
+        self.assertEqual(gateway_bench.repetitions_per_window, 5)
+        self.assertEqual(len(gateway_bench.arms), 5)
+        self.assertEqual(
+            {arm.protocol for arm in gateway_bench.arms}, {"openai_chat"}
+        )
+        self.assertEqual(
+            {arm.canonical_model for arm in gateway_bench.arms},
+            {"moonshotai/kimi-k3"},
         )
 
     def test_route_reason_taxonomy_is_explicit_and_fail_closed(self):

--- a/obench/tests/test_gateway_probe_http.py
+++ b/obench/tests/test_gateway_probe_http.py
@@ -660,6 +660,14 @@ class GatewayProbeHttpTests(unittest.TestCase):
             bodies["concentrate-moonshot"]["routing"],
             {"providers": ["moonshot"], "models": []},
         )
+        self.assertEqual(bodies["concentrate-moonshot"]["seed"], "20260727")
+        self.assertTrue(
+            all(
+                body["seed"] == 20260727
+                for arm_id, body in bodies.items()
+                if arm_id != "concentrate-moonshot"
+            )
+        )
         self.assertEqual(
             by_id["concentrate-moonshot"].requested_model,
             "moonshot/kimi-k3",
@@ -691,6 +699,10 @@ class GatewayProbeHttpTests(unittest.TestCase):
         self.assertTrue(
             all(body["max_completion_tokens"] == 128 for body in bodies.values())
         )
+        self.assertTrue(
+            all(body["temperature"] == 1.0 for body in bodies.values())
+        )
+        self.assertTrue(all(body["top_p"] == 0.95 for body in bodies.values()))
 
         gateway_bench = gateway_spec.load_experiment(
             examples / "gateway-bench-kimi-k3-five-way-chat.toml"
@@ -703,6 +715,12 @@ class GatewayProbeHttpTests(unittest.TestCase):
         self.assertEqual(
             {arm.canonical_model for arm in gateway_bench.arms},
             {"moonshotai/kimi-k3"},
+        )
+        self.assertEqual(
+            {arm.sampling.temperature for arm in gateway_bench.arms}, {1.0}
+        )
+        self.assertEqual(
+            {arm.sampling.top_p for arm in gateway_bench.arms}, {0.95}
         )
 
     def test_route_reason_taxonomy_is_explicit_and_fail_closed(self):

--- a/obench/tests/test_gateway_profiles.py
+++ b/obench/tests/test_gateway_profiles.py
@@ -296,6 +296,7 @@ class GatewayRequestProfileTests(unittest.TestCase):
             requested_provider="moonshotai",
         )
         body = self.base_body()
+        body["seed"] = 20260727
         gateway_profiles.shape_body(
             body, gateway="concentrate", requested_provider="moonshotai"
         )
@@ -303,6 +304,7 @@ class GatewayRequestProfileTests(unittest.TestCase):
             "providers": ["moonshot"],
             "models": [],
         })
+        self.assertEqual(body["seed"], "20260727")
 
     def test_concentrate_replaces_hostile_routing_cache_and_fallback_controls(self):
         body = self.base_body()
@@ -425,6 +427,27 @@ class GatewayRequestProfileTests(unittest.TestCase):
             gateway_profiles.model_evidence_consistent(
                 "openai/gpt-4o-mini",
                 "anthropic/gpt-4o-mini-2024-07-18",
+                "rolling_alias",
+            )
+        )
+        self.assertTrue(
+            gateway_profiles.models_match(
+                "moonshotai/kimi-k3",
+                "moonshotai/kimi-k3-20260715",
+                "rolling_alias",
+            )
+        )
+        self.assertFalse(
+            gateway_profiles.models_match(
+                "moonshotai/kimi-k3",
+                "moonshotai/kimi-k3-20260715",
+                "exact_revision",
+            )
+        )
+        self.assertFalse(
+            gateway_profiles.model_evidence_consistent(
+                "moonshotai/kimi-k3-20260715",
+                "moonshotai/kimi-k3-20260716",
                 "rolling_alias",
             )
         )
@@ -699,6 +722,56 @@ class GatewayEvidenceTests(unittest.TestCase):
         self.assertTrue(result["route_evidence"]["pass"])
         self.assertEqual(result["route"]["gateway_metadata"], {"cost": 0.00125})
         self.assertNotIn(private_value, json.dumps(result, sort_keys=True))
+
+    def test_openrouter_normalizes_moonshot_display_provider_and_compact_revision(self):
+        requested = "moonshotai/kimi-k3"
+        observed = "moonshotai/kimi-k3-20260715"
+
+        def payload(provider):
+            return sse(
+                {
+                    "model": observed,
+                    "provider": provider,
+                    "choices": [{"delta": {"content": "x"}}],
+                    "openrouter_metadata": {
+                        "requested": requested,
+                        "endpoints": {"available": [{
+                            "provider": provider,
+                            "model": observed,
+                            "selected": True,
+                        }]},
+                    },
+                },
+                "[DONE]",
+            )
+
+        result = self.parse(
+            payload("Moonshot AI"),
+            gateway="openrouter",
+            requested_model=requested,
+            requested_provider="moonshotai",
+            allowed_models=(requested,),
+            allowed_providers=("moonshotai",),
+            model_match="rolling_alias",
+        )
+
+        self.assertTrue(result["route_evidence"]["pass"], result)
+        self.assertEqual(result["route"]["provider"], "Moonshot AI")
+        self.assertEqual(result["route"]["served_model"], observed)
+
+        contradictory = self.parse(
+            payload("Moonshot Labs"),
+            gateway="openrouter",
+            requested_model=requested,
+            requested_provider="moonshotai",
+            allowed_models=(requested,),
+            allowed_providers=("moonshotai",),
+            model_match="rolling_alias",
+        )
+        self.assertFalse(contradictory["route_evidence"]["pass"])
+        self.assertIn(
+            "provider_conflict", contradictory["route_evidence"]["reasons"]
+        )
 
     def test_openrouter_rejects_selected_endpoint_from_other_model_family(self):
         requested = "openai/gpt-4o-mini"

--- a/obench/tests/test_gateway_profiles.py
+++ b/obench/tests/test_gateway_profiles.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from obench import gateway_profiles, gateway_metrics
+from obench import gateway_profiles, gateway_metrics, gateway_probe_results
 
 
 def sse(*objects):
@@ -740,6 +740,11 @@ class GatewayEvidenceTests(unittest.TestCase):
                             "model": observed,
                             "selected": True,
                         }]},
+                        "attempts": [{
+                            "provider": provider,
+                            "model": observed,
+                            "status": 200,
+                        }],
                     },
                 },
                 "[DONE]",
@@ -756,8 +761,15 @@ class GatewayEvidenceTests(unittest.TestCase):
         )
 
         self.assertTrue(result["route_evidence"]["pass"], result)
-        self.assertEqual(result["route"]["provider"], "Moonshot AI")
+        self.assertEqual(result["route"]["provider"], "moonshotai")
         self.assertEqual(result["route"]["served_model"], observed)
+        self.assertEqual(
+            result["route"]["attempts"],
+            [{"provider": "moonshotai", "model": observed, "status": 200}],
+        )
+        gateway_probe_results._validate_route(
+            result["route"], "request route"
+        )
 
         contradictory = self.parse(
             payload("Moonshot Labs"),

--- a/obench/tests/test_gateway_profiles.py
+++ b/obench/tests/test_gateway_profiles.py
@@ -249,8 +249,8 @@ class GatewayRequestProfileTests(unittest.TestCase):
             with self.subTest(header=name):
                 self.assertTrue(gateway_profiles.blocked_request_header(name))
 
-    def test_concentrate_requires_exact_responses_route_and_qualified_model(self):
-        valid = {
+    def test_concentrate_requires_exact_protocol_endpoint_pairs(self):
+        responses = {
             "route_kind": "gateway",
             "gateway": "concentrate",
             "endpoint": "https://api.concentrate.ai/v1/responses",
@@ -258,20 +258,51 @@ class GatewayRequestProfileTests(unittest.TestCase):
             "requested_model": "openai/gpt-4o-mini",
             "requested_provider": "openai",
         }
-        gateway_profiles.validate_arm(**valid)
+        chat = {
+            **responses,
+            "endpoint": "https://api.concentrate.ai/v1/chat/completions",
+            "protocol": "openai_chat",
+        }
+        gateway_profiles.validate_arm(**responses)
+        gateway_profiles.validate_arm(**chat)
 
         invalid = (
-            ({"endpoint": valid["endpoint"] + "/"}, "supports only"),
-            ({"protocol": "openai_chat"}, "supports only"),
+            ({**responses, "endpoint": responses["endpoint"] + "/"}, "endpoint must be"),
+            ({**responses, "protocol": "openai_chat"}, "endpoint must be"),
+            ({**chat, "protocol": "openai_responses"}, "endpoint must be"),
             ({"requested_model": "gpt-4o-mini"}, "provider-qualified"),
             ({"requested_model": "azure/gpt-4o-mini"}, "provider-qualified"),
         )
-        for changes, message in invalid:
-            with self.subTest(changes=changes):
+        for candidate, message in invalid:
+            with self.subTest(candidate=candidate):
                 with self.assertRaisesRegex(
                     gateway_profiles.GatewayProfileError, message
                 ):
-                    gateway_profiles.validate_arm(**{**valid, **changes})
+                    gateway_profiles.validate_arm(
+                        **(
+                            candidate
+                            if "route_kind" in candidate
+                            else {**responses, **candidate}
+                        )
+                    )
+
+    def test_concentrate_uses_moonshot_route_slug_for_kimi(self):
+        gateway_profiles.validate_arm(
+            route_kind="gateway",
+            gateway="concentrate",
+            endpoint="https://api.concentrate.ai/v1/chat/completions",
+            protocol="openai_chat",
+            requested_model="moonshot/kimi-k3",
+            requested_provider="moonshotai",
+        )
+        body = self.base_body()
+        gateway_profiles.shape_body(
+            body, gateway="concentrate", requested_provider="moonshotai"
+        )
+        self.assertEqual(body["routing"], {
+            "providers": ["moonshot"],
+            "models": [],
+        })
 
     def test_concentrate_replaces_hostile_routing_cache_and_fallback_controls(self):
         body = self.base_body()
@@ -999,6 +1030,20 @@ class GatewayEvidenceTests(unittest.TestCase):
                 self.assertIn(
                     expected_reason, result["route_evidence"]["reasons"]
                 )
+
+    def test_concentrate_accepts_moonshot_slug_as_moonshotai_route_evidence(self):
+        result = self.parse(
+            sse({"model": "moonshot/kimi-k3"}, "[DONE]"),
+            gateway="concentrate",
+            requested_model="moonshot/kimi-k3",
+            requested_provider="moonshotai",
+            allowed_models=("moonshot/kimi-k3",),
+            allowed_providers=("moonshotai",),
+        )
+
+        self.assertTrue(result["route_evidence"]["pass"])
+        self.assertEqual(result["route"]["provider"], "moonshot")
+        self.assertEqual(result["route"]["served_model"], "moonshot/kimi-k3")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- admit Concentrate Chat Completions with provider-safe route shaping
- add five-way Kimi K3 Gateway Bench and request-probe examples
- normalize Moonshot provider labels and compact Kimi revision IDs
- use Kimi K3-required sampling values across all routes

## Verification
- 1,140 offline tests passed
- `obench validate`: 40/40 tasks passed polarity validation
- live five-route spike: 10/10 measured requests succeeded and 10/10 route integrity checks passed
- 5/5 warm primers completed
- public projection published and tamper verification passed

The live spike remains local and is not included as leaderboard data because one repetition is pipeline proof, not a publishable ranking.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minghinmatthewlam/openbench/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->