### PR TITLE
Preserve Codex 0.153.0 cache-write usage in legacy adapter

### DIFF
--- a/obench/adapters/codex.py
+++ b/obench/adapters/codex.py
@@ -20,11 +20,12 @@ Notes / quirks:
 - Copies only runtime `auth.json` into a fresh `CODEX_HOME`; personal config,
   instructions, skills, plugins, MCPs, rules, memories, and sessions are absent.
 - `--json` emits a JSONL event stream. The final `turn.completed` event carries
-  `usage={input_tokens,cached_input_tokens,output_tokens,reasoning_output_tokens}`.
+  `usage={input_tokens,cached_input_tokens,cache_write_input_tokens,
+          output_tokens,reasoning_output_tokens}` on Codex 0.153.0.
   Token accounting emits TOKEN_PARITY.md split fields from the final aggregate:
-    tokens_input_uncached = input_tokens - cached_input_tokens
+    tokens_input_uncached = input_tokens - cached_input_tokens - cache_write_input_tokens
     tokens_cache_read     = cached_input_tokens
-    tokens_cache_write    = 0
+    tokens_cache_write    = cache_write_input_tokens  # when reported
     tokens_output         = output_tokens  # already reasoning-inclusive
     tokens_reasoning      = reasoning_output_tokens
     tokens                = tokens_input_uncached + tokens_output
@@ -356,10 +357,11 @@ def _parse_json_with_usage(stdout):
         inp = _num(last_usage.get("input_tokens"))
         cached = _num(last_usage.get("cached_input_tokens"))
         cache_write = _num(
-            last_usage.get("cache_write_tokens")
-            or last_usage.get("cache_creation_input_tokens")
-            or last_usage.get("cache_creation_tokens")
-            or 0
+            last_usage.get("cache_write_input_tokens",
+                last_usage.get("cache_write_tokens")
+                or last_usage.get("cache_creation_input_tokens")
+                or last_usage.get("cache_creation_tokens")
+                or 0)
         )
         out = _num(last_usage.get("output_tokens"))
         reasoning = _num(last_usage.get("reasoning_output_tokens"))
