### PR TITLE
docs: add Cursor Cloud setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,3 +178,34 @@ including Terminal-Bench 2, require a separately provisioned validation lane.
 - Transcripts are local-only and never published unscrubbed (`obench/scrub.py`).
 - Committed datasets live under `data/`; local scratch stays in gitignored
   `results/`.
+
+## Cursor Cloud specific instructions
+
+Setup is `pip install -e .` (stdlib-only, no third-party deps). The full
+offline dev/CI loop is the "Always-run CI (offline)" block above — don't
+duplicate those commands; use them as-is.
+
+Non-obvious gotchas for this environment:
+
+- **`obench` console script is not on PATH by default.** `pip install -e .`
+  installs it to `~/.local/bin`, which is not on the default `PATH`. Either run
+  `python3 -m obench ...` or prepend `export PATH="$HOME/.local/bin:$PATH"`.
+- **The VM hostname is `cursor`, which breaks the publish/site/leaderboard
+  tests.** `obench/scrub.py` treats the machine hostname as PII to redact, and
+  `cursor` is also a stock harness name that legitimately appears in generated
+  leaderboard/publish HTML. So the PII scanner trips (`[hostname] cursor` hit),
+  causing ~79 errors + 1 failure in `test_publish` / `test_site` /
+  `test_leaderboard` (and thus in a full `python3 -m unittest discover`). This
+  is an environmental coincidence, not a code defect. To get a fully green
+  suite, run under a non-`cursor` hostname first: `sudo hostname openbench-dev`
+  (does not persist across VM restarts, so re-apply each session).
+- **No linter is configured** (no ruff/flake8/black/mypy). The lint-equivalent
+  correctness gate is `obench validate` (task checker polarity: workspace FAILs,
+  solution PASSes).
+- **Offline "hello world" / smoke of the run pipeline:** use the built-in
+  `null` negative-control harness, which makes no external calls —
+  `obench legacy run --task make-it-run --harness null --results-path results/results.jsonl`
+  then `obench report --results-path results/results.jsonl`. It correctly
+  records `success=False` (the checker is the sole judge). A real `obench run`
+  suite additionally needs Harbor + Docker + installed harness CLIs + provider
+  auth, none of which exist in the offline dev environment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the OpenBench development environment for Cursor Cloud agents and records the durable, non-obvious gotchas discovered during setup under a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No source code was modified.

## Environment setup

- **Install:** `pip install -e .` (stdlib-only, no third-party deps; Python 3.12.3 present, satisfies `>=3.11`). This is the proposed update script.
- **Tests:** `python3 -m unittest discover -s obench/tests` → **1529 passed**.
- **Validate (lint-equivalent / checker polarity):**
  - `obench validate --no-imported` → 8/8 core tasks PASS
  - `obench validate --tasks-dir tasks-imported/terminal-bench` → 9/9 PASS
  - `obench validate --tasks-dir tasks-imported/exercism` → 11/11 PASS
- **Hello-world run pipeline (offline):** `obench legacy run --harness null` then `obench report` — the built-in `null` negative-control harness runs with no external calls and the checker correctly judges it `success=False`.

## Key gotcha documented

The full `unittest` suite initially showed 79 errors + 1 failure — all in `test_publish` / `test_site` / `test_leaderboard`. Root cause: this VM's hostname is `cursor`, which `obench/scrub.py` treats as PII to redact, but `cursor` is also a stock harness name that legitimately appears in generated leaderboard/publish HTML, so the PII scanner trips. Running under a non-`cursor` hostname (`sudo hostname openbench-dev`) makes the suite fully green (verified). This is an environmental coincidence, not a code defect.

## Notes for future agents

- The `obench` console script installs to `~/.local/bin` (not on PATH by default); use `python3 -m obench ...` or add it to PATH.
- No linter is configured; `obench validate` is the lint-equivalent gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-257092fc-effb-4ce6-91ae-5d0a6a67493e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-257092fc-effb-4ce6-91ae-5d0a6a67493e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

