### PR TITLE
Load OPEN_MODELS from an optional TOML registry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ the existing adapters in `obench/adapters/` are working references. Auth must be
 handled inside the adapter, read-only — never modify the user's real config
 files.
 
+To add an open / BYO model route to the existing adapters you do not need to
+touch adapter code at all: write a `.openbench/open_models.toml` registry as
+described in the same spec.
+
 ## Pull requests
 
 - Keep changes focused and reviewable.

--- a/obench/ADAPTER_SPEC.md
+++ b/obench/ADAPTER_SPEC.md
@@ -71,3 +71,52 @@ returns completed=True) is used as a negative control.
 | opencode | `opencode run -m openai/gpt-5.5 --variant medium ...`                |
 | cursor   | `cursor-agent -p --force --model gpt-5.5-medium ...`                 |
 | devin    | CLI at ~/.local/bin/devin - headless support unknown, investigate    |
+
+## Open-model registry (optional)
+
+Adapters that support open / BYO models carry an in-code `OPEN_MODELS` dict.
+That dict is the default. To add or retune a route without editing adapter
+code, write a TOML registry and the adapters merge it over their defaults at
+import time:
+
+1. `$OPENBENCH_OPEN_MODELS` (explicit path; set it empty to disable lookup)
+2. `.openbench/open_models.toml`, walking up from the working directory
+3. `~/.openbench/open_models.toml`
+
+Shared fields go on the model table, adapter-specific ones in a subtable named
+for the adapter:
+
+```toml
+[models.qwen3-coder]
+provider = "openrouter"
+model_id = "qwen/qwen3-coder"
+base_url = "https://openrouter.ai/api/v1"
+env_key  = "OPENROUTER_API_KEY"
+display  = "OpenRouter Qwen3 Coder"
+
+[models.qwen3-coder.opencode]
+variant = "high"
+```
+
+One `[models.<name>]` block is enough for every adapter: each fills its own
+field (`effort`, `variant`, `thinking`, `proxy_route`) from its defaults unless
+a subtable overrides it. `grokbuild` derives `proxy_route` from `provider`.
+
+A name containing a dot must be quoted, or TOML reads it as a dotted key:
+`[models."glm-5.2"]`, not `[models.glm-5.2]`. Most of the built-in names have a
+dot in them.
+
+Overriding one field of a built-in leaves the rest of that entry intact, nested
+tables (`compat`, `thinkingLevelMap`) included, so
+`[models."glm-5.2"] model_id = "glm-5.2-airx"` keeps the existing `env_key`,
+`base_url` and compat flags.
+
+`model_id`, `base_url`, `env_key` and `display` are required on any model the
+registry introduces, plus whatever the adapter needs. A malformed registry
+raises at import rather than silently falling back, so a bad file fails the run
+instead of quietly changing which model was measured.
+
+Every adapter also exposes `OPEN_MODELS_SOURCE`, the registry path or `None`.
+`obench doctor` marks a registry-sourced model as `(open via registry)` and
+prints the path, so a run whose model set was overridden is visible in preflight
+rather than only in the config file.