@@ -529,7 +531,7 @@ def run(
 
     if model in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna") and token_usage.get("token_basis") == "vendor_split":
         raw = token_usage.get("usage_raw") or {}
-        if not any(k in raw for k in ("cache_write_tokens", "cache_creation_input_tokens", "cache_creation_tokens")):
+        if not any(k in raw for k in ("cache_write_input_tokens", "cache_write_tokens", "cache_creation_input_tokens", "cache_creation_tokens")):
             # GPT-5.6 may expose billable cache writes on newer Codex event
             # schemas. If this CLI omits the field, keep the legacy fresh-ish
             # scalar usable for the smoke contract but do not assert complete

--- a/obench/tests/fixtures/usage/codex-0.153.0/README.md
+++ b/obench/tests/fixtures/usage/codex-0.153.0/README.md
@@ -1,0 +1,14 @@
+# Codex 0.153.0 completed-turn usage
+
+This usage-only event was captured on September 5, 2026, from a Codex CLI 0.153.0
+run requesting `gpt-5.6-sol` at medium effort. It contains no transcript or account
+identifiers. The event reports `cache_write_input_tokens: 0`; the field is
+available, rather than unknown.
+
+Source: [original public event](https://github.com/sjh9714/astra-sweetspot/blob/937a6f82d75404eca2d6b95c637cd7583b82c2b4/results/receipts/2026-09-05T06-24-04-221Z-sol-medium-48beb0/usage-event.json)
+and [receipt](https://github.com/sjh9714/astra-sweetspot/blob/937a6f82d75404eca2d6b95c637cd7583b82c2b4/results/receipts/2026-09-05T06-24-04-221Z-sol-medium-48beb0/receipt.json).
+Published under MIT. The served model identifier was not independently exposed.
+
+The regression replays this event through the legacy adapter with the child
+process mocked and an empty temporary Codex home. Its missing-field and positive
+cache-write variants are synthetic schema checks, not additional model runs.

--- a/obench/tests/fixtures/usage/codex-0.153.0/turn-completed.json
+++ b/obench/tests/fixtures/usage/codex-0.153.0/turn-completed.json
@@ -1,0 +1,1 @@
+{"type":"turn.completed","usage":{"input_tokens":124035,"cached_input_tokens":106368,"cache_write_input_tokens":0,"output_tokens":4774,"reasoning_output_tokens":2278}}

--- a/obench/tests/test_token_parity.py
+++ b/obench/tests/test_token_parity.py
@@ -4,11 +4,13 @@
 import importlib.util
 import json
 import os
+import subprocess
 
 BENCH_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 import tempfile
 import unittest
+from unittest import mock
 
 ADAPTERS_DIR = os.path.join(BENCH_DIR, "adapters")
 FIXTURE_DIR = os.path.join(BENCH_DIR, "tests", "fixtures", "usage", "deepseek-v4-flash")
@@ -144,6 +146,40 @@ class TokenParityFixtureTests(unittest.TestCase):
         self.assertEqual(turns, 1)
         self.assert_usage_matches(actual, expected("codex"))
         self.assertEqual(tokens, 508)  # do not double-count reasoning subset
+
+    def test_codex_153_cache_write_field_survives_run_normalization(self):
+        codex = load_adapter("codex")
+        fixture = os.path.join(BENCH_DIR, "tests", "fixtures", "usage",
+                               "codex-0.153.0", "turn-completed.json")
+        with open(fixture, encoding="utf-8") as fh:
+            event = json.load(fh)
+        # The captured event reports zero. Missing and positive values below
+        # are synthetic boundary cases for the same schema.
+        for writes in (0, None, 30):
+            with self.subTest(cache_write_input_tokens=writes):
+                usage = dict(event["usage"])
+                if writes is None:
+                    usage.pop("cache_write_input_tokens")
+                else:
+                    usage["cache_write_input_tokens"] = writes
+                stream = json.dumps({"type": "turn.completed", "usage": usage})
+                proc = subprocess.CompletedProcess([], 0, stdout=stream, stderr="")
+                with tempfile.TemporaryDirectory() as directory:
+                    with mock.patch.object(codex.subprocess, "run", return_value=proc):
+                        result = codex.run(
+                            "offline replay", directory, "gpt-5.6-sol", 1,
+                            env_override={"CODEX_HOME": directory},
+                        )
+                self.assertTrue(result["completed"])
+                self.assertEqual(result["usage_raw"], usage)
+                self.assertEqual(result["tokens_cache_write"], writes)
+                self.assertEqual(result["token_basis"],
+                                 "estimated" if writes is None else "vendor_split")
+                self.assertEqual(result["tokens_input_uncached"], 17667 - (writes or 0))
+                self.assertEqual(result["tokens_cache_read"], 106368)
+                self.assertEqual(result["tokens_output"], 4774)
+                self.assertEqual(result["tokens_reasoning"], 2278)
+                self.assertEqual(result["tokens"], 22441 - (writes or 0))
 
     def test_invariant_violation_downgrades_basis(self):
         pi = load_adapter("pi")


### PR DESCRIPTION
The legacy Codex adapter loses an explicitly reported cache-write count from Codex CLI 0.153.0. Replaying the attached Sol usage event through `run()` currently changes `cache_write_input_tokens: 0` into `tokens_cache_write: null` and downgrades `token_basis` to `estimated`.

This change recognizes `cache_write_input_tokens` in both parsing and the GPT-5.6 completeness check. A reported zero stays zero; a missing field still receives the existing unknown/estimated treatment. Older aliases remain supported. This touches the compatibility adapter, not the canonical Harbor execution path.

The fixture is an unchanged usage-only event from [my Astra Sweetspot pilot](https://github.com/sjh9714/astra-sweetspot/blob/937a6f82d75404eca2d6b95c637cd7583b82c2b4/results/receipts/2026-09-05T06-24-04-221Z-sol-medium-48beb0/usage-event.json), built with Codex. It contains no transcript or account identifiers. The test replays it with a mocked child process and an empty temporary Codex home; its missing-field and positive-write variants are explicitly synthetic.

Validation: the regression failed before the fix and passed afterward; all 12 token-parity tests passed. The full offline suite passed (1540 tests), along with core task validation (8/8), the offline Terminal-Bench tier (9/9), and Exercism (11/11). No live model or API call is part of this verification.
