### PR TITLE
Classify incomplete runs with observed no work as infrastructure failures

### DIFF
--- a/obench/failure_class.py
+++ b/obench/failure_class.py
@@ -121,6 +121,45 @@ def has_instant_cli_exit_shape(row):
     return float(wall) < 30.0
 
 
+def has_no_work_incomplete_shape(row, text=""):
+    """True for a measured incomplete run with zero evidence the model worked.
+
+    Generalizes ``has_instant_cli_exit_shape`` beyond its <30s window. A run that
+    explicitly did NOT complete, reported no tokens across every field, ran no
+    turns, and left the workspace untouched is a harness/provider abandonment --
+    an auth reject, a dropped connection, or a provider-overload retry loop that
+    answers "high demand / Reconnecting 1..5/5" for minutes before exiting. It
+    burns real wall time, so the instant-exit gate (too slow) and the cap-rider
+    gate (never reached the cap) both miss it, and its throttle text is written to
+    the transcript rather than the saved row fields -- so a structural no-work
+    shape catches it where marker matching cannot.
+
+    The gate demands POSITIVE evidence of an abandoned run rather than mere
+    absence of telemetry: ``completed`` explicitly False and a numeric
+    ``wall_time_s``. A sparse/old row simply missing those fields is not swallowed
+    (that would clobber a backfilled class), and meaningful transcript text or any
+    timeout signal (handled before this gate) keeps the cell out. Callers must
+    invoke this AFTER the timeout classification so a real timeout still wins.
+    """
+    row = row or {}
+    if row.get("harness") == "null":
+        return False
+    if row.get("completed") is not False or bool(row.get("success")):
+        return False
+    wall = row.get("wall_time_s")
+    if not isinstance(wall, (int, float)) or isinstance(wall, bool):
+        return False
+    if any(row.get(field) for field in _TOKEN_FIELDS):
+        return False
+    if row.get("turns") not in (None, 0):
+        return False
+    if _has_workspace_work_evidence(row):
+        return False
+    if len(_meaningful_work_text(text)) >= 200:
+        return False
+    return True
+
+
 def per_reply_outputs(row):
     """Per-REQUEST output token counts for a cell, or () if unavailable.
 
@@ -503,6 +542,12 @@ def classify_failure(row, adapter_output="", timeout_s=None):
         return "infra"
     if row.get("checker_exit") == "timeout" or _TIMEOUT_RE.search(structured_status) or rode_cap:
         return "timeout"
+    # After timeout handling: a measured incomplete run that did zero work (no
+    # tokens, no turns, untouched workspace) and did not ride the cap is a
+    # provider abandonment -- e.g. an OpenRouter overload retry loop that gave up
+    # after minutes. The model never answered, so this is infra, not wrong_answer.
+    if has_no_work_incomplete_shape(row, combined):
+        return "infra"
     # wrong_answer must be checker-owned (exit 1). A row with NO checker exit
     # whose error is a Python traceback means the runner's own checker path
     # raised (evidence capture, scrub, or run_checker itself) -- that measures

--- a/obench/tests/test_failure_class.py
+++ b/obench/tests/test_failure_class.py
@@ -137,6 +137,25 @@ class TestClassifyFailure(unittest.TestCase):
         self.assertEqual(failure_class.classify_failure_reason(row, ""),
                          "silent-no-model-call")
 
+    def test_incomplete_zero_work_run_is_infra_not_wrong_answer(self):
+        # Real shape from an OpenRouter provider-overload abandonment: the model
+        # answered "high demand / Reconnecting 1..5/5" for minutes, then exited
+        # with no work done. completed=False, no tokens/turns, workspace
+        # untouched, and it did NOT ride the cap (419s of a 2400s budget). The
+        # throttle text lives only in the transcript, not in any row field, so
+        # marker matching cannot see it -- the structural no-work shape must.
+        row = {"success": False, "completed": False, "checker_exit": 1,
+               "tokens": None, "tokens_output": None, "turns": None,
+               "workspace_changed": False, "wall_time_s": 419.68, "error": "exit 1"}
+        self.assertEqual(failure_class.classify_failure(row, "", timeout_s=2400), "infra")
+
+    def test_incomplete_run_that_did_work_is_not_swallowed_as_infra(self):
+        # Guard: a cell cut off AFTER real model work (tokens/turns) must not be
+        # reclassified by the zero-work gate -- only genuine no-work runs are infra.
+        row = {"success": False, "completed": False, "checker_exit": 1,
+               "tokens": 500, "tokens_output": 200, "turns": 8, "wall_time_s": 419.0}
+        self.assertNotEqual(failure_class.classify_failure(row, "", timeout_s=2400), "infra")
+
     def test_real_wrong_answer_with_tokens_stays_wrong_answer(self):
         row = {"success": False, "completed": True, "checker_exit": 1,
                "tokens": 100, "tokens_output": 25}


### PR DESCRIPTION
## Problem

Provider abandonment can end an incomplete run after minutes with no captured usage, no turns, and an unchanged workspace. These rows fall outside the instant-exit and timeout gates and previously became `wrong_answer`.

## Change

Add a no-work inference after timeout classification. It requires `completed=False`, finite nonnegative elapsed time, present core token/turn fields, and an explicitly unchanged workspace. Present `None` usage remains supported because Codex returns it when no completed-turn event arrives. Nonzero or malformed counters, workspace-change evidence, and meaningful output suppress the inference.

This keeps sparse historical rows and substantive failed answers in the solve-rate denominator while classifying observed abandonment as `infra`. It does not claim that missing usage proves the provider performed no computation. The null control and existing timeout/marker precedence remain intact.

## Validation

- Regression tests cover missing fields, unknown workspace state, short substantive answers, malformed measurements, proxy/reasoning work, and timeout precedence.
- A positive control uses the real Codex parser's empty-event result and confirms both absent usage values and explicit zeros remain supported.
- Classifier, backfill, and report suites: 45 tests pass.
- Full offline suite: 1,547 tests pass.
- Task polarity: all 8 core, 9 imported Terminal-Bench, and 11 imported Exercism cases pass.
- Local validation used Python 3.14.7 on macOS; no live harness or model calls.