--- a/obench/adapters/_open_models.py
+++ b/obench/adapters/_open_models.py
@@ -1,0 +1,185 @@
+"""Optional file-backed registry for adapter ``OPEN_MODELS`` entries.
+
+Each adapter keeps its in-code ``OPEN_MODELS`` dict as the default. This helper
+merges an optional TOML registry over that default so a user can add or retune
+an open/BYO route without editing adapter code and carrying a diff against
+upstream.
+
+Search order, first hit wins:
+
+1. ``$OPENBENCH_OPEN_MODELS`` (explicit path; set it empty to disable lookup)
+2. ``.openbench/open_models.toml``, walking up from the working directory
+3. ``~/.openbench/open_models.toml``
+
+Schema. Shared fields sit on the model table, adapter-specific ones in a
+subtable named for the adapter:
+
+    [models.qwen3-coder]
+    provider  = "openrouter"
+    model_id  = "qwen/qwen3-coder"
+    base_url  = "https://openrouter.ai/api/v1"
+    env_key   = "OPENROUTER_API_KEY"
+    display   = "OpenRouter Qwen3 Coder"
+
+    [models.qwen3-coder.grokbuild]
+    proxy_route = "chat/openrouter"
+
+A model name containing a dot must be quoted, or TOML reads it as a dotted
+key: ``[models."glm-5.2"]``, not ``[models.glm-5.2]``. Most of the built-in
+names have a dot in them.
+
+A model table with no subtable for the current adapter still applies; the
+adapter's ``defaults`` fill in its own fields. Overriding one field of a
+built-in model leaves the rest of that entry intact, nested dicts included.
+
+Loaded by ``spec_from_file_location`` from each adapter, so this module is
+stdlib-only and imports nothing from ``obench``.
+"""
+
+import os
+import tomllib
+
+ENV_VAR = "OPENBENCH_OPEN_MODELS"
+CONFIG_DIRNAME = ".openbench"
+CONFIG_FILENAME = "open_models.toml"
+
+# Fields every entry needs regardless of which adapter reads it.
+BASE_REQUIRED = ("model_id", "base_url", "env_key", "display")
+
+
+class RegistryError(Exception):
+    """Malformed registry file. Raised at import time, never swallowed."""
+
+
+def find_registry(start=None, environ=None):
+    """Return the registry path to use, or ``None`` when there is none."""
+    env = os.environ if environ is None else environ
+    if ENV_VAR in env:
+        explicit = env[ENV_VAR].strip()
+        if not explicit:
+            return None
+        if not os.path.isfile(explicit):
+            raise RegistryError(f"{ENV_VAR}={explicit!r} is not a file")
+        return os.path.abspath(explicit)
+
+    cur = os.path.abspath(start or os.getcwd())
+    while True:
+        candidate = os.path.join(cur, CONFIG_DIRNAME, CONFIG_FILENAME)
+        if os.path.isfile(candidate):
+            return candidate
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+
+    home = os.path.join(os.path.expanduser("~"), CONFIG_DIRNAME, CONFIG_FILENAME)
+    return home if os.path.isfile(home) else None
+
+
+def _read(path):
+    try:
+        with open(path, "rb") as fh:
+            data = tomllib.load(fh)
+    except OSError as exc:
+        raise RegistryError(f"{path}: cannot read ({exc})") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise RegistryError(f"{path}: invalid TOML ({exc})") from exc
+
+    unknown = sorted(set(data) - {"models"})
+    if unknown:
+        raise RegistryError(f"{path}: unknown top-level table(s) {unknown}; expected [models]")
+    models = data.get("models", {})
+    if not isinstance(models, dict):
+        raise RegistryError(f"{path}: [models] must be a table")
+    return models
+
+
+def _dotted_key_hint(name, table):
+    """Explain the ``[models.glm-5.2]`` trap when a name got split on its dot."""
+    if not isinstance(table, dict):
+        return ""
+    for key, value in table.items():
+        if isinstance(value, dict) and key[:1].isdigit():
+            return (f'; a model name containing "." must be quoted, e.g. '
+                    f'[models."{name}.{key}"]')
+    return ""
+
+
+def _merge(base, overlay):
+    """Overlay onto a copy of base, recursing into nested tables."""
+    out = dict(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = _merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
+def _entry_for(adapter, name, table, path):
+    """Split a model table into shared fields plus this adapter's subtable."""
+    if not isinstance(table, dict):
+        raise RegistryError(f"{path}: [models.{name}] must be a table")
+
+    shared = {}
+    mine = {}
+    for key, value in table.items():
+        # A subtable named for some other adapter is not ours to read. Only
+        # treat a nested table as adapter-scoped when its key has no meaning as
+        # a shared field, which is why known nested fields (compat,
+        # thinkingLevelMap) are passed through as shared.
+        if key == adapter:
+            if not isinstance(value, dict):
+                raise RegistryError(
+                    f"{path}: [models.{name}.{adapter}] must be a table")
+            mine = value
+        elif isinstance(value, dict) and key in _KNOWN_ADAPTERS and key != adapter:
+            continue
+        else:
+            shared[key] = value
+    return _merge(shared, mine)
+
+
+# Adapter names whose subtables must be ignored when loading a different
+# adapter. Kept explicit so an unrecognised nested key is surfaced as a shared
+# field rather than silently dropped.
+_KNOWN_ADAPTERS = frozenset({
+    "codex", "codex_v1", "codex_v2", "opencode", "pi", "grokbuild",
+    "claude", "cursor", "devin",
+})
+
+
+def load(adapter, builtin, required=(), defaults=None, derive=None,
+         start=None, environ=None):
+    """Return ``(models, source)`` for ``adapter``.
+
+    ``builtin`` is returned unchanged when no registry file is found, so the
+    in-code dict stays the default. ``required`` names adapter-specific fields
+    that a brand-new model must end up with; ``defaults`` supplies them when the
+    registry does not, and ``derive`` gets a last pass to fill a field that
+    follows from the others.
+    """
+    path = find_registry(start=start, environ=environ)
+    if path is None:
+        return dict(builtin), None
+
+    tables = _read(path)
+    merged = {name: dict(spec) for name, spec in builtin.items()}
+    needed = tuple(BASE_REQUIRED) + tuple(required)
+
+    for name, table in tables.items():
+        entry = _entry_for(adapter, name, table, path)
+        if name in merged:
+            entry = _merge(merged[name], entry)
+        else:
+            entry = _merge(dict(defaults or {}), entry)
+        if derive is not None:
+            entry = derive(entry)
+        missing = [key for key in needed if not entry.get(key)]
+        if missing:
+            raise RegistryError(
+                f"{path}: [models.{name}] is missing {missing} for adapter "
+                f"{adapter!r}{_dotted_key_hint(name, table)}")
+        merged[name] = entry
+
+    return merged, path

--- a/obench/adapters/codex.py
+++ b/obench/adapters/codex.py
@@ -45,6 +45,7 @@ matches the vendor's own billed usage; there is no codex-native usage for these
 models to cross-check against.
 """
 
+import importlib.util
 import json
 import os
 import shlex
@@ -163,6 +164,26 @@ OPEN_MODELS = {
     "kimi-k2.7-code":    {"provider": "moonshot", "model_id": "kimi-k2.7-code",    "base_url": "https://api.moonshot.ai/v1",   "env_key": "MOONSHOT_API_KEY", "display": "Moonshot Kimi", "effort": "medium"},
     "kimi-k3":    {"provider": "moonshot", "model_id": "kimi-k3",    "base_url": "https://api.moonshot.ai/v1",   "env_key": "MOONSHOT_API_KEY", "display": "Moonshot Kimi K3", "effort": "medium"},
 }
+
+
+def _load_open_models():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_open_models.py")
+    spec = importlib.util.spec_from_file_location("openbench_open_models", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# The dict above is the default. An optional TOML registry
+# (``.openbench/open_models.toml`` or ``~/.openbench/open_models.toml``, see
+# ``_open_models.py``) may add entries or retune existing ones, so a user can
+# carry a BYO route without a diff against the adapter. ``OPEN_MODELS_SOURCE``
+# is the file it came from, or None when the built-ins are untouched.
+OPEN_MODELS, OPEN_MODELS_SOURCE = _load_open_models().load(
+    NAME, OPEN_MODELS,
+    required=("provider", "effort"),
+    defaults={"effort": "medium"},
+)
 
 # Host-side bridge (LiteLLM proxy). Port must match bench/openmodel_bridge.sh
 # (both default to 4141; override in lockstep via BENCH_BRIDGE_PORT).

--- a/obench/adapters/grokbuild.py
+++ b/obench/adapters/grokbuild.py
@@ -25,6 +25,7 @@ observed stream, so token accounting also reads Grok's local
 HOME.  Turns are counted from terminal ``end`` events (single `-p` run => 1).
 """
 
+import importlib.util
 import json
 import os
 import shutil
@@ -79,6 +80,33 @@ OPEN_MODELS = {
     # placeholder; it is never an OpenAI API key.
     "gpt-5.6-sol":       {"model_id": "gpt-5.6-sol",       "base_url": "http://127.0.0.1:8317/v1",     "base_url_env": "CLIPROXYAPI_BASE_URL", "env_key": "CLIPROXYAPI_API_KEY", "display": "GPT-5.6 Sol via CLIProxyAPI", "proxy_route": "subbridge", "subscription_bridge": True},
 }
+
+
+def _grokbuild_route(entry):
+    """Fill the proxy route from the provider, as the built-ins do."""
+    if not entry.get("proxy_route") and entry.get("provider"):
+        entry = dict(entry, proxy_route="chat/%s" % entry["provider"])
+    return entry
+
+
+def _load_open_models():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_open_models.py")
+    spec = importlib.util.spec_from_file_location("openbench_open_models", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# The dict above is the default. An optional TOML registry
+# (``.openbench/open_models.toml`` or ``~/.openbench/open_models.toml``, see
+# ``_open_models.py``) may add entries or retune existing ones, so a user can
+# carry a BYO route without a diff against the adapter. ``OPEN_MODELS_SOURCE``
+# is the file it came from, or None when the built-ins are untouched.
+OPEN_MODELS, OPEN_MODELS_SOURCE = _load_open_models().load(
+    NAME, OPEN_MODELS,
+    required=("proxy_route",),
+    derive=_grokbuild_route,
+)
 
 _SUBBRIDGE_PLACEHOLDER = "openbench-local-ingress"
 

--- a/obench/adapters/opencode.py
+++ b/obench/adapters/opencode.py
@@ -29,6 +29,7 @@ Notes / quirks:
   the raw output as the tail, never raising.
 """
 
+import importlib.util
 import json
 import os
 import shutil
@@ -150,6 +151,26 @@ OPEN_MODELS = {
     "laguna-s-2.1": {"provider": "openrouter", "model_id": "poolside/laguna-s-2.1", "base_url": "https://openrouter.ai/api/v1", "env_key": "OPENROUTER_API_KEY", "display": "OpenRouter Poolside Laguna S 2.1", "variant": "medium"},
     "inkling": {"provider": "openrouter", "model_id": "thinkingmachines/inkling", "base_url": "https://openrouter.ai/api/v1", "env_key": "OPENROUTER_API_KEY", "display": "OpenRouter Thinking Machines Inkling", "variant": "medium"},
 }
+
+
+def _load_open_models():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_open_models.py")
+    spec = importlib.util.spec_from_file_location("openbench_open_models", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# The dict above is the default. An optional TOML registry
+# (``.openbench/open_models.toml`` or ``~/.openbench/open_models.toml``, see
+# ``_open_models.py``) may add entries or retune existing ones, so a user can
+# carry a BYO route without a diff against the adapter. ``OPEN_MODELS_SOURCE``
+# is the file it came from, or None when the built-ins are untouched.
+OPEN_MODELS, OPEN_MODELS_SOURCE = _load_open_models().load(
+    NAME, OPEN_MODELS,
+    required=("provider", "variant"),
+    defaults={"variant": "medium"},
+)
 
 
 def _unsupported(model):

--- a/obench/adapters/pi.py
+++ b/obench/adapters/pi.py
@@ -26,6 +26,7 @@ Notes / quirks:
   Parsing is defensive: shape drift yields tokens=None/turns=None + raw tail.
 """
 
+import importlib.util
 import json
 import os
 import re
@@ -262,6 +263,31 @@ OPEN_MODELS = {
     "laguna-s-2.1": {"provider": "openrouter", "context_window": 262144, "max_tokens": 32768, "model_id": "poolside/laguna-s-2.1", "base_url": "https://openrouter.ai/api/v1", "env_key": "OPENROUTER_API_KEY", "display": "OpenRouter Poolside Laguna S 2.1", "thinking": "medium", "compat": {"supportsStore": False, "supportsDeveloperRole": False, "supportsReasoningEffort": True, "supportsStrictMode": False}, "thinkingLevelMap": {"minimal": "minimal", "low": "low", "medium": "medium", "high": "high", "xhigh": "high"}},
     "inkling": {"provider": "openrouter", "context_window": 524288, "max_tokens": 32768, "model_id": "thinkingmachines/inkling", "base_url": "https://openrouter.ai/api/v1", "env_key": "OPENROUTER_API_KEY", "display": "OpenRouter Thinking Machines Inkling", "thinking": "medium", "compat": {"supportsStore": False, "supportsDeveloperRole": False, "supportsReasoningEffort": True, "supportsStrictMode": False}, "thinkingLevelMap": {"minimal": "minimal", "low": "low", "medium": "medium", "high": "high", "xhigh": "high"}},
 }
+
+
+def _load_open_models():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_open_models.py")
+    spec = importlib.util.spec_from_file_location("openbench_open_models", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# The dict above is the default. An optional TOML registry
+# (``.openbench/open_models.toml`` or ``~/.openbench/open_models.toml``, see
+# ``_open_models.py``) may add entries or retune existing ones, so a user can
+# carry a BYO route without a diff against the adapter. ``OPEN_MODELS_SOURCE``
+# is the file it came from, or None when the built-ins are untouched.
+OPEN_MODELS, OPEN_MODELS_SOURCE = _load_open_models().load(
+    NAME, OPEN_MODELS,
+    required=("provider", "thinking"),
+    defaults={
+        "thinking": "medium",
+        "compat": {"supportsStore": False, "supportsDeveloperRole": False,
+                   "supportsReasoningEffort": False},
+        "thinkingLevelMap": {"off": None},
+    },
+)
 
 
 def _unsupported(model):

--- a/obench/doctor.py
+++ b/obench/doctor.py
@@ -377,9 +377,26 @@ def check_model(p, harness, model):
         return True, f"{model} -> {models[model]}"
     open_models = getattr(mod, "OPEN_MODELS", None)
     if isinstance(open_models, dict) and model in open_models:
-        return True, f"{model} -> {open_models[model]['model_id']} (open)"
+        origin = "open via registry" if getattr(mod, "OPEN_MODELS_SOURCE", None) else "open"
+        return True, f"{model} -> {open_models[model]['model_id']} ({origin})"
     known = list(models) + (list(open_models) if isinstance(open_models, dict) else [])
     return False, f"{model} not in MODELS/OPEN_MODELS {known}"
+
+
+def open_models_registry():
+    """Path of the open-model registry in effect, or None.
+
+    Returns the string ``"<error>: ..."`` rather than raising so preflight can
+    report a broken registry instead of dying on it.
+    """
+    path = os.path.join(ADAPTERS_DIR, "_open_models.py")
+    try:
+        spec = importlib.util.spec_from_file_location("doctor_open_models", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.find_registry()
+    except Exception as exc:  # noqa: BLE001 - surface any registry problem
+        return f"<error>: {exc}"
 
 
 def _keys_env_has(p, env_key):
@@ -1120,6 +1137,9 @@ def main(argv=None):
     print()
     print(f"Preflight: {'PASS' if ok else 'FAIL'} "
           f"({len(harnesses)} harness(es), model={args.model})")
+    registry = open_models_registry()
+    if registry:
+        print(f"Open-model registry: {registry}")
     return 0 if ok else 1
 
 

--- a/obench/tests/test_open_models_registry.py
+++ b/obench/tests/test_open_models_registry.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Tests for the optional file-backed OPEN_MODELS registry."""
+
+import importlib.util
+import os
+import shutil
+import tempfile
+import unittest
+
+BENCH_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ADAPTERS_DIR = os.path.join(BENCH_DIR, "adapters")
+
+
+def _load_helper():
+    path = os.path.join(ADAPTERS_DIR, "_open_models.py")
+    spec = importlib.util.spec_from_file_location("test_open_models", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+om = _load_helper()
+
+BUILTIN = {
+    "glm-5.2": {
+        "provider": "zai",
+        "model_id": "glm-5.2",
+        "base_url": "https://api.z.ai/api/paas/v4",
+        "env_key": "ZAI_API_KEY",
+        "display": "Z.ai GLM",
+        "effort": "medium",
+        "compat": {"supportsStore": False, "thinkingFormat": "zai"},
+    },
+}
+
+SHARED = (
+    '[models.qwen3-coder]\n'
+    'provider = "openrouter"\n'
+    'model_id = "qwen/qwen3-coder"\n'
+    'base_url = "https://openrouter.ai/api/v1"\n'
+    'env_key = "OPENROUTER_API_KEY"\n'
+    'display = "OpenRouter Qwen3 Coder"\n'
+)
+
+
+class RegistryFileTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="obench_open_models_")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def write(self, text, name="open_models.toml"):
+        path = os.path.join(self.tmp, name)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        return path
+
+    def load(self, path, adapter="codex", **kw):
+        kw.setdefault("required", ("provider", "effort"))
+        kw.setdefault("defaults", {"effort": "medium"})
+        return om.load(adapter, BUILTIN, environ={om.ENV_VAR: path}, **kw)
+
+    def test_no_registry_returns_builtin_unchanged(self):
+        models, source = om.load("codex", BUILTIN, environ={om.ENV_VAR: ""})
+        self.assertIsNone(source)
+        self.assertEqual(models, BUILTIN)
+        self.assertIsNot(models, BUILTIN)
+
+    def test_adds_model_and_fills_adapter_default(self):
+        path = self.write(SHARED)
+        models, source = self.load(path)
+        self.assertEqual(source, path)
+        self.assertEqual(models["qwen3-coder"]["model_id"], "qwen/qwen3-coder")
+        self.assertEqual(models["qwen3-coder"]["effort"], "medium")
+        self.assertIn("glm-5.2", models)
+
+    def test_adapter_subtable_wins_over_shared(self):
+        path = self.write(SHARED + '\n[models.qwen3-coder.codex]\neffort = "high"\n')
+        models, _ = self.load(path)
+        self.assertEqual(models["qwen3-coder"]["effort"], "high")
+
+    def test_other_adapters_subtable_is_ignored(self):
+        path = self.write(SHARED + '\n[models.qwen3-coder.opencode]\nvariant = "high"\n')
+        models, _ = self.load(path)
+        self.assertNotIn("variant", models["qwen3-coder"])
+        self.assertEqual(models["qwen3-coder"]["effort"], "medium")
+
+    def test_partial_override_keeps_rest_of_builtin_entry(self):
+        path = self.write('[models."glm-5.2"]\nmodel_id = "glm-5.2-airx"\n')
+        models, _ = self.load(path)
+        entry = models["glm-5.2"]
+        self.assertEqual(entry["model_id"], "glm-5.2-airx")
+        self.assertEqual(entry["env_key"], "ZAI_API_KEY")
+        self.assertEqual(entry["compat"]["thinkingFormat"], "zai")
+
+    def test_nested_table_override_merges_not_replaces(self):
+        path = self.write(
+            '[models."glm-5.2".compat]\nsupportsStore = true\n')
+        models, _ = self.load(path)
+        compat = models["glm-5.2"]["compat"]
+        self.assertTrue(compat["supportsStore"])
+        self.assertEqual(compat["thinkingFormat"], "zai")
+
+    def test_builtin_dict_is_not_mutated(self):
+        path = self.write('[models."glm-5.2"]\nmodel_id = "glm-5.2-airx"\n')
+        self.load(path)
+        self.assertEqual(BUILTIN["glm-5.2"]["model_id"], "glm-5.2")
+
+    def test_derive_fills_field_from_another(self):
+        path = self.write(SHARED)
+        models, _ = self.load(
+            path, adapter="grokbuild", required=("proxy_route",), defaults={},
+            derive=lambda e: dict(e, proxy_route="chat/%s" % e["provider"])
+            if not e.get("proxy_route") and e.get("provider") else e)
+        self.assertEqual(models["qwen3-coder"]["proxy_route"], "chat/openrouter")
+
+    def test_missing_required_field_names_the_model(self):
+        path = self.write('[models.broken]\nmodel_id = "x"\n')
+        with self.assertRaises(om.RegistryError) as ctx:
+            self.load(path)
+        msg = str(ctx.exception)
+        self.assertIn("[models.broken]", msg)
+        self.assertIn("base_url", msg)
+
+    def test_unquoted_dotted_name_explains_the_quoting_rule(self):
+        path = self.write('[models.glm-5.2]\nmodel_id = "x"\n')
+        with self.assertRaises(om.RegistryError) as ctx:
+            self.load(path)
+        self.assertIn('[models."glm-5.2"]', str(ctx.exception))
+
+    def test_unknown_top_level_table_is_rejected(self):
+        path = self.write('[routes]\nx = 1\n')
+        with self.assertRaises(om.RegistryError) as ctx:
+            self.load(path)
+        self.assertIn("unknown top-level table", str(ctx.exception))
+
+    def test_invalid_toml_is_rejected(self):
+        path = self.write("[models.x\n")
+        with self.assertRaises(om.RegistryError) as ctx:
+            self.load(path)
+        self.assertIn("invalid TOML", str(ctx.exception))
+
+    def test_env_var_pointing_at_missing_file_is_an_error(self):
+        with self.assertRaises(om.RegistryError):
+            om.find_registry(environ={om.ENV_VAR: os.path.join(self.tmp, "nope.toml")})
+
+    def test_project_dir_beats_home_and_walks_up(self):
+        root = os.path.join(self.tmp, "proj")
+        nested = os.path.join(root, "src", "app")
+        os.makedirs(nested)
+        os.makedirs(os.path.join(root, ".openbench"))
+        want = os.path.join(root, ".openbench", "open_models.toml")
+        with open(want, "w", encoding="utf-8") as fh:
+            fh.write(SHARED)
+        self.assertEqual(om.find_registry(start=nested, environ={}), want)
+
+    def test_no_registry_anywhere_returns_none(self):
+        empty = os.path.join(self.tmp, "empty")
+        os.makedirs(empty)
+        found = om.find_registry(start=empty, environ={})
+        home = os.path.join(os.path.expanduser("~"), ".openbench", "open_models.toml")
+        self.assertIn(found, (None, home))
+
+
+class AdapterWiringTests(unittest.TestCase):
+    """Every adapter with an OPEN_MODELS dict exposes its registry source."""
+
+    ADAPTERS = ("codex", "opencode", "pi", "grokbuild")
+
+    def _import(self, name):
+        path = os.path.join(ADAPTERS_DIR, f"{name}.py")
+        spec = importlib.util.spec_from_file_location(f"wiring_{name}", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_adapters_expose_source_and_builtin_defaults(self):
+        for name in self.ADAPTERS:
+            with self.subTest(adapter=name):
+                mod = self._import(name)
+                self.assertTrue(hasattr(mod, "OPEN_MODELS_SOURCE"))
+                self.assertIsInstance(mod.OPEN_MODELS, dict)
+                self.assertIn("kimi-k3", mod.OPEN_MODELS)
+
+    def test_every_builtin_entry_has_the_base_fields(self):
+        for name in self.ADAPTERS:
+            mod = self._import(name)
+            for model, spec in mod.OPEN_MODELS.items():
+                with self.subTest(adapter=name, model=model):
+                    for field in om.BASE_REQUIRED:
+                        self.assertTrue(spec.get(field), f"{field} missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the registry davisbuilds proposed in #46.

## Summary

- load adapter `OPEN_MODELS` from an optional `.openbench/open_models.toml`; the in-code dicts stay the default and are returned untouched when no registry file exists
- one `[models.<name>]` block covers codex, opencode, pi and grokbuild, each filling its own `effort`/`variant`/`thinking` field from defaults; grokbuild derives `proxy_route` from `provider` the way its built-ins do
- overrides merge into the built-in entry instead of replacing it, so `[models."glm-5.2"] model_id = "glm-5.2-airx"` keeps the existing `env_key`, `base_url` and `compat` flags
- adapters expose `OPEN_MODELS_SOURCE`, and `doctor` marks the row `(open via registry)` and prints the path

Search order is `$OPENBENCH_OPEN_MODELS`, then `.openbench/open_models.toml` walking up from cwd, then `~/.openbench/open_models.toml`. Adapters load the helper by path like `_codex_ablation.py` already does, so they stay self-contained under the isolated importer and the module is stdlib only.

Two things I decided rather than guessed at, say if either is wrong. A registry that silently changed which model got measured seemed like the wrong default for this repo, so the source is surfaced in preflight instead of living only in the file, and a malformed registry raises at import rather than falling back to the built-ins. Second, `glm-5.2` in TOML parses as a dotted key and becomes table `glm-5` containing `2`. Since most built-in names have a dot, that trap is the common case and not an edge one, so a missing-field error checks for a digit-leading subtable and reports `[models."glm-5.2"]` back to you.

## Checklist

- [x] `python3 -m unittest discover -s obench/tests` passes.
- [ ] `obench validate` (or `python3 validate_tasks.py`) is green (every task shows FAIL(ok) … PASS(ok) … PASS).
- [x] No copied or licensed code in `tasks/` — all task code is original (see [CONTRIBUTING-TASKS.md](CONTRIBUTING-TASKS.md)).
- [x] Documentation updated for any user-facing or workflow change (README, adapter spec, etc.).
- [x] Changes are focused and reviewable; no unrelated churn.

## Notes for the reviewer

1556 tests, up from 1539, and 17 of the new ones are the registry. One failure, `test_import_harbor.SolveMaterializeTests.test_solve_sh_rewrites_absolute_app_paths`, which fails identically on clean `main` on this box: solve.sh runs with a scrubbed PATH and there is no `/bin/cat` on NixOS, so it exits 127. Not touched by this change.

I could not tick `obench validate`. It fails here on `main` too, 48 times with `pull access denied` on the pinned task images, so I have no signal either way and did not want to claim one. The diff does not touch `tasks/`.

The adapter diffs are additive only, no existing line changed. `_codex_ablation.py`, `codex_v1`, `codex_v2` pick the merged dict up through `_codex.OPEN_MODELS` and needed nothing.

Open question: I included `~/.openbench/open_models.toml` because `codex.py` already reads `~/.openbench/keys.env`, but ambient home state deciding a benchmark's model set is arguable. Drop that third lookup and keep the env var plus the project dir if you would rather registries were per-project only.
